### PR TITLE
chore: 에디터 포맷 자동화 설정 추가

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+    "bradlc.vscode-tailwindcss"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,35 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "prettier.requireConfig": true,
+  "prettier.configPath": "prettier.config.mjs",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,7 +28,9 @@
   },
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "explicit",
+    "source.sortMembers": "explicit"
   },
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "prettier.requireConfig": true,
-  "prettier.configPath": "prettier.config.mjs",
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },

--- a/apps/app/.vscode/settings.json
+++ b/apps/app/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "editor.codeActionsOnSave": {
-    "source.fixAll": "explicit",
-    "source.organizeImports": "explicit",
-    "source.sortMembers": "explicit"
-  }
-}


### PR DESCRIPTION
## 작업 요약

- 워크스페이스 설정을 추가해 저장 시 Prettier 자동 포맷을 강제합니다
- 권장 확장 안내로 팀원 환경 통일을 자동화합니다

## 작업 세부 내용

- `.vscode/settings.json` 추가
  - `editor.formatOnSave: true` — 저장 시 Prettier 자동 적용
  - `editor.defaultFormatter`를 `esbenp.prettier-vscode`로 강제 지정
  - `prettier.requireConfig: true` — `prettier.config.mjs`가 있을 때만 동작
  - 언어별 포매터 매핑 (`ts`, `tsx`, `js`, `jsx`, `json`, `md`, `css`)
  - ESLint `source.fixAll` 저장 시 자동 수정
- `.vscode/extensions.json` 추가
  - 워크스페이스 진입 시 권장 확장 팝업 자동 노출
  - `esbenp.prettier-vscode`, `dbaeumer.vscode-eslint`, `bradlc.vscode-tailwindcss`

## 적용 방법

- 레포 pull 후 VSCode/Cursor로 워크스페이스 열기
- 우하단 권장 확장 팝업에서 **설치** 클릭 (한 번만)
- 이후 저장(Cmd+S)마다 `prettier.config.mjs` 기준으로 자동 포맷됩니다


## 연관 이슈

closes #29


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 워크스페이스 개발환경 설정 추가 및 권장 확장(포맷터, 린터, Tailwind 지원 등) 제안 포함
  * 저장 시 자동 포맷 적용 및 기본 포맷터(Prettier) 지정, Prettier 설정 요구 활성화
  * ESLint 검증 및 저장 시 자동 수정·임포트 정리·멤버 정렬 동작 구성
  * 프로젝트 내 TypeScript 도구 경로 고정 및 일부 위치의 코드 액션 자동 실행 설정 제거
<!-- end of auto-generated comment: release notes by coderabbit.ai -->