### PR TITLE
Slack PR Bot GitHub Actions 워크플로우 추가

### DIFF
--- a/.github/workflows/slack-pr-bot.yml
+++ b/.github/workflows/slack-pr-bot.yml
@@ -28,17 +28,27 @@ jobs:
     steps:
       - name: Extract PR data
         id: pr
+        env:
+          GH_PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_PR_TITLE: ${{ github.event.pull_request.title }}
+          GH_PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_AUTHOR: ${{ github.event.pull_request.user.login }}
+          GH_ACTION: ${{ github.event.action }}
+          GH_MERGED: ${{ github.event.pull_request.merged }}
+          GH_IS_DRAFT: ${{ github.event.pull_request.draft }}
+          GH_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          GH_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         shell: bash
         run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          PR_URL="${{ github.event.pull_request.html_url }}"
-          AUTHOR="${{ github.event.pull_request.user.login }}"
-          ACTION="${{ github.event.action }}"
-          MERGED="${{ github.event.pull_request.merged }}"
-          IS_DRAFT="${{ github.event.pull_request.draft }}"
-          BASE_REF="${{ github.event.pull_request.base.ref }}"
-          HEAD_REF="${{ github.event.pull_request.head.ref }}"
+          PR_NUMBER="$GH_PR_NUMBER"
+          PR_TITLE="$GH_PR_TITLE"
+          PR_URL="$GH_PR_URL"
+          AUTHOR="$GH_AUTHOR"
+          ACTION="$GH_ACTION"
+          MERGED="$GH_MERGED"
+          IS_DRAFT="$GH_IS_DRAFT"
+          BASE_REF="$GH_BASE_REF"
+          HEAD_REF="$GH_HEAD_REF"
           PR_BODY=$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")
 
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
@@ -75,12 +85,14 @@ jobs:
         id: find_ts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         shell: bash
         run: |
           COMMENTS=$(curl -s \
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.pr.outputs.pr_number }}/comments")
+            "https://api.github.com/repos/$GH_REPO/issues/$PR_NUMBER/comments")
 
           BODY=$(echo "$COMMENTS" | jq -r '.[] | select(.body | contains("slack-pr-bot")) | .body' | tail -n 1)
 
@@ -97,6 +109,15 @@ jobs:
         id: post_parent
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          GH_REPO: ${{ github.repository }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          PR_TITLE: ${{ steps.pr.outputs.pr_title }}
+          PR_AUTHOR: ${{ steps.pr.outputs.author }}
+          PR_HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          PR_BASE_REF: ${{ steps.pr.outputs.base_ref }}
         shell: bash
         run: |
           mention_slack_user() {
@@ -165,7 +186,7 @@ jobs:
               res=$(curl -s \
                 -H "Authorization: Bearer $GH_TOKEN" \
                 -H "Accept: application/vnd.github+json" \
-                "https://api.github.com/repos/${{ github.repository }}/issues/$num")
+                "https://api.github.com/repos/$GH_REPO/issues/$num")
 
               state=$(echo "$res" | jq -r '.state // "unknown"')
 
@@ -177,7 +198,7 @@ jobs:
                 emoji="❓"
               fi
 
-              link="https://github.com/${{ github.repository }}/issues/$num"
+              link="https://github.com/$GH_REPO/issues/$num"
               line="$emoji <$link|#$num>"
 
               if [ -z "$issue_text" ]; then
@@ -229,7 +250,7 @@ jobs:
           ISSUE_TEXT=$(build_issue_text "$PR_BODY")
           SUMMARY=$(build_summary "$PR_BODY")
 
-          TITLE_LINK="<${{ steps.pr.outputs.pr_url }}|#${{ steps.pr.outputs.pr_number }} ${{ steps.pr.outputs.pr_title }}>"
+          TITLE_LINK="<$PR_URL|#$PR_NUMBER $PR_TITLE>"
 
           TEXT=$(cat <<EOF
           [PR] $TITLE_LINK
@@ -243,17 +264,17 @@ jobs:
           $SUMMARY
 
 
-          *Author*: ${{ steps.pr.outputs.author }}
-          *branch*: ${{ steps.pr.outputs.head_ref }} -> ${{ steps.pr.outputs.base_ref }}
+          *Author*: $PR_AUTHOR
+          *branch*: $PR_HEAD_REF -> $PR_BASE_REF
           *reviewer*: $REVIEWER_TEXT
           EOF
           )
 
           RESP=$(curl -s -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
             -H "Content-Type: application/json; charset=utf-8" \
             --data "$(jq -n \
-              --arg channel "${{ secrets.SLACK_CHANNEL_ID }}" \
+              --arg channel "$SLACK_CHANNEL_ID" \
               --arg text "$TEXT" \
               '{channel:$channel,text:$text,unfurl_links:false,unfurl_media:false}')")
 
@@ -271,21 +292,37 @@ jobs:
         if: steps.post_parent.outputs.ts != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          POST_PARENT_TS: ${{ steps.post_parent.outputs.ts }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         shell: bash
         run: |
           INITIAL_REVIEWERS=$(jq -c '[.pull_request.requested_reviewers[]?.login]' "$GITHUB_EVENT_PATH")
-          BODY="<!-- slack-pr-bot: {\"channel\":\"${{ secrets.SLACK_CHANNEL_ID }}\",\"ts\":\"${{ steps.post_parent.outputs.ts }}\",\"initial_reviewers\":$INITIAL_REVIEWERS} -->"
+          BODY="<!-- slack-pr-bot: {\"channel\":\"$SLACK_CHANNEL_ID\",\"ts\":\"$POST_PARENT_TS\",\"initial_reviewers\":$INITIAL_REVIEWERS} -->"
 
           curl -s -X POST \
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.pr.outputs.pr_number }}/comments" \
+            "https://api.github.com/repos/$GH_REPO/issues/$PR_NUMBER/comments" \
             -d "$(jq -n --arg body "$BODY" '{body:$body}')"
 
       - name: Update parent Slack message
         if: github.event.action != 'opened' && steps.find_ts.outputs.ts != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          GH_ACTION: ${{ github.event.action }}
+          CHANNEL_ID: ${{ steps.find_ts.outputs.channel }}
+          PARENT_TS: ${{ steps.find_ts.outputs.ts }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          PR_TITLE: ${{ steps.pr.outputs.pr_title }}
+          PR_MERGED: ${{ steps.pr.outputs.merged }}
+          PR_AUTHOR: ${{ steps.pr.outputs.author }}
+          PR_HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          PR_BASE_REF: ${{ steps.pr.outputs.base_ref }}
         shell: bash
         run: |
           mention_slack_user() {
@@ -354,7 +391,7 @@ jobs:
               res=$(curl -s \
                 -H "Authorization: Bearer $GH_TOKEN" \
                 -H "Accept: application/vnd.github+json" \
-                "https://api.github.com/repos/${{ github.repository }}/issues/$num")
+                "https://api.github.com/repos/$GH_REPO/issues/$num")
 
               state=$(echo "$res" | jq -r '.state // "unknown"')
 
@@ -366,7 +403,7 @@ jobs:
                 emoji="❓"
               fi
 
-              link="https://github.com/${{ github.repository }}/issues/$num"
+              link="https://github.com/$GH_REPO/issues/$num"
               line="$emoji <$link|#$num>"
 
               if [ -z "$issue_text" ]; then
@@ -413,19 +450,17 @@ jobs:
             '
           }
 
-          CHANNEL_ID="${{ steps.find_ts.outputs.channel }}"
-          PARENT_TS="${{ steps.find_ts.outputs.ts }}"
           PR_BODY=$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")
           REVIEWER_TEXT=$(build_reviewer_text)
           ISSUE_TEXT=$(build_issue_text "$PR_BODY")
           SUMMARY=$(build_summary "$PR_BODY")
           STATUS_LINE=""
-          if [ "${{ github.event.action }}" = "closed" ] && [ "${{ steps.pr.outputs.merged }}" = "true" ]; then
+          if [ "$GH_ACTION" = "closed" ] && [ "$PR_MERGED" = "true" ]; then
             STATUS_LINE="✅ 머지 완료"
-          elif [ "${{ github.event.action }}" = "closed" ] && [ "${{ steps.pr.outputs.merged }}" != "true" ]; then
+          elif [ "$GH_ACTION" = "closed" ] && [ "$PR_MERGED" != "true" ]; then
             STATUS_LINE="🗑️ 머지 없이 종료됨"
           fi
-          TITLE_LINK="<${{ steps.pr.outputs.pr_url }}|#${{ steps.pr.outputs.pr_number }} ${{ steps.pr.outputs.pr_title }}>"
+          TITLE_LINK="<$PR_URL|#$PR_NUMBER $PR_TITLE>"
 
           TEXT=$(cat <<EOF
           [PR] $TITLE_LINK
@@ -439,14 +474,14 @@ jobs:
           $SUMMARY
 
 
-          *Author*: ${{ steps.pr.outputs.author }}
-          *Branch*: ${{ steps.pr.outputs.head_ref }} -> ${{ steps.pr.outputs.base_ref }}
+          *Author*: $PR_AUTHOR
+          *Branch*: $PR_HEAD_REF -> $PR_BASE_REF
           *Reviewer*: $REVIEWER_TEXT
           EOF
           )
 
           RESP=$(curl -s -X POST https://slack.com/api/chat.update \
-            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
             -H "Content-Type: application/json; charset=utf-8" \
             --data "$(jq -n \
               --arg channel "$CHANNEL_ID" \
@@ -465,13 +500,17 @@ jobs:
         if: github.event.action != 'opened' && steps.find_ts.outputs.ts != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          THREAD_TS: ${{ steps.find_ts.outputs.ts }}
+          CHANNEL_ID: ${{ steps.find_ts.outputs.channel }}
+          INITIAL_REVIEWERS: ${{ steps.find_ts.outputs.initial_reviewers }}
+          PR_ACTION: ${{ steps.pr.outputs.action }}
+          PR_MERGED: ${{ steps.pr.outputs.merged }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          PR_HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          PR_BASE_REF: ${{ steps.pr.outputs.base_ref }}
         shell: bash
         run: |
-          THREAD_TS="${{ steps.find_ts.outputs.ts }}"
-          CHANNEL_ID="${{ steps.find_ts.outputs.channel }}"
-          ACTION="${{ steps.pr.outputs.action }}"
-          MERGED="${{ steps.pr.outputs.merged }}"
-
           mention_slack_user() {
             local github_id="$1"
             local slack_id
@@ -486,9 +525,8 @@ jobs:
 
           TEXT=""
 
-          if [ "$ACTION" = "review_requested" ]; then
+          if [ "$PR_ACTION" = "review_requested" ]; then
             REQUESTED_REVIEWER=$(jq -r '.requested_reviewer.login // ""' "$GITHUB_EVENT_PATH")
-            INITIAL_REVIEWERS='${{ steps.find_ts.outputs.initial_reviewers }}'
             [ -z "$INITIAL_REVIEWERS" ] && INITIAL_REVIEWERS="[]"
 
             IS_INITIAL=$(echo "$INITIAL_REVIEWERS" | jq -r --arg r "$REQUESTED_REVIEWER" 'map(. == $r) | any')
@@ -502,7 +540,7 @@ jobs:
             else
               TEXT="🙋 리뷰 요청됨"
             fi
-          elif [ "$ACTION" = "review_request_removed" ]; then
+          elif [ "$PR_ACTION" = "review_request_removed" ]; then
             REMOVED_REVIEWER=$(jq -r '.requested_reviewer.login // ""' "$GITHUB_EVENT_PATH")
             if [ -n "$REMOVED_REVIEWER" ]; then
               TEXT="➖ 리뷰 요청 해제됨: $(mention_slack_user "$REMOVED_REVIEWER")"
@@ -510,7 +548,7 @@ jobs:
               TEXT="➖ 리뷰 요청이 해제되었습니다."
             fi
 
-          elif [ "$ACTION" = "synchronize" ]; then
+          elif [ "$PR_ACTION" = "synchronize" ]; then
             COMMITS_URL=$(jq -r '.pull_request.commits_url' "$GITHUB_EVENT_PATH")
             COMMITS=$(curl -s \
             -H "Authorization: Bearer $GH_TOKEN" \
@@ -526,17 +564,17 @@ jobs:
               TEXT="🔄 새 커밋이 추가되었습니다."
             fi
 
-          elif [ "$ACTION" = "closed" ] && [ "$MERGED" = "true" ]; then
-            TEXT="✅ PR #${{ steps.pr.outputs.pr_number }} 머지 완료: ${{ steps.pr.outputs.head_ref }} -> ${{ steps.pr.outputs.base_ref }}"
-          elif [ "$ACTION" = "closed" ] && [ "$MERGED" != "true" ]; then
-            TEXT="🗑️ PR #${{ steps.pr.outputs.pr_number }} 이 머지 없이 닫혔습니다: ${{ steps.pr.outputs.head_ref }} -> ${{ steps.pr.outputs.base_ref }}"
+          elif [ "$PR_ACTION" = "closed" ] && [ "$PR_MERGED" = "true" ]; then
+            TEXT="✅ PR #$PR_NUMBER 머지 완료: $PR_HEAD_REF -> $PR_BASE_REF"
+          elif [ "$PR_ACTION" = "closed" ] && [ "$PR_MERGED" != "true" ]; then
+            TEXT="🗑️ PR #$PR_NUMBER 이 머지 없이 닫혔습니다: $PR_HEAD_REF -> $PR_BASE_REF"
           else
             echo "No message needed."
             exit 0
           fi
 
           RESP=$(curl -s -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
             -H "Content-Type: application/json; charset=utf-8" \
             --data "$(jq -n \
               --arg channel "$CHANNEL_ID" \

--- a/.github/workflows/slack-pr-bot.yml
+++ b/.github/workflows/slack-pr-bot.yml
@@ -1,0 +1,552 @@
+name: Slack PR Bot
+
+on:
+  pull_request:
+    types:
+      - opened
+      - review_requested
+      - review_request_removed
+      - edited
+      - synchronize
+      - closed
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: slack-pr-bot-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    env:
+      SLACK_USER_MAP: '{"iOdiO89":"U0AKB7N0C66","kanghaeun":"U0AKA5ZNYEA","soyeong0115":"U0AK4SC7C2X","ychany":"U0AK6MZM9RR","sevineleven":"U0AK6U2J62F"}'
+
+    steps:
+      - name: Extract PR data
+        id: pr
+        shell: bash
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          AUTHOR="${{ github.event.pull_request.user.login }}"
+          ACTION="${{ github.event.action }}"
+          MERGED="${{ github.event.pull_request.merged }}"
+          IS_DRAFT="${{ github.event.pull_request.draft }}"
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          HEAD_REF="${{ github.event.pull_request.head.ref }}"
+          PR_BODY=$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")
+
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "pr_title<<EOF"
+            echo "$PR_TITLE"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          AUTHOR_SLACK_ID=$(echo "$SLACK_USER_MAP" | jq -r --arg login "$AUTHOR" '.[$login] // empty')
+
+          if [ -n "$AUTHOR_SLACK_ID" ]; then
+            AUTHOR_MENTION="<@$AUTHOR_SLACK_ID>"
+          else
+            AUTHOR_MENTION="$AUTHOR"
+          fi
+
+          echo "author=$AUTHOR_MENTION" >> "$GITHUB_OUTPUT"
+          echo "action=$ACTION" >> "$GITHUB_OUTPUT"
+          echo "merged=$MERGED" >> "$GITHUB_OUTPUT"
+          echo "is_draft=$IS_DRAFT" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$BASE_REF" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "pr_body<<EOF"
+            echo "$PR_BODY"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Find existing Slack ts from PR comments
+        id: find_ts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          COMMENTS=$(curl -s \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.pr.outputs.pr_number }}/comments")
+
+          BODY=$(echo "$COMMENTS" | jq -r '.[] | select(.body | contains("slack-pr-bot")) | .body' | tail -n 1)
+
+          TS=$(echo "$BODY" | sed -n 's/.*"ts":"\([^"]*\)".*/\1/p')
+          CHANNEL=$(echo "$BODY" | sed -n 's/.*"channel":"\([^"]*\)".*/\1/p')
+          INITIAL_REVIEWERS=$(echo "$BODY" | grep -oP '"initial_reviewers":\K\[[^\]]*\]' || echo "[]")
+
+          echo "ts=$TS" >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "initial_reviewers=$INITIAL_REVIEWERS" >> "$GITHUB_OUTPUT"
+
+      - name: Post parent message
+        if: steps.find_ts.outputs.ts == '' && github.event.action == 'opened' && github.event.pull_request.draft == false
+        id: post_parent
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          mention_slack_user() {
+            local github_id="$1"
+            local slack_id
+            slack_id=$(echo "$SLACK_USER_MAP" | jq -r --arg id "$github_id" '.[$id] // empty')
+
+            if [ -n "$slack_id" ]; then
+              echo "<@$slack_id>"
+            else
+              echo "@$github_id"
+            fi
+          }
+
+          build_reviewer_text() {
+            local reviewers
+            local reviewer_text
+            local user_mention
+
+            reviewers=$(jq -r '.pull_request.requested_reviewers[]?.login' "$GITHUB_EVENT_PATH")
+            reviewer_text=""
+
+            if [ -z "$reviewers" ]; then
+              echo "없음"
+              return
+            fi
+
+            while IFS= read -r reviewer; do
+              [ -z "$reviewer" ] && continue
+              user_mention=$(mention_slack_user "$reviewer")
+
+              if [ -z "$reviewer_text" ]; then
+                reviewer_text="$user_mention"
+              else
+                reviewer_text="$reviewer_text, $user_mention"
+              fi
+            done <<< "$reviewers"
+
+            [ -z "$reviewer_text" ] && reviewer_text="없음"
+            echo "$reviewer_text"
+          }
+
+          build_issue_text() {
+            local pr_body="$1"
+            local issues
+            local issue_text
+            local num
+            local res
+            local state
+            local emoji
+            local link
+            local line
+
+            issues=$(echo "$pr_body" | grep -oiE '\bclose[sd]?[[:space:]]+#[0-9]+' | grep -oE '#[0-9]+' | sort -u || true)
+            issue_text=""
+
+            if [ -z "$issues" ]; then
+              echo "없음"
+              return
+            fi
+
+            while IFS= read -r issue; do
+              [ -z "$issue" ] && continue
+              num=$(echo "$issue" | tr -d '#')
+
+              res=$(curl -s \
+                -H "Authorization: Bearer $GH_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/repos/${{ github.repository }}/issues/$num")
+
+              state=$(echo "$res" | jq -r '.state // "unknown"')
+
+              if [ "$state" = "open" ]; then
+                emoji="🟢"
+              elif [ "$state" = "closed" ]; then
+                emoji="⚫"
+              else
+                emoji="❓"
+              fi
+
+              link="https://github.com/${{ github.repository }}/issues/$num"
+              line="$emoji <$link|#$num>"
+
+              if [ -z "$issue_text" ]; then
+                issue_text="$line"
+              else
+                issue_text=$(printf "%s\n%s" "$issue_text" "$line")
+              fi
+            done <<< "$issues"
+
+            [ -z "$issue_text" ] && issue_text="없음"
+            echo "$issue_text"
+          }
+
+          build_summary() {
+            local pr_body="$1"
+            printf '%s\n' "$pr_body" | awk '
+              BEGIN { in_task=0; n=0; out="" }
+              /^##/ {
+                if (in_task == 1) exit
+                r = $0
+                sub(/^##[[:space:]]+/, "", r)
+                ok = (match(r, /^[Tt][Aa][Ss][Kk]([^A-Za-z]|$)/) || match(r, /[[:space:]][Tt][Aa][Ss][Kk]([^A-Za-z]|$)/))
+                if (ok) { in_task=1; next }
+                next
+              }
+              in_task == 1 && /^##/ { exit }
+              in_task == 1 {
+                s = $0
+                sub(/^[[:space:]]+/, "", s)
+                if (s ~ /^>/) next
+                if (s ~ /^-[[:space:]]*\[[[:space:]xX]\]/) next
+                if (s ~ /^-[[:space:]]+/) {
+                  sub(/^-[[:space:]]+/, "", s)
+                  if (length(s) > 0) {
+                    if (n++ > 0) out = out "\n"
+                    out = out "• " s
+                  }
+                }
+              }
+              END {
+                if (n > 0) print out
+                else print "요약 없음"
+              }
+            '
+          }
+
+          PR_BODY=$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")
+          REVIEWER_TEXT=$(build_reviewer_text)
+          ISSUE_TEXT=$(build_issue_text "$PR_BODY")
+          SUMMARY=$(build_summary "$PR_BODY")
+
+          TITLE_LINK="<${{ steps.pr.outputs.pr_url }}|#${{ steps.pr.outputs.pr_number }} ${{ steps.pr.outputs.pr_title }}>"
+
+          TEXT=$(cat <<EOF
+          [PR] $TITLE_LINK
+
+
+          🔥 연관 이슈
+          $ISSUE_TEXT
+
+
+          📝 작업 요약
+          $SUMMARY
+
+
+          *Author*: ${{ steps.pr.outputs.author }}
+          *branch*: ${{ steps.pr.outputs.head_ref }} -> ${{ steps.pr.outputs.base_ref }}
+          *reviewer*: $REVIEWER_TEXT
+          EOF
+          )
+
+          RESP=$(curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$(jq -n \
+              --arg channel "${{ secrets.SLACK_CHANNEL_ID }}" \
+              --arg text "$TEXT" \
+              '{channel:$channel,text:$text,unfurl_links:false,unfurl_media:false}')")
+
+          OK=$(echo "$RESP" | jq -r '.ok')
+          if [ "$OK" != "true" ]; then
+            echo "Slack post failed"
+            echo "$RESP"
+            exit 1
+          fi
+
+          TS=$(echo "$RESP" | jq -r '.ts')
+          echo "ts=$TS" >> "$GITHUB_OUTPUT"
+
+      - name: Save Slack ts into PR comment
+        if: steps.post_parent.outputs.ts != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          INITIAL_REVIEWERS=$(jq -c '[.pull_request.requested_reviewers[]?.login]' "$GITHUB_EVENT_PATH")
+          BODY="<!-- slack-pr-bot: {\"channel\":\"${{ secrets.SLACK_CHANNEL_ID }}\",\"ts\":\"${{ steps.post_parent.outputs.ts }}\",\"initial_reviewers\":$INITIAL_REVIEWERS} -->"
+
+          curl -s -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.pr.outputs.pr_number }}/comments" \
+            -d "$(jq -n --arg body "$BODY" '{body:$body}')"
+
+      - name: Update parent Slack message
+        if: github.event.action != 'opened' && steps.find_ts.outputs.ts != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          mention_slack_user() {
+            local github_id="$1"
+            local slack_id
+            slack_id=$(echo "$SLACK_USER_MAP" | jq -r --arg id "$github_id" '.[$id] // empty')
+
+            if [ -n "$slack_id" ]; then
+              echo "<@$slack_id>"
+            else
+              echo "$github_id"
+            fi
+          }
+
+          build_reviewer_text() {
+            local reviewers
+            local reviewer_text
+            local user_mention
+
+            reviewers=$(jq -r '.pull_request.requested_reviewers[]?.login' "$GITHUB_EVENT_PATH")
+            reviewer_text=""
+
+            if [ -z "$reviewers" ]; then
+              echo "없음"
+              return
+            fi
+
+            while IFS= read -r reviewer; do
+              [ -z "$reviewer" ] && continue
+              user_mention=$(mention_slack_user "$reviewer")
+
+              if [ -z "$reviewer_text" ]; then
+                reviewer_text="$user_mention"
+              else
+                reviewer_text="$reviewer_text, $user_mention"
+              fi
+            done <<< "$reviewers"
+
+            [ -z "$reviewer_text" ] && reviewer_text="없음"
+            echo "$reviewer_text"
+          }
+
+          build_issue_text() {
+            local pr_body="$1"
+            local issues
+            local issue_text
+            local num
+            local res
+            local state
+            local emoji
+            local link
+            local line
+
+            issues=$(echo "$pr_body" | grep -oiE '\bclose[sd]?[[:space:]]+#[0-9]+' | grep -oE '#[0-9]+' | sort -u || true)
+            issue_text=""
+
+            if [ -z "$issues" ]; then
+              echo "없음"
+              return
+            fi
+
+            while IFS= read -r issue; do
+              [ -z "$issue" ] && continue
+              num=$(echo "$issue" | tr -d '#')
+
+              res=$(curl -s \
+                -H "Authorization: Bearer $GH_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/repos/${{ github.repository }}/issues/$num")
+
+              state=$(echo "$res" | jq -r '.state // "unknown"')
+
+              if [ "$state" = "open" ]; then
+                emoji="🟢"
+              elif [ "$state" = "closed" ]; then
+                emoji="⚫"
+              else
+                emoji="❓"
+              fi
+
+              link="https://github.com/${{ github.repository }}/issues/$num"
+              line="$emoji <$link|#$num>"
+
+              if [ -z "$issue_text" ]; then
+                issue_text="$line"
+              else
+                issue_text=$(printf "%s\n%s" "$issue_text" "$line")
+              fi
+            done <<< "$issues"
+
+            [ -z "$issue_text" ] && issue_text="없음"
+            echo "$issue_text"
+          }
+
+          build_summary() {
+            local pr_body="$1"
+            printf '%s\n' "$pr_body" | awk '
+              BEGIN { in_task=0; n=0; out="" }
+              /^##/ {
+                if (in_task == 1) exit
+                r = $0
+                sub(/^##[[:space:]]+/, "", r)
+                ok = (match(r, /^[Tt][Aa][Ss][Kk]([^A-Za-z]|$)/) || match(r, /[[:space:]][Tt][Aa][Ss][Kk]([^A-Za-z]|$)/))
+                if (ok) { in_task=1; next }
+                next
+              }
+              in_task == 1 && /^##/ { exit }
+              in_task == 1 {
+                s = $0
+                sub(/^[[:space:]]+/, "", s)
+                if (s ~ /^>/) next
+                if (s ~ /^-[[:space:]]*\[[[:space:]xX]\]/) next
+                if (s ~ /^-[[:space:]]+/) {
+                  sub(/^-[[:space:]]+/, "", s)
+                  if (length(s) > 0) {
+                    if (n++ > 0) out = out "\n"
+                    out = out "• " s
+                  }
+                }
+              }
+              END {
+                if (n > 0) print out
+                else print "요약 없음"
+              }
+            '
+          }
+
+          CHANNEL_ID="${{ steps.find_ts.outputs.channel }}"
+          PARENT_TS="${{ steps.find_ts.outputs.ts }}"
+          PR_BODY=$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")
+          REVIEWER_TEXT=$(build_reviewer_text)
+          ISSUE_TEXT=$(build_issue_text "$PR_BODY")
+          SUMMARY=$(build_summary "$PR_BODY")
+          STATUS_LINE=""
+          if [ "${{ github.event.action }}" = "closed" ] && [ "${{ steps.pr.outputs.merged }}" = "true" ]; then
+            STATUS_LINE="✅ 머지 완료"
+          elif [ "${{ github.event.action }}" = "closed" ] && [ "${{ steps.pr.outputs.merged }}" != "true" ]; then
+            STATUS_LINE="🗑️ 머지 없이 종료됨"
+          fi
+          TITLE_LINK="<${{ steps.pr.outputs.pr_url }}|#${{ steps.pr.outputs.pr_number }} ${{ steps.pr.outputs.pr_title }}>"
+
+          TEXT=$(cat <<EOF
+          [PR] $TITLE_LINK
+          $STATUS_LINE
+
+          🔥 *연관 이슈*
+          $ISSUE_TEXT
+
+
+          📝 *작업 요약*
+          $SUMMARY
+
+
+          *Author*: ${{ steps.pr.outputs.author }}
+          *Branch*: ${{ steps.pr.outputs.head_ref }} -> ${{ steps.pr.outputs.base_ref }}
+          *Reviewer*: $REVIEWER_TEXT
+          EOF
+          )
+
+          RESP=$(curl -s -X POST https://slack.com/api/chat.update \
+            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$(jq -n \
+              --arg channel "$CHANNEL_ID" \
+              --arg ts "$PARENT_TS" \
+              --arg text "$TEXT" \
+              '{channel:$channel,ts:$ts,text:$text,unfurl_links:false,unfurl_media:false}')")
+
+          OK=$(echo "$RESP" | jq -r '.ok')
+          if [ "$OK" != "true" ]; then
+            echo "Slack update failed"
+            echo "$RESP"
+            exit 1
+          fi
+
+      - name: Reply to thread
+        if: github.event.action != 'opened' && steps.find_ts.outputs.ts != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          THREAD_TS="${{ steps.find_ts.outputs.ts }}"
+          CHANNEL_ID="${{ steps.find_ts.outputs.channel }}"
+          ACTION="${{ steps.pr.outputs.action }}"
+          MERGED="${{ steps.pr.outputs.merged }}"
+
+          mention_slack_user() {
+            local github_id="$1"
+            local slack_id
+            slack_id=$(echo "$SLACK_USER_MAP" | jq -r --arg id "$github_id" '.[$id] // empty')
+
+            if [ -n "$slack_id" ]; then
+              echo "<@$slack_id>"
+            else
+              echo "@$github_id"
+            fi
+          }
+
+          TEXT=""
+
+          if [ "$ACTION" = "review_requested" ]; then
+            REQUESTED_REVIEWER=$(jq -r '.requested_reviewer.login // ""' "$GITHUB_EVENT_PATH")
+            INITIAL_REVIEWERS='${{ steps.find_ts.outputs.initial_reviewers }}'
+            [ -z "$INITIAL_REVIEWERS" ] && INITIAL_REVIEWERS="[]"
+
+            IS_INITIAL=$(echo "$INITIAL_REVIEWERS" | jq -r --arg r "$REQUESTED_REVIEWER" 'map(. == $r) | any')
+            if [ "$IS_INITIAL" = "true" ]; then
+              echo "Reviewer $REQUESTED_REVIEWER was present at PR open, skipping thread reply."
+              exit 0
+            fi
+
+            if [ -n "$REQUESTED_REVIEWER" ]; then
+              TEXT="🙋 리뷰 요청됨: $(mention_slack_user "$REQUESTED_REVIEWER")"
+            else
+              TEXT="🙋 리뷰 요청됨"
+            fi
+          elif [ "$ACTION" = "review_request_removed" ]; then
+            REMOVED_REVIEWER=$(jq -r '.requested_reviewer.login // ""' "$GITHUB_EVENT_PATH")
+            if [ -n "$REMOVED_REVIEWER" ]; then
+              TEXT="➖ 리뷰 요청 해제됨: $(mention_slack_user "$REMOVED_REVIEWER")"
+            else
+              TEXT="➖ 리뷰 요청이 해제되었습니다."
+            fi
+
+          elif [ "$ACTION" = "synchronize" ]; then
+            COMMITS_URL=$(jq -r '.pull_request.commits_url' "$GITHUB_EVENT_PATH")
+            COMMITS=$(curl -s \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "$COMMITS_URL")
+
+            LAST_COMMIT_MSG=$(echo "$COMMITS" | jq -r '.[-1].commit.message // ""' | head -n 1)
+            COMMIT_COUNT=$(echo "$COMMITS" | jq 'length')
+
+            if [ -n "$LAST_COMMIT_MSG" ] && [ "$LAST_COMMIT_MSG" != "null" ]; then
+              TEXT=$(printf '🔄 새 커밋 추가됨 (%s commits)\n• %s' "$COMMIT_COUNT" "$LAST_COMMIT_MSG")
+            else
+              TEXT="🔄 새 커밋이 추가되었습니다."
+            fi
+
+          elif [ "$ACTION" = "closed" ] && [ "$MERGED" = "true" ]; then
+            TEXT="✅ PR #${{ steps.pr.outputs.pr_number }} 머지 완료: ${{ steps.pr.outputs.head_ref }} -> ${{ steps.pr.outputs.base_ref }}"
+          elif [ "$ACTION" = "closed" ] && [ "$MERGED" != "true" ]; then
+            TEXT="🗑️ PR #${{ steps.pr.outputs.pr_number }} 이 머지 없이 닫혔습니다: ${{ steps.pr.outputs.head_ref }} -> ${{ steps.pr.outputs.base_ref }}"
+          else
+            echo "No message needed."
+            exit 0
+          fi
+
+          RESP=$(curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$(jq -n \
+              --arg channel "$CHANNEL_ID" \
+              --arg text "$TEXT" \
+              --arg thread_ts "$THREAD_TS" \
+              '{channel:$channel,text:$text,thread_ts:$thread_ts,reply_broadcast:false,unfurl_links:false,unfurl_media:false}')")
+
+          OK=$(echo "$RESP" | jq -r '.ok')
+          if [ "$OK" != "true" ]; then
+            echo "Slack reply failed"
+            echo "$RESP"
+            exit 1
+          fi

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
-}>) {
+}>): JSX.Element {
   return (
     <html lang="ko">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 
@@ -22,7 +23,7 @@ export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
-}>): JSX.Element {
+}>): React.JSX.Element {
   return (
     <html lang="ko">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -17,7 +17,7 @@ const ThemeImage = (props: Props) => {
   );
 };
 
-export default function Home() {
+export default function Home(): JSX.Element {
   return (
     <div className={styles.page}>
       <main className={styles.main}>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import Image, { type ImageProps } from 'next/image';
 import styles from './page.module.css';
 
@@ -17,7 +18,7 @@ const ThemeImage = (props: Props) => {
   );
 };
 
-export default function Home(): JSX.Element {
+export default function Home(): React.JSX.Element {
   return (
     <div className={styles.page}>
       <main className={styles.main}>

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -8,7 +8,7 @@ type ProvidersProps = {
   children: React.ReactNode;
 };
 
-function Providers({ children }: ProvidersProps): JSX.Element {
+function Providers({ children }: ProvidersProps): React.JSX.Element {
   const [queryClient] = useState(
     () =>
       new QueryClient({

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -8,7 +8,7 @@ type ProvidersProps = {
   children: React.ReactNode;
 };
 
-function Providers({ children }: ProvidersProps) {
+function Providers({ children }: ProvidersProps): JSX.Element {
   const [queryClient] = useState(
     () =>
       new QueryClient({


### PR DESCRIPTION
## Situation
- server repo에 이미 적용된 slack-pr-bot을 client repo에도 동일하게 연동해야 했음
- client repo는 main 브랜치가 없고 branch protection이 걸려 있어, server의 워크플로우를 그대로 쓸 수 없었음
- GitHub Actions Secrets가 설정되어 있지 않아 별도 세팅 필요

## Task
- PR 이벤트(open, review_request, synchronize, closed)를 Slack으로 알리는 워크플로우 추가
- server와 달리 `alert-direct-push` job 제거, 팀 멤버 Slack ID 매핑 교체

## Action
- `.github/workflows/slack-pr-bot.yml` 추가
- `alert-direct-push` job 및 `push` 트리거 전체 제거 (main 브랜치 없음)
- SLACK_USER_MAP을 client 팀 구성원으로 교체 (iOdiO89, kanghaeun, soyeong0115, ychany, sevineleven)
- assign-reviewer와의 실행 순서 통합은 하지 않음
  - PR open 시 reviewer는 항상 없는 상태로 부모 메시지가 생성되고,
    이후 assign-reviewer가 랜덤 지정 → review_requested 이벤트 → 스레드 답글로 자연스럽게 이어짐
  - IS_INITIAL 로직도 이 흐름에서 문제없이 동작

## Result
- PR 이벤트 발생 시 Slack 채널에 부모 메시지 + 스레드 답글 구조로 알림 전송
- 사전 설정 필요: Repository Secrets에 `SLACK_BOT_TOKEN`, `SLACK_CHANNEL_ID` 등록

---
## 연관 이슈

- close #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **작업**
  * Slack 통합 워크플로우 추가: 풀 리퀘스트 생성, 편집, 리뷰 요청, 병합 등의 이벤트를 자동으로 Slack 채널에 알림하고, GitHub 사용자를 Slack 사용자에 매핑하여 관련자들에게 멘션 전달

<!-- end of auto-generated comment: release notes by coderabbit.ai -->