### PR TITLE
chore: PR 랜덤 리뷰어 자동 배정 workflow 추가

### DIFF
--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -1,0 +1,29 @@
+name: Assign Random Reviewers
+
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - dev
+
+jobs:
+  assign-reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign random reviewers
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const candidates = ['kanghaeun','iOdiO89', 'ychany', 'soyeong0115'];
+            const author = context.payload.pull_request.user.login;
+
+            const filtered = candidates.filter(id => id !== author);
+            const shuffled = filtered.sort(() => Math.random() - 0.5);
+            const reviewers = shuffled.slice(0, 2);
+
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              reviewers,
+            });


### PR DESCRIPTION
##  작업 내용 
> PR 생성 시 리뷰어를 수동으로 지정하는 번거로움을 없애기 위해 랜덤 리뷰어 자동 배정 workflow를 추가합니다.

`.github/workflows/assign-reviewer.yml` 추가

### 동작 방식

PR 생성 및 재오픈 시 자동 실행

1. PR 작성자를 후보에서 제외
2. 나머지 3명 중 랜덤으로 2명 선정
3. 선정된 2명을 리뷰어로 자동 배정

## 스크린샷 
머지 후 잘 동작하는지 확인해봐야 할 것 같아요
## 관련 이슈 
#2 


