### PR TITLE
style: 전역 레이아웃 공통화 및 페이지 전환 흔들림 수정

### DIFF
--- a/apps/web/src/app/home/_components/CreateTournamentDialog.tsx
+++ b/apps/web/src/app/home/_components/CreateTournamentDialog.tsx
@@ -44,7 +44,7 @@ function CreateTournamentDialog({ onCreate }: CreateTournamentDialogProps) {
       </DialogTrigger>
       <DialogContent
         showCloseButton={false}
-        className="flex w-[360px] max-w-[calc(100%-40px)] flex-col gap-5"
+        className="flex flex-col gap-5"
       >
         <DialogTitle className="text-center heading-1 text-text-neutral-primary">
           새 토너먼트

--- a/apps/web/src/app/home/page.tsx
+++ b/apps/web/src/app/home/page.tsx
@@ -21,7 +21,7 @@ async function HomePage() {
   });
 
   return (
-    <div className="relative flex min-h-dvh flex-col bg-bg-layer-basement pt-9 pb-32">
+    <div className="relative flex min-h-dvh flex-col pt-9 pb-32">
       {/* 상단 헤더 */}
       <Header
         right={
@@ -32,7 +32,7 @@ async function HomePage() {
         }
       />
       {/* 메인 컨텐츠 */}
-      <main className="mt-[54px] flex w-full flex-col gap-12 px-5">
+      <main className="mt-[54px] flex w-full flex-col gap-12">
         {/* 로고 + CTA 영역 */}
         <section className="flex flex-col items-center gap-12">
           {/* PIKI 로고 */}

--- a/apps/web/src/app/home/page.tsx
+++ b/apps/web/src/app/home/page.tsx
@@ -21,7 +21,7 @@ async function HomePage() {
   });
 
   return (
-    <div className="relative flex min-h-dvh flex-col bg-bg-layer-basement pt-15 pb-32">
+    <div className="relative flex min-h-dvh flex-col bg-bg-layer-basement pt-9 pb-32">
       {/* 상단 헤더 */}
       <Header
         right={

--- a/apps/web/src/app/item/[id]/edit/_components/ItemEditForm.tsx
+++ b/apps/web/src/app/item/[id]/edit/_components/ItemEditForm.tsx
@@ -56,7 +56,7 @@ function ItemEditForm({
   return (
     <main className="flex min-h-dvh flex-col bg-bg-layer-default pt-9 pb-[78px]">
       {isWish && <Header left={<HeaderIcon name="BACK" />} />}
-      <div className="flex w-full flex-col gap-6 px-5 pt-3">
+      <div className="flex w-full flex-col gap-6 pt-3">
         {/* 헤더 */}
         <header className="flex flex-col items-center gap-2 text-center">
           <h1 className="text-[24px] leading-8 font-bold tracking-[-0.6px] text-text-neutral-primary">

--- a/apps/web/src/app/item/[id]/edit/_components/ItemEditForm.tsx
+++ b/apps/web/src/app/item/[id]/edit/_components/ItemEditForm.tsx
@@ -95,7 +95,7 @@ function ItemEditForm({
       </div>
 
       {/* 하단 고정 버튼 */}
-      <div className="fixed right-0 bottom-0 left-0 mx-auto flex w-full max-w-120 items-center gap-3 border-t border-gray-50 bg-bg-layer-basement px-5 py-3">
+      <div className="fixed right-0 bottom-0 left-0 mx-auto flex w-full max-w-120 items-center gap-3 border-t border-gray-50 bg-bg-layer-basement p-5">
         {!isWish && (
           <Button
             variant="secondary"

--- a/apps/web/src/app/item/[id]/edit/_components/ItemEditForm.tsx
+++ b/apps/web/src/app/item/[id]/edit/_components/ItemEditForm.tsx
@@ -95,7 +95,7 @@ function ItemEditForm({
       </div>
 
       {/* 하단 고정 버튼 */}
-      <div className="fixed right-0 bottom-0 left-0 mx-auto flex w-full max-w-120 items-center gap-3 border-t border-gray-50 bg-bg-layer-default px-5 py-3">
+      <div className="fixed right-0 bottom-0 left-0 mx-auto flex w-full max-w-120 items-center gap-3 border-t border-gray-50 bg-bg-layer-basement px-5 py-3">
         {!isWish && (
           <Button
             variant="secondary"

--- a/apps/web/src/app/item/[id]/edit/_components/ItemEditForm.tsx
+++ b/apps/web/src/app/item/[id]/edit/_components/ItemEditForm.tsx
@@ -95,7 +95,7 @@ function ItemEditForm({
       </div>
 
       {/* 하단 고정 버튼 */}
-      <div className="fixed right-0 bottom-0 left-0 mx-auto flex w-full max-w-120 items-center gap-3 border-t border-gray-50 bg-bg-layer-basement p-5">
+      <div className="fixed right-0 bottom-0 left-0 mx-auto flex w-full max-w-120 items-center gap-3 p-5">
         {!isWish && (
           <Button
             variant="secondary"

--- a/apps/web/src/app/item/[id]/edit/_components/ItemEditForm.tsx
+++ b/apps/web/src/app/item/[id]/edit/_components/ItemEditForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 import { EditIconFill } from '@/assets/icons';
+import BottomCta from '@/components/common/bottom-cta';
 import Button from '@/components/common/button';
 import { Header, HeaderIcon } from '@/components/common/header';
 import Input from '@/components/common/input';
@@ -95,7 +96,7 @@ function ItemEditForm({
       </div>
 
       {/* 하단 고정 버튼 */}
-      <div className="fixed right-0 bottom-0 left-0 mx-auto flex w-full max-w-120 items-center gap-3 p-5">
+      <BottomCta>
         {!isWish && (
           <Button
             variant="secondary"
@@ -116,7 +117,7 @@ function ItemEditForm({
         >
           저장하기
         </Button>
-      </div>
+      </BottomCta>
     </main>
   );
 }

--- a/apps/web/src/app/item/[id]/edit/_components/ItemEditForm.tsx
+++ b/apps/web/src/app/item/[id]/edit/_components/ItemEditForm.tsx
@@ -35,8 +35,7 @@ function ItemEditForm({
   const [price, setPrice] = useState(formatPrice(initialPrice));
 
   const isChanged =
-    name.trim() !== initialName.trim() ||
-    formatPrice(price) !== formatPrice(initialPrice);
+    name.trim() !== initialName.trim() || formatPrice(price) !== formatPrice(initialPrice);
 
   const handleDelete = () => {
     // TODO: 후보 삭제 처리
@@ -55,7 +54,7 @@ function ItemEditForm({
     : '상품명과 가격은 직접 수정할 수 있어요';
 
   return (
-    <main className="flex min-h-dvh flex-col bg-bg-layer-default pt-15 pb-[78px]">
+    <main className="flex min-h-dvh flex-col bg-bg-layer-default pt-9 pb-[78px]">
       {isWish && <Header left={<HeaderIcon name="BACK" />} />}
       <div className="flex w-full flex-col gap-6 px-5 pt-3">
         {/* 헤더 */}

--- a/apps/web/src/app/item/[id]/edit/_components/ItemLinkBanner.tsx
+++ b/apps/web/src/app/item/[id]/edit/_components/ItemLinkBanner.tsx
@@ -11,7 +11,7 @@ function ItemLinkBanner({ href, label }: ItemLinkBannerProps) {
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="flex w-full items-center gap-4 rounded-xl bg-[#EAEAEC] px-4 py-3 transition-colors active:bg-gray-100"
+      className="flex w-full items-center gap-4 rounded-xl bg-gray-75 px-4 py-3 transition-colors active:bg-gray-100"
     >
       <span className="flex size-12 shrink-0 items-center justify-center rounded-full bg-bg-layer-default">
         <LinkIconFill className="size-6 text-icon-neutral-primary" />

--- a/apps/web/src/app/item/[id]/edit/_components/ItemLinkBanner.tsx
+++ b/apps/web/src/app/item/[id]/edit/_components/ItemLinkBanner.tsx
@@ -11,7 +11,7 @@ function ItemLinkBanner({ href, label }: ItemLinkBannerProps) {
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="flex w-full items-center gap-4 rounded-xl bg-gray-50 px-4 py-3 transition-colors active:bg-gray-100"
+      className="flex w-full items-center gap-4 rounded-xl bg-[#EAEAEC] px-4 py-3 transition-colors active:bg-gray-100"
     >
       <span className="flex size-12 shrink-0 items-center justify-center rounded-full bg-bg-layer-default">
         <LinkIconFill className="size-6 text-icon-neutral-primary" />

--- a/apps/web/src/app/item/manual/_components/ItemManualForm.tsx
+++ b/apps/web/src/app/item/manual/_components/ItemManualForm.tsx
@@ -49,12 +49,12 @@ function ItemManualForm() {
     price.replace(/[^\d]/g, '') !== '0';
 
   return (
-    <main className="flex min-h-dvh flex-col bg-bg-layer-basement pb-[78px]">
+    <main className="flex min-h-dvh flex-col pb-[78px]">
       <div className="pt-9">
         <Header left={<HeaderIcon name="BACK" onClick={handleBack} />} />
       </div>
 
-      <div className="flex w-full flex-col gap-6 px-5 pt-6">
+      <div className="flex w-full flex-col gap-6 pt-6">
         {/* 헤더 */}
         <header className="flex flex-col items-center gap-2 text-center">
           <h1 className="text-[24px] leading-8 font-bold tracking-[-0.6px] text-text-neutral-primary">

--- a/apps/web/src/app/item/manual/_components/ItemManualForm.tsx
+++ b/apps/web/src/app/item/manual/_components/ItemManualForm.tsx
@@ -3,8 +3,9 @@
 import { useRouter } from 'next/navigation';
 import { useRef, useState } from 'react';
 
-import { ChevronBackwardIconFill, ImageIconOutline } from '@/assets/icons';
+import { ImageIconOutline } from '@/assets/icons';
 import Button from '@/components/common/button';
+import { Header, HeaderIcon } from '@/components/common/header';
 import Input from '@/components/common/input';
 import formatPrice from '@/utils/formatPrice';
 
@@ -49,16 +50,11 @@ function ItemManualForm() {
 
   return (
     <main className="flex min-h-dvh flex-col bg-bg-layer-basement pb-[78px]">
-      <button
-        type="button"
-        onClick={handleBack}
-        aria-label="뒤로가기"
-        className="absolute top-9 left-5 cursor-pointer p-0"
-      >
-        <ChevronBackwardIconFill className="size-[30px] text-icon-neutral-primary" />
-      </button>
+      <div className="pt-9">
+        <Header left={<HeaderIcon name="BACK" onClick={handleBack} />} />
+      </div>
 
-      <div className="flex w-full flex-col gap-6 px-5 pt-[102px]">
+      <div className="flex w-full flex-col gap-6 px-5 pt-6">
         {/* 헤더 */}
         <header className="flex flex-col items-center gap-2 text-center">
           <h1 className="text-[24px] leading-8 font-bold tracking-[-0.6px] text-text-neutral-primary">

--- a/apps/web/src/app/item/manual/_components/ItemManualForm.tsx
+++ b/apps/web/src/app/item/manual/_components/ItemManualForm.tsx
@@ -41,7 +41,11 @@ function ItemManualForm() {
     router.back();
   };
 
-  const isValid = Boolean(imageUrl) && name.trim().length > 0 && price.replace(/[^\d]/g, '') !== '' && price.replace(/[^\d]/g, '') !== '0';
+  const isValid =
+    Boolean(imageUrl) &&
+    name.trim().length > 0 &&
+    price.replace(/[^\d]/g, '') !== '' &&
+    price.replace(/[^\d]/g, '') !== '0';
 
   return (
     <main className="flex min-h-dvh flex-col bg-bg-layer-basement pb-[78px]">
@@ -49,7 +53,7 @@ function ItemManualForm() {
         type="button"
         onClick={handleBack}
         aria-label="뒤로가기"
-        className="absolute top-[60px] left-5 cursor-pointer p-0"
+        className="absolute top-9 left-5 cursor-pointer p-0"
       >
         <ChevronBackwardIconFill className="size-[30px] text-icon-neutral-primary" />
       </button>

--- a/apps/web/src/app/item/manual/_components/ItemManualForm.tsx
+++ b/apps/web/src/app/item/manual/_components/ItemManualForm.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import { useRef, useState } from 'react';
 
 import { ImageIconOutline } from '@/assets/icons';
+import BottomCta from '@/components/common/bottom-cta';
 import Button from '@/components/common/button';
 import { Header, HeaderIcon } from '@/components/common/header';
 import Input from '@/components/common/input';
@@ -118,7 +119,7 @@ function ItemManualForm() {
       </div>
 
       {/* 하단 고정 버튼 */}
-      <div className="fixed right-0 bottom-0 left-0 mx-auto flex w-full max-w-120 items-center gap-2.5 px-5 pt-3 pb-5">
+      <BottomCta>
         <Button
           variant="secondary"
           size="lg"
@@ -137,7 +138,7 @@ function ItemManualForm() {
         >
           저장하기
         </Button>
-      </div>
+      </BottomCta>
     </main>
   );
 }

--- a/apps/web/src/app/item/manual/_components/ItemManualForm.tsx
+++ b/apps/web/src/app/item/manual/_components/ItemManualForm.tsx
@@ -118,7 +118,7 @@ function ItemManualForm() {
       </div>
 
       {/* 하단 고정 버튼 */}
-      <div className="fixed right-0 bottom-0 left-0 mx-auto flex w-full max-w-120 items-center gap-2.5 bg-bg-layer-basement px-5 pt-3 pb-5">
+      <div className="fixed right-0 bottom-0 left-0 mx-auto flex w-full max-w-120 items-center gap-2.5 px-5 pt-3 pb-5">
         <Button
           variant="secondary"
           size="lg"

--- a/apps/web/src/app/item/manual/_components/ItemManualForm.tsx
+++ b/apps/web/src/app/item/manual/_components/ItemManualForm.tsx
@@ -118,7 +118,7 @@ function ItemManualForm() {
       </div>
 
       {/* 하단 고정 버튼 */}
-      <div className="fixed right-0 bottom-0 left-0 mx-auto flex w-full max-w-120 items-center gap-2.5 bg-bg-layer-default px-5 pt-3 pb-5">
+      <div className="fixed right-0 bottom-0 left-0 mx-auto flex w-full max-w-120 items-center gap-2.5 bg-bg-layer-basement px-5 pt-3 pb-5">
         <Button
           variant="secondary"
           size="lg"

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -56,7 +56,7 @@ function RootLayout({
       <body className="h-full overflow-hidden">
         <Providers>
           {/** TEMP: max width 임시 값 */}
-          <div className="mx-auto h-full max-w-120 overflow-y-auto bg-bg-layer-basement px-5 [scrollbar-gutter:stable] [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">{children}</div>
+          <div className="mx-auto h-full max-w-120 overflow-y-auto bg-bg-layer-basement px-5 [scrollbar-gutter:stable] hide-scrollbar">{children}</div>
         </Providers>
       </body>
     </html>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -37,7 +37,7 @@ function RootLayout({
 }>) {
   return (
     /** TEMP: 임시 배경색 추가 */
-    <html lang="ko" className={cn(pretendard.className, 'h-full bg-gray-100 antialiased')}>
+    <html lang="ko" className={cn(pretendard.className, 'h-full overflow-hidden bg-gray-100 antialiased')}>
       <head>
         {process.env.NODE_ENV === 'development' && (
           <>
@@ -53,10 +53,10 @@ function RootLayout({
           </>
         )}
       </head>
-      <body className="h-full">
+      <body className="h-full overflow-hidden">
         <Providers>
           {/** TEMP: max width 임시 값 */}
-          <div className="mx-auto h-full max-w-120 bg-bg-layer-basement px-5">{children}</div>
+          <div className="mx-auto h-full max-w-120 overflow-y-auto bg-bg-layer-basement px-5 [scrollbar-gutter:stable] [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">{children}</div>
         </Providers>
       </body>
     </html>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -56,7 +56,7 @@ function RootLayout({
       <body className="h-full">
         <Providers>
           {/** TEMP: max width 임시 값 */}
-          <div className="mx-auto h-full max-w-120 bg-white">{children}</div>
+          <div className="mx-auto h-full max-w-120 bg-bg-layer-basement px-5">{children}</div>
         </Providers>
       </body>
     </html>

--- a/apps/web/src/app/tournament/create/_components/wishBasketStatus/WishBasketStatus.tsx
+++ b/apps/web/src/app/tournament/create/_components/wishBasketStatus/WishBasketStatus.tsx
@@ -1,7 +1,7 @@
 function WishBasketStatus() {
   return (
     <div className="flex items-center justify-center">
-      <span className="inline-flex h-[40px] items-center rounded-[24px] border border-gray-100 bg-[#EAEAEC] px-3 body-2-regular text-gray-600">
+      <span className="inline-flex h-[40px] items-center rounded-[24px] border border-gray-100 bg-gray-75 px-3 body-2-regular text-gray-600">
         최소 2개 이상 담아주세요
       </span>
     </div>

--- a/apps/web/src/app/tournament/create/by-wish/_components/WishSelectHeader.tsx
+++ b/apps/web/src/app/tournament/create/by-wish/_components/WishSelectHeader.tsx
@@ -18,16 +18,16 @@ function WishSelectHeader({
     if (isMaxExceeded)
       return (
         <p>
-          <span className="heading-2 text-[#686F7E]">최대 {MAX_SELECT}개</span>
-          <span className="heading-2-medium text-[#ADB1BB]">까지 선택할 수 있어요</span>
+          <span className="heading-2 text-gray-600">최대 {MAX_SELECT}개</span>
+          <span className="heading-2-medium text-gray-300">까지 선택할 수 있어요</span>
         </p>
       );
     // 이미 토너먼트 후보가 담겨있을 때
     if (tournamentCandidateCount && tournamentCandidateCount > 0)
       return (
         <p className="whitespace-pre-line">
-          <span className="heading-2 text-[#686F7E]">{tournamentCandidateCount}개가</span>
-          <span className="heading-2-medium text-[#686F7E]">
+          <span className="heading-2 text-gray-600">{tournamentCandidateCount}개가</span>
+          <span className="heading-2-medium text-gray-600">
             {' 이미 담겨있어요\n더 추가하고 싶은 상품을 골라보세요.'}
           </span>
         </p>
@@ -35,8 +35,8 @@ function WishSelectHeader({
     // 기본 상태
     return (
       <p className="whitespace-pre-line">
-        <span className="heading-2 text-[#686F7E]">최소 {MIN_SELECT}개 이상</span>
-        <span className="heading-2-medium text-[#ADB1BB]">
+        <span className="heading-2 text-gray-600">최소 {MIN_SELECT}개 이상</span>
+        <span className="heading-2-medium text-gray-300">
           {' 선택해야\n토너먼트를 시작할 수 있어요.'}
         </span>
       </p>
@@ -46,12 +46,12 @@ function WishSelectHeader({
   return (
     <div className="mt-20 flex flex-col gap-[25px]">
       <div className="flex flex-col gap-2">
-        <h1 className="title-1 text-[#171719]">비교할 위시템을 선택해주세요</h1>
+        <h1 className="title-1 text-gray-950">비교할 위시템을 선택해주세요</h1>
         <div className="min-h-[52px]">{renderSubtitle()}</div>
       </div>
       <p className="body-1-medium">
-        <span className="text-[#1A1A1A]">{selectedCount}</span>
-        <span className="text-[#737373]">/{totalCount}개 선택 중</span>
+        <span className="text-gray-950">{selectedCount}</span>
+        <span className="text-gray-600">/{totalCount}개 선택 중</span>
       </p>
     </div>
   );

--- a/apps/web/src/app/tournament/create/by-wish/page.tsx
+++ b/apps/web/src/app/tournament/create/by-wish/page.tsx
@@ -59,7 +59,7 @@ function ByWishPage() {
       </main>
 
       {/* 하단 버튼: 뒤로 / 다음 */}
-      <div className="fixed bottom-0 left-1/2 z-10 flex w-full max-w-120 -translate-x-1/2 gap-[10px] bg-[#FFF] px-5 py-3 pt-4">
+      <div className="bg-layer-basement fixed bottom-0 left-1/2 z-10 flex w-full max-w-120 -translate-x-1/2 gap-[10px] px-5 py-3">
         <Button variant="secondary" size="lg" onClick={() => router.back()}>
           뒤로
         </Button>

--- a/apps/web/src/app/tournament/create/by-wish/page.tsx
+++ b/apps/web/src/app/tournament/create/by-wish/page.tsx
@@ -34,7 +34,7 @@ function ByWishPage() {
   };
 
   return (
-    <div className="flex min-h-dvh flex-col bg-[#F4F4F6]">
+    <div className="flex h-full flex-col">
       {/* 헤더: 선택 안내 문구 + 선택 개수 */}
       <WishSelectHeader
         selectedCount={selectedIds.length}
@@ -43,7 +43,7 @@ function ByWishPage() {
       />
 
       {/* 위시 아이템 그리드 */}
-      <main className="mt-4 flex flex-1 flex-col pb-32">
+      <main className="mt-4 flex flex-1 flex-col overflow-y-auto pb-32 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         <div className="grid grid-cols-2 gap-x-2 gap-y-3">
           {items.map(item => (
             <WishSelectCard
@@ -59,7 +59,7 @@ function ByWishPage() {
       </main>
 
       {/* 하단 버튼: 뒤로 / 다음 */}
-      <div className="bg-layer-basement fixed bottom-0 left-1/2 z-10 flex w-full max-w-120 -translate-x-1/2 gap-[10px] px-5 py-3">
+      <div className="fixed bottom-0 left-1/2 z-10 flex w-full max-w-120 -translate-x-1/2 gap-[10px] px-5 py-3">
         <Button variant="secondary" size="lg" onClick={() => router.back()}>
           뒤로
         </Button>

--- a/apps/web/src/app/tournament/create/by-wish/page.tsx
+++ b/apps/web/src/app/tournament/create/by-wish/page.tsx
@@ -34,7 +34,7 @@ function ByWishPage() {
   };
 
   return (
-    <div className="flex min-h-dvh flex-col bg-[#F4F4F6] px-5">
+    <div className="flex min-h-dvh flex-col bg-[#F4F4F6]">
       {/* 헤더: 선택 안내 문구 + 선택 개수 */}
       <WishSelectHeader
         selectedCount={selectedIds.length}

--- a/apps/web/src/app/tournament/create/by-wish/page.tsx
+++ b/apps/web/src/app/tournament/create/by-wish/page.tsx
@@ -43,7 +43,7 @@ function ByWishPage() {
       />
 
       {/* 위시 아이템 그리드 */}
-      <main className="mt-4 flex flex-1 flex-col overflow-y-auto pb-32 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <main className="mt-4 flex flex-1 flex-col overflow-y-auto pb-32 hide-scrollbar">
         <div className="grid grid-cols-2 gap-x-2 gap-y-3">
           {items.map(item => (
             <WishSelectCard

--- a/apps/web/src/app/tournament/create/page.tsx
+++ b/apps/web/src/app/tournament/create/page.tsx
@@ -13,7 +13,7 @@ function TournamentCreatePage() {
         <WishBasketStatus />
         <WishBasketCarousel />
       </div>
-      <div className="pb-8">
+      <div className="pb-5">
         <TournamentStartButton count={0} />
       </div>
     </div>

--- a/apps/web/src/app/tournament/create/page.tsx
+++ b/apps/web/src/app/tournament/create/page.tsx
@@ -6,7 +6,7 @@ import WishBasketStatus from './_components/wishBasketStatus/WishBasketStatus';
 
 function TournamentCreatePage() {
   return (
-    <div className="flex min-h-screen flex-col bg-gray-50 px-5">
+    <div className="flex min-h-screen flex-col bg-gray-50">
       <div className="flex flex-1 flex-col gap-4 pt-[80px]">
         <TournamentHeader />
         <InviteFriends />

--- a/apps/web/src/app/tournament/loading/page.tsx
+++ b/apps/web/src/app/tournament/loading/page.tsx
@@ -21,7 +21,7 @@ function TournamentLoadingPage() {
   }, [router]);
 
   return (
-    <main className="flex min-h-dvh flex-col bg-bg-layer-basement px-5 pt-[calc(env(safe-area-inset-top)+24px)] pb-[calc(env(safe-area-inset-bottom)+24px)]">
+    <main className="flex min-h-dvh flex-col pt-[calc(env(safe-area-inset-top)+24px)] pb-[calc(env(safe-area-inset-bottom)+24px)]">
       <header className="flex flex-col gap-2 tracking-[-0.6px]">
         <h1 className="text-[28px] leading-10 font-bold text-text-neutral-primary">
           대진표를 만드는 중이에요

--- a/apps/web/src/app/tournament/result/page.tsx
+++ b/apps/web/src/app/tournament/result/page.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation';
 import { useEffect, useState, useSyncExternalStore } from 'react';
 
+import BottomCta from '@/components/common/bottom-cta';
 import ActionSnackbar from '@/components/common/toast/ActionSnackbar';
 import { readResult } from '@/utils/resultStorage';
 
@@ -102,7 +103,7 @@ function TournamentResultPage() {
       </div>
 
       {/* 하단 버튼 */}
-      <div className="fixed right-0 bottom-0 left-0 z-30 mx-auto flex w-full max-w-120 items-center gap-2.5 px-5 pt-3 pb-5">
+      <BottomCta>
         <button
           type="button"
           onClick={handleGoHome}
@@ -117,7 +118,7 @@ function TournamentResultPage() {
         >
           결과 저장하기
         </button>
-      </div>
+      </BottomCta>
     </main>
   );
 }

--- a/apps/web/src/app/tournament/result/page.tsx
+++ b/apps/web/src/app/tournament/result/page.tsx
@@ -102,7 +102,7 @@ function TournamentResultPage() {
       </div>
 
       {/* 하단 버튼 */}
-      <div className="fixed right-0 bottom-0 left-0 z-30 mx-auto flex w-full max-w-120 items-center gap-2.5 bg-bg-layer-basement px-5 pt-3 pb-5">
+      <div className="fixed right-0 bottom-0 left-0 z-30 mx-auto flex w-full max-w-120 items-center gap-2.5 px-5 pt-3 pb-5">
         <button
           type="button"
           onClick={handleGoHome}

--- a/apps/web/src/app/wishlist/_components/TournamentHistoryContent.tsx
+++ b/apps/web/src/app/wishlist/_components/TournamentHistoryContent.tsx
@@ -12,7 +12,7 @@ function TournamentHistoryContent() {
 
   return (
     <>
-      <main className="flex flex-1 items-center justify-center">
+      <main className="flex flex-1 items-center justify-center pb-24">
         <p className="body-1-medium text-gray-300">토너먼트 기록이 없어요</p>
       </main>
       <div className="fixed bottom-10 left-1/2 z-20 flex -translate-x-1/2 items-center gap-3">

--- a/apps/web/src/app/wishlist/_components/WishTab.tsx
+++ b/apps/web/src/app/wishlist/_components/WishTab.tsx
@@ -31,7 +31,7 @@ function WishTab() {
 
   return (
     <div className="w-full">
-      <div className="flex h-[48px] items-center rounded-[12px] bg-[#E7E8EA] p-1">
+      <div className="flex h-[48px] items-center rounded-[12px] bg-gray-75 p-1">
         {TABS.map(tab => (
           <button
             key={tab}
@@ -40,7 +40,7 @@ function WishTab() {
             className={cn(
               'flex h-10 flex-1 cursor-pointer items-center justify-center gap-2 body-1-semibold transition-colors',
               activeTab === tab
-                ? 'rounded-lg bg-white text-gray-900 shadow-[0_0_8px_0_rgba(0,0,0,0.08)]'
+                ? 'rounded-lg bg-white text-gray-950 shadow-[0_0_8px_0_rgba(0,0,0,0.08)]'
                 : 'text-black/30'
             )}
           >

--- a/apps/web/src/app/wishlist/_components/WishTab.tsx
+++ b/apps/web/src/app/wishlist/_components/WishTab.tsx
@@ -30,8 +30,8 @@ function WishTab() {
   };
 
   return (
-    <div className="w-full px-5">
-      <div className="flex h-12 items-center rounded-xl bg-[#E7E8EA] p-1">
+    <div className="w-full">
+      <div className="flex h-[48px] items-center rounded-[12px] bg-[#E7E8EA] p-1">
         {TABS.map(tab => (
           <button
             key={tab}

--- a/apps/web/src/app/wishlist/_components/WishlistContent.tsx
+++ b/apps/web/src/app/wishlist/_components/WishlistContent.tsx
@@ -15,12 +15,17 @@ function WishlistContent() {
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
 
   const { data: wishlistData } = useGetWishlist();
-  const { isDeleteMode, selectedIds, handleEnterDeleteMode, handleToggleSelect, handleConfirmDelete } =
-    useWishlistDelete();
+  const {
+    isDeleteMode,
+    selectedIds,
+    handleEnterDeleteMode,
+    handleToggleSelect,
+    handleConfirmDelete,
+  } = useWishlistDelete();
 
   return (
     <>
-      <main className="flex flex-1 flex-col px-5 pb-24">
+      <main className="flex flex-1 flex-col pb-24">
         <WishlistTabContent
           items={wishlistData}
           isDeleteMode={isDeleteMode}

--- a/apps/web/src/app/wishlist/_components/WishlistTabContent.tsx
+++ b/apps/web/src/app/wishlist/_components/WishlistTabContent.tsx
@@ -16,9 +16,9 @@ function WishlistTabContent({
 }: WishlistTabContentProps) {
   if (items.length === 0) {
     return (
-      <div className="flex flex-1 flex-col items-center justify-center gap-2 text-gray-300">
-        <p className="body-1-medium">아직 저장한 위시템이 없어요</p>
-      </div>
+      <main className="flex flex-1 items-center justify-center">
+        <p className="body-1-medium text-gray-300">아직 저장한 위시템이 없어요</p>
+      </main>
     );
   }
 

--- a/apps/web/src/app/wishlist/page.tsx
+++ b/apps/web/src/app/wishlist/page.tsx
@@ -1,6 +1,5 @@
-import { Suspense } from 'react';
-
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
+import { Suspense } from 'react';
 
 import { getQueryClient } from '@/utils/queryClient';
 

--- a/apps/web/src/components/common/bottom-cta/index.tsx
+++ b/apps/web/src/components/common/bottom-cta/index.tsx
@@ -1,0 +1,13 @@
+type BottomCtaProps = {
+  children: React.ReactNode;
+};
+
+function BottomCta({ children }: BottomCtaProps) {
+  return (
+    <div className="fixed right-0 bottom-0 left-0 z-30 mx-auto flex w-full max-w-120 items-center gap-2.5 px-5 pt-3 pb-5">
+      {children}
+    </div>
+  );
+}
+
+export default BottomCta;

--- a/apps/web/src/components/common/bottom-tab-bar/index.tsx
+++ b/apps/web/src/components/common/bottom-tab-bar/index.tsx
@@ -24,7 +24,7 @@ function BottomTabBar() {
             type="button"
             onClick={() => router.push(href)}
             className={`flex w-[100px] flex-col items-center justify-center gap-0.5 rounded-[100px] py-[9px] transition-colors ${
-              isActive ? 'bg-[#F4F4F6] text-[#686F7E]' : 'text-[#ADB1BB]'
+              isActive ? 'bg-gray-50 text-gray-600' : 'text-gray-300'
             }`}
           >
             <Icon width={24} height={24} />

--- a/apps/web/src/components/common/drawer/index.tsx
+++ b/apps/web/src/components/common/drawer/index.tsx
@@ -56,7 +56,7 @@ function DrawerContent({
         style={{ zIndex: Z_INDEX.DRAWER, ...props.style }}
         {...props}
       >
-        <div className="mx-auto mt-3 hidden h-1 w-9 shrink-0 rounded-full bg-[#d9d9d9] group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        <div className="mx-auto mt-3 hidden h-1 w-9 shrink-0 rounded-full bg-gray-200 group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
         <div className="p-5">{children}</div>
       </DrawerPrimitive.Content>
     </DrawerPortal>

--- a/apps/web/src/components/common/header/index.tsx
+++ b/apps/web/src/components/common/header/index.tsx
@@ -46,7 +46,7 @@ function Header({
   return (
     <header
       className={cn(
-        'relative flex h-7.5 w-full shrink-0 items-center justify-between px-5',
+        'relative flex h-7.5 w-full shrink-0 items-center justify-between',
         className
       )}
     >
@@ -66,7 +66,7 @@ function Header({
   );
 }
 
-const ICON_BASE_STYLE = 'p-[3px] cursor-pointer';
+const ICON_BASE_STYLE = 'cursor-pointer';
 
 function HeaderIcon({
   name,

--- a/apps/web/src/components/common/header/index.tsx
+++ b/apps/web/src/components/common/header/index.tsx
@@ -45,10 +45,7 @@ function Header({
 }: Props) {
   return (
     <header
-      className={cn(
-        'relative flex h-7.5 w-full shrink-0 items-center justify-between',
-        className
-      )}
+      className={cn('relative flex h-7.5 w-full shrink-0 items-center justify-between', className)}
     >
       <div className={cn('inline-flex h-full items-center', leftClassName)}>{left}</div>
       <div
@@ -66,7 +63,7 @@ function Header({
   );
 }
 
-const ICON_BASE_STYLE = 'cursor-pointer';
+const ICON_BASE_STYLE = 'p-[3px] cursor-pointer';
 
 function HeaderIcon({
   name,

--- a/apps/web/src/components/common/input/index.tsx
+++ b/apps/web/src/components/common/input/index.tsx
@@ -56,15 +56,14 @@ function Input({
         {right && <span className="shrink-0 text-gray-300">{right}</span>}
       </div>
 
-      <p
-        id={helperTextId}
-        className={cn(
-          'min-h-lh body-2-regular',
-          status === 'error' ? 'text-red-600' : 'text-gray-300'
-        )}
-      >
-        {helperText}
-      </p>
+      {helperText && (
+        <p
+          id={helperTextId}
+          className={cn('body-2-regular', status === 'error' ? 'text-red-600' : 'text-gray-300')}
+        >
+          {helperText}
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/common/toast/ActionSnackbar.tsx
+++ b/apps/web/src/components/common/toast/ActionSnackbar.tsx
@@ -14,7 +14,7 @@ function ActionSnackbar({ message, actionLabel, isVisible, onAction }: ActionSna
       }`}
     >
       <span aria-hidden className="absolute inset-0 bg-gray-900 opacity-[0.52]" />
-      <span aria-hidden className="absolute inset-0 bg-[#0066FF] opacity-[0.05]" />
+      <span aria-hidden className="absolute inset-0 bg-blue-600 opacity-[0.05]" />
       <p className="relative flex-1 px-0.5 py-[5px] text-[15px] leading-snug font-semibold text-white opacity-[0.88]">
         {message}
       </p>

--- a/apps/web/src/components/common/toast/SuccessToast.tsx
+++ b/apps/web/src/components/common/toast/SuccessToast.tsx
@@ -14,7 +14,7 @@ function SuccessToast({ message, isVisible }: SuccessToastProps) {
       }`}
     >
       <span aria-hidden className="absolute inset-0 bg-gray-900 opacity-[0.52]" />
-      <span aria-hidden className="absolute inset-0 bg-[#0066FF] opacity-[0.05]" />
+      <span aria-hidden className="absolute inset-0 bg-blue-500 opacity-[0.05]" />
       <CheckCircledIconFill className="relative size-6 shrink-0 text-icon-success" />
       <span className="relative flex-1 body-2-semibold text-white opacity-[0.88]">{message}</span>
     </div>

--- a/apps/web/src/components/common/toast/Toast.tsx
+++ b/apps/web/src/components/common/toast/Toast.tsx
@@ -1,0 +1,29 @@
+type ToastVariantT = 'error';
+
+type ToastProps = {
+  message: string;
+  icon?: React.ReactNode;
+  isVisible: boolean;
+  variant?: ToastVariantT;
+};
+
+// variant별 배경색 — 추후 'info' | 'success' 등 추가 시 여기에 색 추가
+const variantBg: Record<ToastVariantT, string> = {
+  error: 'bg-red-50',
+};
+
+function Toast({ message, icon, isVisible, variant = 'error' }: ToastProps) {
+  return (
+    <div
+      role="alert"
+      className={`flex h-[67px] w-full items-center gap-5 rounded-[12px] px-5 transition-opacity duration-500 ${isVisible ? 'opacity-100' : 'pointer-events-none opacity-0'} ${variantBg[variant]}`}
+    >
+      {icon && (
+        <div className="flex size-[26.787px] shrink-0 items-center justify-center">{icon}</div>
+      )}
+      <span className="caption-1-semibold whitespace-pre-line text-gray-950">{message}</span>
+    </div>
+  );
+}
+
+export default Toast;

--- a/apps/web/src/components/common/wish-card/index.tsx
+++ b/apps/web/src/components/common/wish-card/index.tsx
@@ -24,10 +24,10 @@ function WishCard({ name, price, imageUrl }: WishCardProps) {
 
       {/* 상품명 + 가격 */}
       <div className="flex flex-1 flex-col items-center justify-center gap-[9.351px] self-stretch px-3 py-3">
-        <p className="self-stretch text-center text-[16.364px] leading-[23.377px] font-medium tracking-[-0.701px] text-[#686F7E]">
+        <p className="self-stretch text-center text-[16.364px] leading-[23.377px] font-medium tracking-[-0.701px] text-gray-600">
           {name}
         </p>
-        <p className="text-[18.701px] leading-[25.714px] font-bold tracking-[-0.701px] text-[#2D3037]">
+        <p className="text-[18.701px] leading-[25.714px] font-bold tracking-[-0.701px] text-gray-950">
           {price.toLocaleString()}원
         </p>
       </div>

--- a/apps/web/src/components/common/wish-grid/index.tsx
+++ b/apps/web/src/components/common/wish-grid/index.tsx
@@ -46,7 +46,7 @@ function WishGrid({ items, isDeleteMode = false, selectedIds, onToggleSelect }: 
                 {isSelected ? (
                   <CheckboxSelectedIconFill className="size-6 text-icon-accent" />
                 ) : (
-                  <CheckboxEmptyIconFill className="size-6 text-[#8E8E93]" />
+                  <CheckboxEmptyIconFill className="size-6 text-gray-500" />
                 )}
               </span>
             </button>

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -10,6 +10,7 @@
   --color-base-950: #000000;
 
   --color-gray-50: #f4f4f6;
+  --color-gray-75: #e9e9ed;
   --color-gray-100: #dcdee2;
   --color-gray-200: #c5c8ce;
   --color-gray-300: #adb1bb;


### PR DESCRIPTION
## 작업 요약

- 레이아웃 스타일(px-5, 배경색, 헤더 여백 등) 공통화 및 페이지별 UI 불일치 수정, 중복 코드 제거

## 작업 세부 내용
### 레이아웃 공통화
- 각 페이지마다 개별 선언하던 `px-5`, `bg-bg-layer-basement`를 루트 `layout.tsx` 공통 컨테이너로 통합
- 홈, 위시리스트, 아이템 편집/수동입력 등 각 페이지의 중복 스타일 제거

### 페이지 전환 시 레이아웃 흔들림 수정
- `html`, `body`에 `overflow-hidden` 적용 → 문서 자체는 스크롤되지 않도록 고정
- 스크롤은 내부 컨테이너(`overflow-y-auto`)에서만 발생하도록 변경
- `scrollbar-gutter: stable`을 실제 스크롤 컨테이너에 적용하여 스크롤바 유무에 따른 레이아웃 shift 방지
- 스크롤바 시각적으로 숨김 처리

### 페이지 내부 스크롤 개선
- 위시템 선택(`by-wish`) 페이지: 헤더·하단 버튼은 고정, 아이템 그리드 영역만 내부 스크롤되도록 변경
-  전체 페이지 스크롤 제거

### 하단 버튼 배경색 제거
- `tournament/result`, `item/manual`, `item/edit` 하단 고정 버튼 영역의 배경색 제거
- 뒤 콘텐츠가 자연스럽게 비쳐 보이도록 처리

### 페이지별 세부 수정
- 헤더 상단 여백 `pt-9`(36px)으로 통일 (홈, 위시리스트, 아이템 편집)
- `item/manual` 뒤로가기 버튼 → 공통 `Header` 컴포넌트로 교체
- 위시리스트 sticky 헤더에 `bg-bg-layer-basement` 추가 (스크롤 시 콘텐츠 비침 현상 수정)
- `CreateTournamentDialog` 중복 width 제거
- `ItemLinkBanner` 배경색 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 페이지 레이아웃의 패딩 및 여백 조정으로 UI 간격 최적화
  * 색상 팔레트를 시맨틱 유틸리티 클래스로 표준화하여 시각 일관성 개선
  * 다이얼로그 및 입력 필드 컴포넌트 스타일 개선

* **New Features**
  * 하단 고정 액션 영역을 위한 재사용 가능한 컴포넌트 추가

* **Chores**
  * 전역 스크롤 동작 관리 방식 개선
  * Import 순서 정렬로 코드 조직화 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Client/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->