### PR TITLE
style: 토너먼트 UI QA 피드백 반영 및 레이아웃 정밀 조정

### DIFF
--- a/apps/web/src/app/tournament/page.tsx
+++ b/apps/web/src/app/tournament/page.tsx
@@ -21,10 +21,12 @@ export default function TournamentPage() {
   }, [products]);
 
   return (
-    <div className="scrollbar-hide flex h-full flex-col items-center gap-6 overflow-y-auto px-4 pt-[calc(env(safe-area-inset-top)+48px)] pb-[calc(env(safe-area-inset-bottom)+24px)]">
-      <RoundBadge label={roundLabel} />
+    <div className="scrollbar-hide flex h-full flex-col items-center overflow-y-auto bg-[#F5F7F8] px-4 pt-[calc(env(safe-area-inset-top)+48px)] pb-[calc(env(safe-area-inset-bottom)+24px)]">
+      <div className="mb-6">
+        <RoundBadge label={roundLabel} />
+      </div>
       <TournamentQuestion />
-      <div className="mt-8 w-full">
+      <div className="mt-3 w-full">
         {currentMatch && (
           <VsSection
             key={roundLabel}

--- a/apps/web/src/components/tournament/FinalProductCard.tsx
+++ b/apps/web/src/components/tournament/FinalProductCard.tsx
@@ -26,10 +26,7 @@ export default function FinalProductCard({
   isPicked,
 }: FinalProductCardProps) {
   return (
-    <div
-      className={`relative cursor-pointer transition-all duration-[800ms] ease-in-out ${isPicked ? 'w-[178px]' : 'w-[148px]'}`}
-      onClick={onClick}
-    >
+    <div className="relative w-[148px] cursor-pointer" onClick={onClick}>
       {isPicked && (
         <div className="absolute top-0 left-1/2 z-10 flex h-[60px] w-[60px] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-[#1F7AF9] shadow-lg">
           <span className="text-base font-bold text-white" style={{ transform: 'rotate(-15deg)' }}>
@@ -37,10 +34,8 @@ export default function FinalProductCard({
           </span>
         </div>
       )}
-      <div
-        className={`flex flex-col overflow-hidden rounded-2xl bg-white shadow-[0_4px_20px_rgba(0,0,0,0.08)] transition-all duration-[800ms] ease-in-out ${isPicked ? 'w-[178px]' : 'w-[148px]'}`}
-      >
-        <div className="relative h-40 w-full shrink-0 bg-gray-100">
+      <div className="flex w-[148px] flex-col overflow-hidden rounded-2xl bg-white shadow-[0_1px_8px_0_rgba(0,0,0,0.10)]">
+        <div className="relative h-[123px] w-[148px] shrink-0 bg-gray-100">
           <Image
             src={imagePath}
             alt={name}

--- a/apps/web/src/components/tournament/ProductCard.tsx
+++ b/apps/web/src/components/tournament/ProductCard.tsx
@@ -17,14 +17,14 @@ export default function ProductCard({
   return (
     <div className="relative w-[148px] cursor-pointer" onClick={onClick}>
       {isPicked && (
-        <div className="justify-center absolute top-0 left-1/2 z-10 flex h-[60px] w-[60px] -translate-x-1/2 -translate-y-1/2 items-center rounded-full bg-[#1F7AF9] shadow-lg">
+        <div className="absolute top-0 left-1/2 z-10 flex h-[60px] w-[60px] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-[#1F7AF9] shadow-lg">
           <span className="text-base font-bold text-white" style={{ transform: 'rotate(-15deg)' }}>
             Pick!
           </span>
         </div>
       )}
-      <div className="flex w-[148px] flex-col overflow-hidden rounded-2xl bg-white shadow-[0_4px_20px_rgba(0,0,0,0.08)]">
-        <div className="relative h-40 w-full shrink-0 bg-gray-100">
+      <div className="flex w-[148px] flex-col overflow-hidden rounded-2xl bg-white shadow-[0_1px_8px_0_rgba(0,0,0,0.10)]">
+        <div className="relative h-[123px] w-[148px] shrink-0 bg-gray-100">
           <Image
             src={imagePath}
             alt={name}

--- a/apps/web/src/components/tournament/VsSection.tsx
+++ b/apps/web/src/components/tournament/VsSection.tsx
@@ -73,7 +73,7 @@ export default function VsSection({ left, right, onSelect, isFinal = false }: Vs
           className={`flex min-w-0 flex-1 flex-col items-center ${transition}`}
           style={{
             transform: `translateY(${leftCardShift}px) scale(${leftCardStyle.scale})`,
-            filter: `blur(${leftCardStyle.blur}px)`,
+            ...(leftCardStyle.blur > 0 && { filter: `blur(${leftCardStyle.blur}px)` }),
             ...duration,
           }}
         >
@@ -96,7 +96,7 @@ export default function VsSection({ left, right, onSelect, isFinal = false }: Vs
           className={`flex min-w-0 flex-1 flex-col items-center ${transition}`}
           style={{
             transform: `translateY(${rightCardShift}px) scale(${rightCardStyle.scale})`,
-            filter: `blur(${rightCardStyle.blur}px)`,
+            ...(rightCardStyle.blur > 0 && { filter: `blur(${rightCardStyle.blur}px)` }),
             ...duration,
           }}
         >

--- a/apps/web/src/components/tournament/VsSection.tsx
+++ b/apps/web/src/components/tournament/VsSection.tsx
@@ -9,7 +9,7 @@ import ProductCard from './ProductCard';
 
 const HANGER_HEIGHT = 54;
 const HOOK_HEIGHT = 33;
-const IMAGE_HEIGHT = 148;
+const IMAGE_HEIGHT = 123;
 const HORIZONTAL_LINE_WIDTH = 304.524;
 const DASH_V = 'repeating-linear-gradient(to bottom, rgba(77,77,77,0.60) 0, rgba(77,77,77,0.60) 3px, transparent 3px, transparent 6px)';
 const DASH_H = 'repeating-linear-gradient(to right, rgba(77,77,77,0.60) 0, rgba(77,77,77,0.60) 3px, transparent 3px, transparent 6px)';
@@ -118,7 +118,7 @@ export default function VsSection({ left, right, onSelect, isFinal = false }: Vs
         <div
           className={`absolute left-1/2 z-10 flex h-[32px] w-[32px] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-[#454545] text-[12.026px] leading-[17.18px] font-semibold tracking-[-0.515px] text-white ${transition}`}
           style={{
-            top: '50%',
+            top: HOOK_HEIGHT + IMAGE_HEIGHT,
             filter: selectedSide ? 'blur(2px)' : 'none',
             ...duration,
           }}

--- a/apps/web/src/components/tournament/VsSection.tsx
+++ b/apps/web/src/components/tournament/VsSection.tsx
@@ -9,8 +9,11 @@ import ProductCard from './ProductCard';
 
 const HANGER_HEIGHT = 54;
 const HOOK_HEIGHT = 33;
-const IMAGE_HEIGHT = 320;
-const HORIZONTAL_LINE_WIDTH = 350;
+const IMAGE_HEIGHT = 148;
+const HORIZONTAL_LINE_WIDTH = 304.524;
+const DASH_V = 'repeating-linear-gradient(to bottom, rgba(77,77,77,0.60) 0, rgba(77,77,77,0.60) 3px, transparent 3px, transparent 6px)';
+const DASH_H = 'repeating-linear-gradient(to right, rgba(77,77,77,0.60) 0, rgba(77,77,77,0.60) 3px, transparent 3px, transparent 6px)';
+const DASH_TOP = 'repeating-linear-gradient(to bottom, rgba(77,77,77,0.60) 0, rgba(77,77,77,0.60) 3px, transparent 3px, transparent 6px)';
 
 type VsSectionProps = {
   left: ProductT;
@@ -42,11 +45,21 @@ export default function VsSection({ left, right, onSelect, isFinal = false }: Vs
     <div className="w-full">
       {/* 헹거 영역 */}
       <div className="relative" style={{ height: HANGER_HEIGHT }}>
-        <div className="absolute top-0 left-1/2 h-full w-0 -translate-x-1/2 border-l-2 border-dashed border-gray-300" />
         <div
-          className={`absolute bottom-0 left-1/2 -translate-x-1/2 border-t border-dashed border-gray-300 ${transition}`}
+          className="absolute top-0 left-1/2 h-full -translate-x-1/2"
+          style={{
+            width: '1px',
+            backgroundImage: DASH_TOP,
+            maskImage: 'linear-gradient(to bottom, transparent 0%, black 100%)',
+            WebkitMaskImage: 'linear-gradient(to bottom, transparent 0%, black 100%)',
+          }}
+        />
+        <div
+          className={`absolute bottom-0 left-1/2 -translate-x-1/2 ${transition}`}
           style={{
             width: HORIZONTAL_LINE_WIDTH,
+            height: '1px',
+            backgroundImage: DASH_H,
             transform: `rotate(${hangerRotate}deg)`,
             ...duration,
           }}
@@ -65,8 +78,11 @@ export default function VsSection({ left, right, onSelect, isFinal = false }: Vs
           }}
         >
           <div
-            className="border-l-2 border-dashed border-gray-300"
-            style={{ height: HOOK_HEIGHT }}
+            style={{
+              width: '1px',
+              height: HOOK_HEIGHT,
+              backgroundImage: DASH_V,
+            }}
           />
           <CardComponent
             {...leftProduct}
@@ -85,8 +101,11 @@ export default function VsSection({ left, right, onSelect, isFinal = false }: Vs
           }}
         >
           <div
-            className="w-0 border-l-2 border-dashed border-gray-300"
-            style={{ height: HOOK_HEIGHT }}
+            style={{
+              width: '1px',
+              height: HOOK_HEIGHT,
+              backgroundImage: DASH_V,
+            }}
           />
           <CardComponent
             {...rightProduct}
@@ -99,7 +118,7 @@ export default function VsSection({ left, right, onSelect, isFinal = false }: Vs
         <div
           className={`absolute left-1/2 z-10 flex h-[32px] w-[32px] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-[#454545] text-[12.026px] leading-[17.18px] font-semibold tracking-[-0.515px] text-white ${transition}`}
           style={{
-            top: HOOK_HEIGHT + IMAGE_HEIGHT / 2,
+            top: '50%',
             filter: selectedSide ? 'blur(2px)' : 'none',
             ...duration,
           }}


### PR DESCRIPTION
## 작업 요약
배경색, 컴포넌트 간 간격, 이미지 비율 및 행거의 점선 스타일을 시안과 일치하도록 보정하였습니다.

## 작업 세부 내용
### 1. 페이지 및 카드 
**배경색 변경**: 페이지 전체 배경에 #F5F7F8 적용

**간격 조정**: 제목 섹션과 행거 구조물 사이의 간격을 12px로 조정

**카드 쉐도우**: 상품 카드에 0 1px 8px 0 rgba(0,0,0,0.10) 값 적용

### 2. 상품 카드 이미지
**이미지 영역 고정**: 카드 내 이미지 영역을 148×123px로 고정

**VS 뱃지 정렬**: VS 뱃지의 위치를 이미지 영역의 하단 경계선을 기준으로 수평 정렬

### 3. 행거 시스템 
**점선 스타일 통일**: 모든 수평/수직선의 대시 패턴을 3px/3px로 통일

**그라데이션 페이드인**: 위쪽 수직선에 rgba(0,0,0,0.10) 색상의 점선과 함께 위에서 아래로 흐려지는 그라데이션 효과 추가


### 4. 결승전 인터랙션 
**애니메이션 제거**: FinalProductCard 선택 시 적용되던 너비 확장 애니메이션 제거

**스타일 일치**: 일반 라운드 카드와 동일한 스타일 적용


## 연관 이슈

closes #57 
