### PR TITLE
chore: 서비스명 PIKI — 앱·패키지 설정

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -65,11 +65,10 @@
 │   ├── app/              # React Native + Expo (WebView 래퍼)
 │   └── web/              # Next.js 16 (메인 서비스)
 ├── packages/
-│   ├── core/             # @repo/core — 웹뷰 통신용 type/hook/util
-│   ├── ui/               # @repo/ui — 공유 UI (현재 미사용)
-│   ├── eslint-config/    # @repo/eslint-config
-│   └── typescript-config/ # @repo/typescript-config
+│   ├── core/             # @piki/core — 웹뷰 통신용 type/hook/util
+│   └── typescript-config/ # @piki/typescript-config
 ├── prettier.config.mjs   # 루트 Prettier (공통)
+├── eslint.config.mjs   # 루트 ESLint (공통)
 ├── .prettierignore
 └── turbo.json
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,12 +9,15 @@
 ## 🎯 프로젝트 컨텍스트
 
 ### 한 줄 정의
+
 **쌓인 위시리스트에서 먼저 살 것을 골라주는 소비 결정 서비스**
 
 ### 타겟 유저
+
 위시리스트와 장바구니는 가득하지만, 선택 피로로 구매를 계속 미루는 패션·라이프스타일 중심의 **20~30대 모바일 쇼핑 사용자**.
 
 ### 핵심 기능
+
 - **링크 기반 상품 저장** — 여러 쇼핑몰 링크를 한곳에 모음
 - **1:1 토너먼트 비교** — 두 개씩 비교해 최종 1순위 결정 (WOW 포인트)
 - **AI 소비 메이트** — 질문/공감/리마인드 (WOW 포인트)
@@ -22,6 +25,7 @@
 - **커머스 직접 연동** — 결정된 상품 즉시 구매
 
 ### 플랫폼 전략
+
 **RN(Expo) 앱이 WebView로 Next.js 웹앱을 감싸는 구조.**
 → 실제 UI/비즈니스 로직은 `apps/web`에 집중. 네이티브 기능만 `apps/app`에서 처리.
 
@@ -30,12 +34,14 @@
 ## 💻 기술 스택
 
 ### 공통
+
 - **패키지 매니저**: pnpm 10.17.0
 - **모노레포**: Turborepo
 - **언어**: TypeScript 5.9.2
 - **배포**: Vercel (web), Expo (app)
 
 ### apps/web (Next.js)
+
 - **프레임워크**: Next.js 16 (App Router)
 - **React**: 19.2.0
 - **상태관리**: Zustand
@@ -46,11 +52,13 @@
 - **아이콘**: Lucide React 우선 → 불가 시 SVG 컴포넌트화
 
 ### apps/app (React Native)
+
 - **프레임워크**: React Native + Expo
 - **라우팅**: Expo Router
 - **주요 역할**: WebView로 `apps/web` 렌더링
 
 ### CI/CD
+
 - **GitHub Actions**: PR 단위 빌드 검사 (`lint` → `check-types` → `build`)
 - **필수 통과 조건**: `pnpm install --frozen-lockfile`
 
@@ -59,22 +67,23 @@
 ## 📁 프로젝트 구조
 
 ### 모노레포 루트
+
 ```
 18th-team3-client/
 ├── apps/
 │   ├── app/              # React Native + Expo (WebView 래퍼)
 │   └── web/              # Next.js 16 (메인 서비스)
 ├── packages/
-│   ├── core/             # @repo/core — 웹뷰 통신용 type/hook/util
-│   ├── ui/               # @repo/ui — 공유 UI (현재 미사용)
-│   ├── eslint-config/    # @repo/eslint-config
-│   └── typescript-config/ # @repo/typescript-config
+│   ├── core/             # @piki/core — 웹뷰 통신용 type/hook/util
+│   └── typescript-config/ # @piki/typescript-config
 ├── prettier.config.mjs   # 루트 Prettier (공통)
+├── eslint.config.mjs   # 루트 ESLint (공통)
 ├── .prettierignore
 └── turbo.json
 ```
 
 ### apps/web 내부 (고전 구조)
+
 ```
 apps/web/src/
 ├── app/          # Next.js App Router (layout, page, providers)
@@ -98,25 +107,27 @@ apps/web/src/
 ```
 
 ### Path Alias
+
 `@/*` → `apps/web/src/*`
 
 ---
 
 ## 📝 네이밍 컨벤션
 
-| 대상 | 규칙 | 예시 |
-|---|---|---|
-| **컴포넌트 파일** | PascalCase | `ScaleResult.tsx` |
-| **일반 파일** (훅, 유틸) | camelCase | `useAuth.ts`, `formatDate.ts` |
-| **폴더** | kebab-case | `scale-result/` |
-| **타입** | T suffix | `UserT`, `ProductT` |
-| **API 함수** | HTTP 메서드 prefix | `getUser`, `postWishlist`, `patchProfile`, `deleteItem` |
+| 대상                     | 규칙               | 예시                                                    |
+| ------------------------ | ------------------ | ------------------------------------------------------- |
+| **컴포넌트 파일**        | PascalCase         | `ScaleResult.tsx`                                       |
+| **일반 파일** (훅, 유틸) | camelCase          | `useAuth.ts`, `formatDate.ts`                           |
+| **폴더**                 | kebab-case         | `scale-result/`                                         |
+| **타입**                 | T suffix           | `UserT`, `ProductT`                                     |
+| **API 함수**             | HTTP 메서드 prefix | `getUser`, `postWishlist`, `patchProfile`, `deleteItem` |
 
 ---
 
 ## 🎨 코딩 컨벤션
 
 ### 컴포넌트
+
 - **`function` 키워드 + default export**
 
 ```tsx
@@ -128,6 +139,7 @@ export default MyComponent;
 ```
 
 ### 유틸 함수
+
 - **화살표 함수** 사용
 
 ```ts
@@ -135,6 +147,7 @@ const formatDate = (date: Date) => date.toISOString();
 ```
 
 ### 타입 선언
+
 - **`type` 사용** (interface 대신)
 - **T suffix** (컨벤션상 타입 선언 시)
 - Props 타입명: `{ComponentName}Props`
@@ -151,6 +164,7 @@ type MyComponentProps = {
 ```
 
 ### Props 네이밍
+
 - **내부 핸들러**: `handle-` (예: `handleClick`, `handleSubmit`)
 - **외부에서 받는 props**: `on-` (예: `onClick`, `onSubmit`)
 
@@ -165,6 +179,7 @@ function Button({ onClick }: ButtonProps) {
 ```
 
 ### 기타
+
 - **세미콜론**: 사용 (`semi: true`)
 - **따옴표**: `singleQuote: true` (`'홑따옴표'`)
 - **printWidth**: 100
@@ -176,6 +191,7 @@ function Button({ onClick }: ButtonProps) {
 ## 📦 Import 규칙
 
 ### 정렬 (자동화됨 — `@trivago/prettier-plugin-sort-imports`)
+
 ```
 1. 외부 라이브러리  (<THIRD_PARTY_MODULES>)
 2. 절대경로        (^@/)
@@ -183,6 +199,7 @@ function Button({ onClick }: ButtonProps) {
 ```
 
 ### 예시
+
 ```tsx
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
@@ -195,6 +212,7 @@ import styles from './Page.module.css';
 ```
 
 ### Prettier 옵션
+
 - `importOrderSeparation: true` (그룹 간 빈 줄)
 - `importOrderSortSpecifiers: true` (그룹 내 알파벳 정렬)
 
@@ -214,16 +232,19 @@ import styles from './Page.module.css';
 ## 🔀 Git 전략
 
 ### 브랜치 구조
+
 ```
 main ← dev ← {type}/{issue-number}-{description}
 ```
 
 ### 브랜치 네이밍
+
 - **패턴**: `{type}/{issue-number}-{description}`
 - **예시**: `feat/1-login-page`, `chore/3-web-setup`, `fix/5-auth-bug`
 - **타입**: `feat`, `fix`, `chore`, `docs`, `refactor`, `style`, `test`
 
 ### 커밋 메시지
+
 - **형식**: `{type}: {한글 설명}`
 - **예시**:
   - `feat: 로그인 페이지 구현`
@@ -231,23 +252,29 @@ main ← dev ← {type}/{issue-number}-{description}
   - `fix: 토큰 만료 처리 수정`
 
 ### 머지 방식
+
 - **Squash Merge** 사용
 - PR 제목이 그대로 dev의 커밋 메시지가 됨 → PR 제목 신중히 작성
 
 ### PR 컨벤션
+
 - **base 브랜치**: `dev` (main 아님)
 - **템플릿**:
+
 ```markdown
 ## 작업 내용
+
 [내용 정리]
 
 ## 스크린샷
 
 ## 연관 이슈
+
 closes #이슈번호
 ```
 
 ### 코드 리뷰 — PN 룰
+
 - **P1** (Request changes): 꼭 반영 — 중대한 오류 가능성
 - **P2** (Request changes): 적극 고려 — 수용 or 토론
 - **P3** (Comment): 웬만하면 반영 — 미반영 시 사유 설명
@@ -255,6 +282,7 @@ closes #이슈번호
 - **P5** (Approve): 사소한 의견 — 무시 가능
 
 ### 리뷰 규칙
+
 - **랜덤 1명 승인** 시 머지 가능
 - 리뷰 자동 배정 워크플로우 사용
 
@@ -263,12 +291,14 @@ closes #이슈번호
 ## 🌐 API 통신 — Response Schema 규약
 
 ### 기본 원칙
+
 1. **HTTP Status Code는 REST 의미대로 사용** (200, 201, 400, 401, 403, 404, 500)
 2. **성공/실패 Body 구조 통일**
 3. **`fetch`는 4xx/5xx에서 자동 throw 안 함** → 반드시 `response.ok` 확인
 4. **`success` 필드 사용 안 함** (`response.ok`와 중복)
 
 ### 응답 구조
+
 ```json
 {
   "status": 200,
@@ -278,31 +308,31 @@ closes #이슈번호
 }
 ```
 
-| 필드 | 설명 |
-|---|---|
-| `status` | HTTP Status Code와 동일 |
-| `data` | 실제 비즈니스 응답 데이터 (실패 시 `null`) |
-| `detail` | 응답 메시지 (사용자 표시용) |
-| `code` | 서버 정의 Enum 코드 (세부 분기용) |
+| 필드     | 설명                                       |
+| -------- | ------------------------------------------ |
+| `status` | HTTP Status Code와 동일                    |
+| `data`   | 실제 비즈니스 응답 데이터 (실패 시 `null`) |
+| `detail` | 응답 메시지 (사용자 표시용)                |
+| `code`   | 서버 정의 Enum 코드 (세부 분기용)          |
 
 ### 검증 오류 응답 (400)
+
 ```json
 {
   "status": 400,
   "data": null,
   "detail": "입력값이 올바르지 않습니다.",
   "code": "INVALID_INPUT",
-  "errors": [
-    { "field": "url", "reason": "URL 형식이 올바르지 않습니다." }
-  ]
+  "errors": [{ "field": "url", "reason": "URL 형식이 올바르지 않습니다." }]
 }
 ```
 
 ### 페이지 응답 구조
+
 ```json
 {
   "status": 200,
-  "data": [ { "wishId": 1, "title": "셔츠" } ],
+  "data": [{ "wishId": 1, "title": "셔츠" }],
   "detail": "요청이 정상적으로 처리되었습니다.",
   "code": "COMMON_SUCCESS",
   "pageInfo": { "nextCursor": "abc123", "hasNext": true }
@@ -310,6 +340,7 @@ closes #이슈번호
 ```
 
 ### 프론트엔드 fetch 처리 표준
+
 ```ts
 export async function request(url: string, options?: RequestInit) {
   const response = await fetch(url, options);
@@ -330,6 +361,7 @@ export async function request(url: string, options?: RequestInit) {
 ```
 
 ### 검증 오류 세부 처리
+
 ```ts
 if (response.status === 400 && body.errors) {
   return body.errors;
@@ -337,6 +369,7 @@ if (response.status === 400 && body.errors) {
 ```
 
 ### 분기 처리 (세부 에러)
+
 ```ts
 if (body.code === 'WISH_NOT_FOUND') {
   // 특정 에러 처리
@@ -344,21 +377,23 @@ if (body.code === 'WISH_NOT_FOUND') {
 ```
 
 ### HTTP Status 사용 기준
-| 상황 | HTTP Status |
-|---|---|
-| 조회 성공 | 200 OK |
-| 생성 성공 | 201 Created |
-| 잘못된 요청 | 400 Bad Request |
-| 인증 실패 | 401 Unauthorized |
-| 권한 없음 | 403 Forbidden |
-| 리소스 없음 | 404 Not Found |
-| 서버 오류 | 500 Internal Server Error |
+
+| 상황        | HTTP Status               |
+| ----------- | ------------------------- |
+| 조회 성공   | 200 OK                    |
+| 생성 성공   | 201 Created               |
+| 잘못된 요청 | 400 Bad Request           |
+| 인증 실패   | 401 Unauthorized          |
+| 권한 없음   | 403 Forbidden             |
+| 리소스 없음 | 404 Not Found             |
+| 서버 오류   | 500 Internal Server Error |
 
 ---
 
 ## 🤖 Claude 작업 지침
 
 ### 코드 생성 시
+
 - **위 컨벤션을 반드시 준수**
 - 신규 컴포넌트: `function` 키워드 + PascalCase 파일명 + default export
 - 신규 훅: 화살표 함수 + camelCase 파일명
@@ -367,25 +402,29 @@ if (body.code === 'WISH_NOT_FOUND') {
 - 경로는 `@/*` 절대경로 우선, 같은 디렉토리는 상대경로
 
 ### 커밋 메시지 제안 시
+
 - `{type}: {한글 설명}` 형식 사용
 - type: feat, fix, chore, docs, refactor, style, test
 
 ### PR 작성 시
+
 - 제목: `{type}: {한글 설명}` 형식
 - 본문에 `closes #이슈번호` 포함
 - base 브랜치는 `dev`
 
 ### 리뷰 코멘트 작성 시
+
 - PN 태그 (P1~P5) 사용
 - 이유 명확히 설명
 
 ### API 관련 코드 생성 시
+
 - HTTP status 기반 분기 (`response.ok`)
 - body 구조: `{ status, data, detail, code }` 가정
 - fetch 래퍼 함수 활용 패턴
 
-
 ### 의심스러울 때
+
 - 기존 코드 패턴 확인
 - 팀 컨벤션 우선 (이 문서)
 - 판단 어려우면 사용자에게 확인

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This Turborepo includes the following packages/apps:
 
 - `docs`: a [Next.js](https://nextjs.org/) app
 - `web`: another [Next.js](https://nextjs.org/) app
-- `@repo/typescript-config`: `tsconfig.json`s used throughout the monorepo
+- `@piki/typescript-config`: `tsconfig.json`s used throughout the monorepo
 
 Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).
 

--- a/apps/app/app.json
+++ b/apps/app/app.json
@@ -10,10 +10,10 @@
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "day.no30s.piki"
+      "bundleIdentifier": "com.piki.app"
     },
     "android": {
-      "package": "day.no30s.piki",
+      "package": "com.piki.app",
       "adaptiveIcon": {
         "backgroundColor": "#E6F4FE",
         "foregroundImage": "./assets/images/android-icon-foreground.png",

--- a/apps/app/app.json
+++ b/apps/app/app.json
@@ -1,17 +1,19 @@
 {
   "expo": {
-    "name": "app",
-    "slug": "app",
+    "name": "PIKI",
+    "slug": "piki",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "app",
+    "scheme": "piki",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.piki.piki"
     },
     "android": {
+      "package": "com.piki.piki",
       "adaptiveIcon": {
         "backgroundColor": "#E6F4FE",
         "foregroundImage": "./assets/images/android-icon-foreground.png",

--- a/apps/app/app.json
+++ b/apps/app/app.json
@@ -10,10 +10,10 @@
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.piki.piki"
+      "bundleIdentifier": "day.no30s.piki"
     },
     "android": {
-      "package": "com.piki.piki",
+      "package": "day.no30s.piki",
       "adaptiveIcon": {
         "backgroundColor": "#E6F4FE",
         "foregroundImage": "./assets/images/android-icon-foreground.png",

--- a/apps/app/app/index.tsx
+++ b/apps/app/app/index.tsx
@@ -1,4 +1,4 @@
-import { type WebBridgeMessageT } from '@repo/core';
+import { type WebBridgeMessageT } from '@piki/core';
 import { useCallback, useEffect, useRef } from 'react';
 import { KeyboardAvoidingView, Platform } from 'react-native';
 import type { WebView } from 'react-native-webview';

--- a/apps/app/hooks/useWebBridgeMessage.ts
+++ b/apps/app/hooks/useWebBridgeMessage.ts
@@ -1,4 +1,4 @@
-import { type WebBridgeMessageT, isWebBridgeMessageT } from '@repo/core';
+import { type WebBridgeMessageT, isWebBridgeMessageT } from '@piki/core';
 import { useCallback } from 'react';
 import type { WebViewMessageEvent } from 'react-native-webview';
 

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
-    "@repo/core": "workspace:*",
+    "@piki/core": "workspace:*",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app",
+  "name": "piki-app",
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {

--- a/apps/app/utils/webBridge.ts
+++ b/apps/app/utils/webBridge.ts
@@ -1,4 +1,4 @@
-import type { WebBridgeMessageT } from '@repo/core';
+import type { WebBridgeMessageT } from '@piki/core';
 import type { RefObject } from 'react';
 import type { WebView } from 'react-native-webview';
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
     "check-types": "next typegen && tsc --noEmit"
   },
   "dependencies": {
-    "@repo/core": "workspace:*",
+    "@piki/core": "workspace:*",
     "@tanstack/react-query": "^5.96.2",
     "@tanstack/react-query-devtools": "^5.96.2",
     "axios": "^1.15.2",
@@ -25,8 +25,8 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
-    "@repo/typescript-config": "workspace:*",
     "@svgr/webpack": "^8.1.0",
+    "@piki/typescript-config": "workspace:*",
     "@tailwindcss/postcss": "^4.2.2",
     "@types/node": "^22.15.3",
     "@types/react": "19.2.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "web",
+  "name": "piki-web",
   "version": "0.1.0",
   "type": "module",
   "private": true,

--- a/apps/web/src/hooks/useWebBridgeMessage.ts
+++ b/apps/web/src/hooks/useWebBridgeMessage.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { type WebBridgeMessageT, isWebBridgeMessageT } from '@repo/core';
+import { type WebBridgeMessageT, isWebBridgeMessageT } from '@piki/core';
 import { useEffect, useRef } from 'react';
 
 /**

--- a/apps/web/src/utils/webBridge.ts
+++ b/apps/web/src/utils/webBridge.ts
@@ -1,4 +1,4 @@
-import type { WebBridgeMessageT } from '@repo/core';
+import type { WebBridgeMessageT } from '@piki/core';
 
 type RNWebViewWindowT = {
   ReactNativeWebView: {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@repo/typescript-config/nextjs.json",
+  "extends": "@piki/typescript-config/nextjs.json",
   "compilerOptions": {
     "plugins": [
       {

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "check-types": "turbo run check-types",
-    "install:web": "pnpm --filter web install",
-    "dev:web": "pnpm --filter web dev",
-    "build:web": "pnpm --filter web build",
-    "install:app": "pnpm --filter app install",
-    "dev:app": "pnpm --filter app start"
+    "install:web": "pnpm --filter piki-web install",
+    "dev:web": "pnpm --filter piki-web dev",
+    "build:web": "pnpm --filter piki-web build",
+    "install:app": "pnpm --filter piki-app install",
+    "dev:app": "pnpm --filter piki-app start"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dep-client",
+  "name": "piki",
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@repo/core",
+  "name": "@piki/core",
   "version": "0.0.1",
   "private": true,
   "exports": {
@@ -9,7 +9,7 @@
     "react": "19.2.0"
   },
   "devDependencies": {
-    "@repo/typescript-config": "workspace:*",
+    "@piki/typescript-config": "workspace:*",
     "@types/react": "19.2.2",
     "typescript": "5.9.2"
   }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@repo/typescript-config/react-library.json",
+  "extends": "@piki/typescript-config/react-library.json",
   "compilerOptions": {
     "strictNullChecks": true
   },

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@repo/typescript-config",
+  "name": "@piki/typescript-config",
   "version": "0.0.0",
   "private": true,
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@expo/vector-icons':
         specifier: ^15.0.3
         version: 15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.2)(react@19.2.0))(react@19.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.2)(react@19.2.0))(react@19.2.0)
+      '@piki/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@react-navigation/bottom-tabs':
         specifier: ^7.4.0
         version: 7.15.9(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.2)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.2)(react@19.2.0))(react@19.2.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.2)(react@19.2.0))(react@19.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.2)(react@19.2.0))(react@19.2.0)
@@ -65,9 +68,6 @@ importers:
       '@react-navigation/native':
         specifier: ^7.1.8
         version: 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.2)(react@19.2.0))(react@19.2.0)
-      '@repo/core':
-        specifier: workspace:*
-        version: link:../../packages/core
       expo:
         specifier: ~54.0.33
         version: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.16.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.2)(react@19.2.0))(react@19.2.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.2)(react@19.2.0))(react@19.2.0)(typescript@5.9.2)
@@ -150,7 +150,7 @@ importers:
 
   apps/web:
     dependencies:
-      '@repo/core':
+      '@piki/core':
         specifier: workspace:*
         version: link:../../packages/core
       '@tanstack/react-query':
@@ -187,7 +187,7 @@ importers:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
     devDependencies:
-      '@repo/typescript-config':
+      '@piki/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
       '@svgr/webpack':
@@ -227,7 +227,7 @@ importers:
         specifier: 19.2.0
         version: 19.2.0
     devDependencies:
-      '@repo/typescript-config':
+      '@piki/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
       '@types/react':


### PR DESCRIPTION
## 작업 요약

- 서비스명 `PIKI`로 확정함에 따라 웹, 앱 설정에 서비스명을 추가한다.

## 작업 세부 내용

### APP
- [x] `expo.name` → `PIKI` (실제 보여지는 앱 이름)
- [x] `expo.slug` → `piki` (Expo에서 사용하는 프로젝트 ID)
- [x] `expo.scheme` → `piki` (deep link, universal link 등에 활용되는 앱 도메인)
- [x] `ios.bundleIdentifier`, `android.package` → `com.piki.piki`로 설정
- [x] `apps/app/package.json` `name` → `piki-app`

### WEB
- [x] `name` → `"piki-web"`

### 기타
- [ ] 레포 이름 PIKI-Client

---

## 📢 팀원 확인 및 논의 필요 사항

1. **레포지토리 이름 변경 안내**
   - 레포지토리 이름은 **5/19(화) 디자인 시스템 관련 PR이 모두 머지된 이후**에 `PIKI-Client`로 변경할 예정입니다.

2. **iOS Bundle Identifier / Android Package Name 관련 의견 수렴**
   - 현재 팀 이름이 따로 정해지지 않아 관례(도메인.회사명.서비스)에 따라 **`day.no30s.piki`**로 설정해 두었습니다.
   - `com.depromeet.piki`, `com.team.piki` 등 다른 네이밍 선택지도 열려 있으니, 더 좋은 아이디어나 의견이 있으신 분은 코멘트로 편하게 남겨주세요! (com.piki.piki는 이미 사용 중이었음 ㅠ.ㅠ)

## 연관 이슈

close #65


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 프로젝트명과 앱 식별자를 PIKI로 통일하고 관련 패키지/스크립트 명칭을 piki-*로 업데이트
  * 워크스페이스 패키지 스코프를 `@repo에서` `@piki로` 이관 및 TypeScript 설정 참조 갱신
  * 앱 메타데이터(이름/슬러그/스킴/번들 식별자) 및 실행 스크립트 조정

* **Documentation**
  * 개발 가이드 문서를 마크다운 형식으로 재구성하고 API/코딩 규칙을 명확히 정리

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Client/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->