### PR TITLE
feat: 토너먼트 아이템 상태별 클릭 분기 처리

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/TournamentCreateClient.tsx
@@ -20,7 +20,9 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
         <TournamentHeader name={tournamentData.name} />
         <InviteFriends />
         <TournamentItemBasketStatus
-          isProcessing={tournamentData.pending?.items.some(item => item.status === 'PROCESSING') ?? false}
+          isProcessing={
+            tournamentData.pending?.items.some(item => item.status === 'PROCESSING') ?? false
+          }
           count={tournamentData.pending?.items.length ?? 0}
         />
         <TournamentItemBasketCarousel items={tournamentData.pending?.items} />
@@ -29,6 +31,11 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
         <TournamentStartButton
           count={tournamentData.pending?.items.length ?? 0}
           tournamentId={tournamentId}
+          hasUnreadyItem={
+            tournamentData.pending?.items.some(
+              item => item.status === 'PROCESSING' || item.status === 'FAILED'
+            ) ?? false
+          }
         />
       </div>
     </div>

--- a/apps/web/src/app/tournament/[id]/create/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/TournamentCreateClient.tsx
@@ -19,7 +19,10 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
       <div className="flex flex-1 flex-col gap-4 pt-[80px]">
         <TournamentHeader name={tournamentData.name} />
         <InviteFriends />
-        <TournamentItemBasketStatus />
+        <TournamentItemBasketStatus
+          isProcessing={tournamentData.pending?.items.some(item => item.status === 'PROCESSING') ?? false}
+          count={tournamentData.pending?.items.length ?? 0}
+        />
         <TournamentItemBasketCarousel items={tournamentData.pending?.items} />
       </div>
       <div className="pb-8">

--- a/apps/web/src/app/tournament/[id]/create/_components/tournamentItemBasket/TournamentBasketItem.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournamentItemBasket/TournamentBasketItem.tsx
@@ -14,6 +14,7 @@ function TournamentBasketItem({ item, index }: TournamentBasketItemProps) {
         size="sm"
         fill
         alt={`토너먼트 아이템 ${index + 1}`}
+        parsingStatus={item.status}
       />
     </div>
   );

--- a/apps/web/src/app/tournament/[id]/create/_components/tournamentItemBasket/TournamentBasketItem.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournamentItemBasket/TournamentBasketItem.tsx
@@ -4,11 +4,15 @@ import type { TournamentItemT } from '@/types/tournament';
 type TournamentBasketItemProps = {
   item: TournamentItemT;
   index: number;
+  onClick?: () => void;
 };
 
-function TournamentBasketItem({ item, index }: TournamentBasketItemProps) {
+function TournamentBasketItem({ item, index, onClick }: TournamentBasketItemProps) {
   return (
-    <div className="relative aspect-square">
+    <div
+      className={`relative aspect-square${item.status === 'READY' || item.status === 'FAILED' ? ' cursor-pointer' : ''}`}
+      onClick={onClick}
+    >
       <ProductImage
         {...(item.imageUrl ? { src: item.imageUrl } : {})}
         size="sm"

--- a/apps/web/src/app/tournament/[id]/create/_components/tournamentItemBasket/TournamentItemBasket.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournamentItemBasket/TournamentItemBasket.tsx
@@ -1,4 +1,6 @@
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 
 import AddIcon from '@/assets/icons/fill/add.svg';
 import basketImg from '@/assets/images/basket-gray.png';
@@ -8,6 +10,7 @@ import type { TournamentItemT } from '@/types/tournament';
 import { ITEMS_PER_BASKET } from '../../_consts/tournamentItemBasketConsts';
 import AddWishDialog from '../addWishDialog/AddWishDialog';
 import EmptyBasketSlot from './EmptyBasketSlot';
+import TournamentItemFailedModal from './TournamentItemFailedDrawer';
 import TournamentBasketItem from './TournamentBasketItem';
 
 type TournamentItemBasketProps = {
@@ -16,6 +19,14 @@ type TournamentItemBasketProps = {
 };
 
 function TournamentItemBasket({ basketIndex, items }: TournamentItemBasketProps) {
+  const router = useRouter();
+  const [failedDrawerOpen, setFailedDrawerOpen] = useState(false);
+
+  const handleItemClick = (item: TournamentItemBasketProps['items'][number]) => {
+    if (item.status === 'READY') router.push(`/item/${item.tournamentItemId}/edit?type=tournament`);
+    if (item.status === 'FAILED') setFailedDrawerOpen(true);
+  };
+
   return (
     <div className="relative mx-auto aspect-356/464 w-full">
       <Image
@@ -31,7 +42,12 @@ function TournamentItemBasket({ basketIndex, items }: TournamentItemBasketProps)
             const item = items[slotIndex];
             if (item)
               return (
-                <TournamentBasketItem key={item.tournamentItemId} item={item} index={slotIndex} />
+                <TournamentBasketItem
+                  key={item.tournamentItemId}
+                  item={item}
+                  index={slotIndex}
+                  onClick={() => handleItemClick(item)}
+                />
               );
             return <EmptyBasketSlot key={`empty-${slotIndex}`} slotIndex={slotIndex} />;
           })}
@@ -48,6 +64,10 @@ function TournamentItemBasket({ basketIndex, items }: TournamentItemBasketProps)
           />
         </div>
       </div>
+      <TournamentItemFailedModal
+        open={failedDrawerOpen}
+        onClose={() => setFailedDrawerOpen(false)}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/tournament/[id]/create/_components/tournamentItemBasket/TournamentItemFailedDrawer.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournamentItemBasket/TournamentItemFailedDrawer.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import WarningIconFill from '@/assets/icons/outline/warning.svg';
+import Button from '@/components/common/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/common/dialog';
+
+type TournamentItemFailedModalProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+function TournamentItemFailedModal({ open, onClose }: TournamentItemFailedModalProps) {
+  const router = useRouter();
+
+  const handleManualInput = () => {
+    onClose();
+    router.push('/item/manual');
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={isOpen => !isOpen && onClose()}>
+      <DialogContent showCloseButton={false} className="text-center">
+        <div className="flex justify-center">
+          <div style={{ width: 48, height: 48 }}>
+            <WarningIconFill width="100%" height="100%" className="text-red-300" aria-hidden />
+          </div>
+        </div>
+        <DialogHeader className="mt-4 gap-1">
+          <DialogTitle className="heading-1">상품 정보를 가져오지 못했어요</DialogTitle>
+          <p className="body-1-medium text-text-neutral-tertiary">서버에서 문제가 발생했어요</p>
+        </DialogHeader>
+        <DialogFooter className="mt-6 flex-row gap-3">
+          <Button variant="secondary" size="lg" className="flex-1" onClick={onClose}>
+            삭제하기
+          </Button>
+          <Button variant="primary" size="lg" className="flex-1" onClick={handleManualInput}>
+            직접 입력하기
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default TournamentItemFailedModal;

--- a/apps/web/src/app/tournament/[id]/create/_components/tournamentItemBasketStatus/TournamentItemBasketStatus.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournamentItemBasketStatus/TournamentItemBasketStatus.tsx
@@ -1,8 +1,20 @@
-function TournamentItemBasketStatus() {
+
+type TournamentItemBasketStatusProps = {
+  isProcessing: boolean;
+  count: number;
+};
+
+function TournamentItemBasketStatus({ isProcessing, count }: TournamentItemBasketStatusProps) {
+  const label = (() => {
+    if (isProcessing) return '담는 중...';
+    if (count < 2) return '최소 2개 이상 담아주세요';
+    return `${count}/32`;
+  })();
+
   return (
     <div className="flex items-center justify-center">
       <span className="inline-flex h-[40px] items-center rounded-[24px] border border-gray-100 bg-gray-75 px-3 body-2-regular text-gray-600">
-        최소 2개 이상 담아주세요
+        {label}
       </span>
     </div>
   );

--- a/apps/web/src/app/tournament/[id]/create/_components/tournamentStartButton/TournamentStartButton.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournamentStartButton/TournamentStartButton.tsx
@@ -8,17 +8,19 @@ import { usePostTournamentStart } from '../../_hooks/usePostTournamentStart';
 type TournamentStartButtonProps = {
   count: number;
   tournamentId: string;
+  hasUnreadyItem: boolean;
 };
 
-function TournamentStartButton({ count, tournamentId }: TournamentStartButtonProps) {
-  const { postTournamentStartMutation, isPostTournamentStartPending } =
-    usePostTournamentStart(Number(tournamentId));
+function TournamentStartButton({ count, tournamentId, hasUnreadyItem }: TournamentStartButtonProps) {
+  const { postTournamentStartMutation, isPostTournamentStartPending } = usePostTournamentStart(
+    Number(tournamentId)
+  );
 
   return (
     <Button
       variant="primary"
       size="lg"
-      disabled={count < 2 || isPostTournamentStartPending}
+      disabled={count < 2 || isPostTournamentStartPending || hasUnreadyItem}
       onClick={() => postTournamentStartMutation()}
     >
       {isPostTournamentStartPending ? <Spinner size={20} /> : '토너먼트 시작하기'}

--- a/apps/web/src/app/tournament/[id]/create/_hooks/usePostTournamentItemLink.ts
+++ b/apps/web/src/app/tournament/[id]/create/_hooks/usePostTournamentItemLink.ts
@@ -1,11 +1,23 @@
-import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { postTournamentItemLink } from '../_apis/postTournamentItemLink';
+import { useGetTournamentItem } from './useGetTournamentItem';
 
 export const usePostTournamentItemLink = (tournamentId: number) => {
+  const queryClient = useQueryClient();
+  const [tournamentItemId, setTournamentItemId] = useState<number | null>(null);
+
+  useGetTournamentItem(tournamentId, tournamentItemId);
+
   const { mutate: postTournamentItemLinkMutation, isPending: isPostTournamentItemLinkPending } =
     useMutation({
       mutationFn: (url: string) => postTournamentItemLink(tournamentId, url),
+      onSuccess: ({ tournamentItemId: newItemId }) => {
+        queryClient.invalidateQueries({ queryKey: ['tournament', tournamentId] });
+        setTournamentItemId(newItemId);
+      },
     });
 
   return { postTournamentItemLinkMutation, isPostTournamentItemLinkPending };

--- a/apps/web/src/components/common/product-image/index.tsx
+++ b/apps/web/src/components/common/product-image/index.tsx
@@ -19,7 +19,6 @@ type ProductImageProps = Omit<ImageProps, 'width' | 'height' | 'src'> & {
   size?: SizeVariantT;
   /** true면 부모 크기에 맞게 꽉 채움 (size prop 무시) */
   fill?: boolean;
-
   /** 파싱 상태. PROCESSING이면 스피너, FAILED이면 경고 아이콘 표시 */
   parsingStatus?: ItemStatusT;
   /** 로딩 중 표시할 커스텀 UI */

--- a/apps/web/src/types/tournament.ts
+++ b/apps/web/src/types/tournament.ts
@@ -1,4 +1,5 @@
 import type { TOURNAMENT_STATUS } from '@/consts/tournament';
+import type { ItemStatusT } from '@/types/item';
 
 export type TournamentStatusT = (typeof TOURNAMENT_STATUS)[keyof typeof TOURNAMENT_STATUS];
 
@@ -9,6 +10,7 @@ export type TournamentItemT = {
   price: number;
   currency: string;
   imageUrl: string | null;
+  status?: ItemStatusT;
 };
 
 export type TournamentMatchHistoryT = {


### PR DESCRIPTION
## 작업 요약
- READY/FAILED/PROCESSING 상태별 클릭 분기 처리 및 파싱 실패 모달(삭제/직접입력) 구현

## 작업 세부 내용

### 토너먼트 아이템 파싱 상태 연동
- `GET /api/v1/tournaments/{tournamentId}/items/{tournamentItemId}` 단건 조회 API 연결
- `status === PROCESSING` 인 경우 3초 간격 폴링, `READY` / `FAILED` 전환 시 자동 중단
- `READY` / `FAILED` 상태 전환 감지 시 전체 아이템 목록 쿼리 자동 갱신 (`invalidateQueries`)
- 링크 등록 직후 전체 조회 즉시 갱신하여 `PROCESSING` 상태 바로 노출 (spinner 적용)

### 위시 아이템 상태별 클릭 분기
| 상태 | 동작 |
|------|------|
| `READY` | `/item/:id/edit?type=tournament` 로 이동 |
| `FAILED` | 파싱 실패 모달 노출 (삭제하기 / 직접 입력하기) |
| `PROCESSING` | 클릭 이벤트 차단 |

- 빈 슬롯(플레이스홀더) 클릭 시 이벤트 발생하지 않도록 처리

### 파싱 실패 모달 (`FAILED`)
- 경고 아이콘: `WishItem` 썸네일 위에 오버레이
- 모달 안내 문구: `상품 정보를 불러오지 못했어요`
- `직접 입력하기`: `/item/manual` 로 이동
- 모달 외부 클릭 및 닫기 버튼 가능

### 토너먼트 상품 상태 연동
- `TournamentItemBasketStatus` 컴포넌트 구현
  - `isProcessing`, `count` props 연결
  - 담는 중 / 최소 2개 이상 / `n/32` 상태 텍스트 분기 처리
- `TournamentStartButton` — `PROCESSING` 또는 `FAILED` 아이템이 존재하면 버튼 비활성화




## 연관 이슈

closes #117 
