### PR TITLE
chore: CI를 위한 GitHub Actions 워크플로우 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  ci:
+    name: Lint, Type Check, Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type Check
+        run: pnpm check-types
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - dev
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Lint, Type Check, Build


### PR DESCRIPTION


## 작업 내용
### As-Is
- 프로젝트에 CI가 전혀 구성되어 있지 않아, 코드 변경 시 자동으로 검증되는 단계가 없음
- Node.js 및 pnpm 버전에 대한 기준이 없어, 개발자 환경 간 실행 결과 차이가 발생할 수 있는 상태
### To-Be
- GitHub Actions를 이용한 CI 워크플로우 추가
- dev 브랜치 대상 PR 생성 및 추가 커밋 push 시 CI가 자동 실행되도록 설정
   - push 트리거는 의도적으로 제외했습니다. PR 단계에서 이미 검증이 이루어지기 때문에 merge 후 중복 실행이 불필요하다고 판단했습니다
- CI는 다음 순서로 동작
  - 의존성 설치 → lint → type check → build
- pnpm store를 명시적으로 캐싱하여 매 실행마다 의존성을 새로 내려받지 않도록 구성
  - cache: pnpm 단축 옵션 대신 pnpm store path로 실제 경로를 동적으로 가져와 캐싱합니다

## 스크린샷 
추후 잘 동작하는지 확인해봐야 할 것 같아요

## 관련 이슈 
#2 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 개발 브랜치를 대상으로 한 풀 리퀘스트에서 자동으로 실행되는 CI 워크플로우를 추가했습니다. 워크플로우는 저장소 체크아웃, 의존성 설치 및 캐시 처리 후 린팅, 타입 검사, 빌드를 순차적으로 실행합니다. 이를 통해 변경 사항에 대한 자동 검증이 도입됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->