### PR TITLE
fix: 라우팅 경로를 /item으로 통일

### DIFF
--- a/apps/web/src/app/tournament/create/_components/addWishDialog/AddWishDialog.tsx
+++ b/apps/web/src/app/tournament/create/_components/addWishDialog/AddWishDialog.tsx
@@ -69,7 +69,7 @@ function AddWishDialog({ trigger }: AddWishDialogProps) {
   const handleLinkSubmit = (url: string) => {
     // TODO: 입력된 url로 상품 정보 가져오기 (API 연동 전 mock)
     // 임시 itemId 'new'로 상품 확인 페이지 이동, type=tournament로 분기
-    router.push(`/items/new/edit?type=tournament&url=${encodeURIComponent(url)}`);
+    router.push(`/item/new/edit?type=tournament&url=${encodeURIComponent(url)}`);
   };
 
   return (

--- a/apps/web/src/components/common/wish-failed-card/index.tsx
+++ b/apps/web/src/components/common/wish-failed-card/index.tsx
@@ -8,7 +8,7 @@ function WishFailedCard() {
       <WarningIconFill className="size-6 text-icon-neutral-secondary" />
       <p className="body-2-semibold text-text-neutral-secondary">가져오는데 실패했어요</p>
       <Link
-        href="/items/manual"
+        href="/item/manual"
         className="body-2-medium text-text-neutral-secondary underline underline-offset-[3px]"
       >
         직접 입력하기

--- a/apps/web/src/components/common/wish-grid/index.tsx
+++ b/apps/web/src/components/common/wish-grid/index.tsx
@@ -56,7 +56,7 @@ function WishGrid({ items, isDeleteMode = false, selectedIds, onToggleSelect }: 
         return (
           <Link
             key={item.id}
-            href={`/items/${item.id}/edit?type=wish`}
+            href={`/item/${item.id}/edit?type=wish`}
             className="transition-colors active:opacity-80"
           >
             {card}


### PR DESCRIPTION
## 작업 요약

- `/items` → `/item` 라우트 변경에 누락된 호출부 3곳을 갱신해 404를 수정합니다

## 작업 세부 내용

#94에서 `/items` → `/item`으로 라우트가 단수형으로 변경되었으나, 호출부 일부가 옛 경로(`/items/...`)를 그대로 가리키고 있어 클릭/제출 시 404가 발생했습니다. 해당 3곳을 새 경로로 갱신했습니다.

### 수정 파일
- `components/common/wish-grid/index.tsx` — 보관함 카드 클릭 라우팅 (`/items/{id}/edit` → `/item/{id}/edit`)
- `components/common/wish-failed-card/index.tsx` — 추출 실패 카드 "직접 입력하기" 링크 (`/items/manual` → `/item/manual`)
- `app/tournament/create/_components/addWishDialog/AddWishDialog.tsx` — 토너먼트 링크 등록 후 라우팅 (`/items/new/edit` → `/item/new/edit`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 항목 편집 및 생성 경로 라우팅을 통일하여 링크 동작을 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Client/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->