### PR TITLE
style: 알림 히스토리 페이지 UI 구현

### DIFF
--- a/apps/web/src/app/notification/_components/NotificationEmptyState.tsx
+++ b/apps/web/src/app/notification/_components/NotificationEmptyState.tsx
@@ -1,0 +1,23 @@
+import NotificationIconFill from '@/assets/icons/fill/notification.svg';
+import Button from '@/components/common/button';
+
+function NotificationEmptyState() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-[15px] px-6">
+      <NotificationIconFill width={90} height={90} className="text-gray-100" aria-hidden />
+      <div className="flex flex-col items-center gap-[15px]">
+        <h1 className="heading-2 text-text-neutral-secondary">새로운 알림이 없어요</h1>
+        <p className="text-center body-2-medium text-text-neutral-tertiary">
+          토너먼트에 참여하고,
+          <br />
+          친구를 초대해서 소식을 받아보세요
+        </p>
+      </div>
+      <Button variant="secondary" size="md">
+        기기 알림 설정
+      </Button>
+    </div>
+  );
+}
+
+export default NotificationEmptyState;

--- a/apps/web/src/app/notification/_components/NotificationItem.tsx
+++ b/apps/web/src/app/notification/_components/NotificationItem.tsx
@@ -1,0 +1,21 @@
+type NotificationItemProps = {
+  profileImage?: string;
+  message: string;
+  time: string;
+};
+
+function NotificationItem({ profileImage, message, time }: NotificationItemProps) {
+  return (
+    <li className="flex items-center gap-3 py-5">
+      <div className="size-8 shrink-0 overflow-hidden rounded-full bg-blue-200">
+        {profileImage && <img src={profileImage} alt="" className="size-full object-cover" />}
+      </div>
+      <div className="flex flex-col gap-1">
+        <p className="body-1-semibold text-text-neutral-secondary">{message}</p>
+        <span className="caption-1-regular text-text-neutral-tertiary">{time}</span>
+      </div>
+    </li>
+  );
+}
+
+export default NotificationItem;

--- a/apps/web/src/app/notification/_components/PushDisabledBanner.tsx
+++ b/apps/web/src/app/notification/_components/PushDisabledBanner.tsx
@@ -1,0 +1,18 @@
+import ChevronForwardIcon from '@/assets/icons/fill/chevron-forward.svg';
+import NotificationIconFill from '@/assets/icons/fill/notification.svg';
+
+function PushDisabledBanner() {
+  return (
+    <div className="flex items-center justify-between rounded-2xl bg-gray-75 px-4 py-4">
+      <div className="flex h-6 items-center gap-3">
+        <NotificationIconFill className="size-6 text-icon-neutral-secondary" aria-hidden />
+        <span className="body-2-medium text-text-neutral-secondary">
+          휴대폰의 앱 알림이 꺼져있어요
+        </span>
+      </div>
+      <ChevronForwardIcon className="size-6 text-icon-neutral-secondary" aria-hidden />
+    </div>
+  );
+}
+
+export default PushDisabledBanner;

--- a/apps/web/src/app/notification/_components/PushDisabledBanner.tsx
+++ b/apps/web/src/app/notification/_components/PushDisabledBanner.tsx
@@ -10,7 +10,10 @@ function PushDisabledBanner() {
           휴대폰의 앱 알림이 꺼져있어요
         </span>
       </div>
-      <ChevronForwardIcon className="size-6 text-icon-neutral-secondary" aria-hidden />
+      <ChevronForwardIcon
+        className="size-6 cursor-pointer text-icon-neutral-secondary"
+        aria-hidden
+      />
     </div>
   );
 }

--- a/apps/web/src/app/notification/page.tsx
+++ b/apps/web/src/app/notification/page.tsx
@@ -1,0 +1,49 @@
+import { Header, HeaderIcon } from '@/components/common/header';
+import Spacing from '@/components/common/spacing';
+
+import NotificationEmptyState from './_components/NotificationEmptyState';
+import NotificationItem from './_components/NotificationItem';
+import PushDisabledBanner from './_components/PushDisabledBanner';
+
+// TODO: API 연동 시 제거
+const MOCK_NOTIFICATIONS = [
+  { id: 1, message: '배부른 사자님이 아이템을 추가했어요', time: '오전 11:25' },
+  { id: 2, message: '맛있는 캔디님이 아이템을 추가했어요', time: '오전 11:25' },
+  { id: 3, message: '졸린 호랑이님이 새 아이템을 담았어요', time: '오전 11:25' },
+  { id: 4, message: '노는 원숭이님의 토너먼트에 신입 등장', time: '오전 11:25' },
+];
+
+// TODO: API 연동 시 실제 데이터로 교체
+const notifications = MOCK_NOTIFICATIONS;
+const isPushEnabled = false; /* 앱 알림 권한 여부 */
+
+function Notification() {
+  const isEmpty = notifications.length === 0;
+
+  return (
+    <div className="relative flex min-h-dvh flex-col pt-9 pb-9">
+      <Header left={<HeaderIcon name="BACK" />} center="알림 히스토리" centerClassName="title-1" />
+      <Spacing size={32} />
+      {isEmpty ? (
+        <NotificationEmptyState />
+      ) : (
+        <div className="flex flex-col gap-4">
+          {!isPushEnabled && <PushDisabledBanner />}
+          <div className="rounded-xl bg-base-50">
+            <ul className="divide-y divide-gray-100 px-5">
+              {notifications.map(notification => (
+                <NotificationItem
+                  key={notification.id}
+                  message={notification.message}
+                  time={notification.time}
+                />
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Notification;

--- a/apps/web/src/app/notification/page.tsx
+++ b/apps/web/src/app/notification/page.tsx
@@ -21,27 +21,30 @@ function Notification() {
   const isEmpty = notifications.length === 0;
 
   return (
-    <div className="relative flex min-h-dvh flex-col pt-9 pb-9">
+    <div className="flex h-dvh flex-col pt-9">
       <Header left={<HeaderIcon name="BACK" />} center="알림 히스토리" centerClassName="title-1" />
-      <Spacing size={32} />
-      {isEmpty ? (
-        <NotificationEmptyState />
-      ) : (
-        <div className="flex flex-col gap-4">
-          {!isPushEnabled && <PushDisabledBanner />}
-          <div className="rounded-xl bg-base-50">
-            <ul className="divide-y divide-gray-100 px-5">
-              {notifications.map(notification => (
-                <NotificationItem
-                  key={notification.id}
-                  message={notification.message}
-                  time={notification.time}
-                />
-              ))}
-            </ul>
+      <Spacing size={16} />
+
+      <div className="hide-scrollbar flex-1 overflow-y-auto pt-5">
+        {isEmpty ? (
+          <NotificationEmptyState />
+        ) : (
+          <div className="flex flex-col gap-4 pb-9">
+            {!isPushEnabled && <PushDisabledBanner />}
+            <div className="rounded-xl bg-base-50">
+              <ul className="divide-y divide-gray-100 px-5">
+                {notifications.map(notification => (
+                  <NotificationItem
+                    key={notification.id}
+                    message={notification.message}
+                    time={notification.time}
+                  />
+                ))}
+              </ul>
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 작업 요약

- 알림 없음 / 알림 목록 / 푸시 권한 OFF 3가지 상태에 따른 알림 히스토리 페이지 UI 구현

## 작업 세부 내용

### 화면 상태 분기

| 상태 | 조건 | 노출 UI |
|------|------|---------|
| 알림 없음 | 수신된 알림이 0개 | 빈 상태 UI + 기기 알림 설정 버튼 |
| 알림 있음 (권한 ON) | 알림 1개 이상, 푸시 권한 ON | 알림 목록 |
| 알림 있음 (권한 OFF) | 알림 1개 이상, OS/앱 푸시 권한 OFF | 상단 권한 안내 배너 + 알림 목록 |


#### 알림 없음 상태
- 회색 벨 아이콘 + `새로운 알림이 없어요` 타이틀 + 서브텍스트 중앙 정렬
- `기기 알림 설정` 버튼: OS 알림 설정으로 이동

#### 알림 항목 컴포넌트
- 좌측 프로필 이미지(파란 원형 스마일), 중앙 알림 메시지, 우측 하단 수신 시각 구성
- 발신자명 bold 처리, 줄바꿈 지원
- 아이템 사이 구분선 처리

#### 앱 푸시 권한 OFF 배너
- 알림 목록 최상단 고정, 좌측 벨 아이콘 + 안내 문구 + 우측 `>` 화살표
- 푸시 권한 ON 전환 시 배너 자동 제거

#### `page.tsx`
- 알림 유무 / 푸시 권한 여부에 따라 3가지 상태 분기 처리
- 헤더 `sticky` 고정, 리스트 영역 스크롤바 숨김 (`hide-scrollbar`)
- API 연동 전까지 mock 데이터로 세 가지 상태 확인 가능


## 스크린샷
<img width="475" height="926" alt="image" src="https://github.com/user-attachments/assets/464daad5-e2a9-4ef1-bba7-4240802bda7f" />

## 연관 이슈

> closes #126 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 알림 히스토리 페이지를 추가하여 사용자가 모든 알림을 한 곳에서 확인할 수 있습니다.
  * 알림이 없을 때 친절한 빈 상태 화면을 보여줍니다(아이콘·설명·설정 버튼 포함).
  * 휴대폰 푸시 알림이 비활성화된 경우 안내 배너를 표시합니다.
  * 각 알림 항목에 프로필 이미지(선택), 메시지 및 수신 시간을 표시합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->