### PR TITLE
fix: 토너먼트 라운드 진행 race condition 수정

### DIFF
--- a/apps/web/src/app/tournament/[id]/match/_hooks/useTournament.ts
+++ b/apps/web/src/app/tournament/[id]/match/_hooks/useTournament.ts
@@ -69,10 +69,9 @@ const useTournament = ({ tournamentId, tournamentName, inProgress }: UseTourname
 
   const advanceToNextRound = async () => {
     // 라운드 종료 후 서버에서 다음 라운드 정보 가져오기
-    const next = await queryClient.fetchQuery({
-      queryKey: ['tournament', tournamentId],
-      queryFn: () => getTournament(tournamentId),
-    });
+    // queryClient.fetchQuery는 setQueryData로 시드된 캐시를 반환할 수 있어 직접 fetch
+    const next = await getTournament(tournamentId);
+    queryClient.setQueryData(['tournament', tournamentId], next);
 
     if (next.status !== 'IN_PROGRESS') return;
     setCurrentRound(next.inProgress.currentRound);
@@ -99,6 +98,18 @@ const useTournament = ({ tournamentId, tournamentName, inProgress }: UseTourname
       return;
     }
 
+    // 라운드 마지막 매치 → POST 응답 기다린 후 전환 화면 노출
+    // (응답 안 기다리고 advance 시 서버가 아직 다음 라운드로 전환 못해 같은 라운드 다시 받는 race 방지)
+    if (isLastMatchInRound) {
+      postRecordMatchMutation(matchBody, {
+        onSuccess: () => {
+          const nextRoundItemCount = currentRound / 2;
+          setTransitionStage(getTransitionStage(nextRoundItemCount));
+        },
+      });
+      return;
+    }
+
     // 일반 라운드 — 낙관적 진행 (성공/실패와 무관하게 다음 매치로)
     postRecordMatchMutation(matchBody);
 
@@ -110,12 +121,6 @@ const useTournament = ({ tournamentId, tournamentName, inProgress }: UseTourname
           item.tournamentItemId !== second.tournamentItemId
       )
     );
-
-    // 라운드 마지막 매치 → 전환 화면 노출
-    if (isLastMatchInRound) {
-      const nextRoundItemCount = currentRound / 2;
-      setTransitionStage(getTransitionStage(nextRoundItemCount));
-    }
   };
 
   const handleTransitionComplete = async () => {


### PR DESCRIPTION
## 작업 요약

- 토너먼트 진행 중 4강 라운드에서 결승전으로 넘어가지 못하고 같은 라운드가 반복되던 버그 수정

## 작업 세부 내용

### 원인
라운드 마지막 매치 POST 직후, 서버가 다음 라운드로 전환하기 전에 GET 요청이 도착해 옛 라운드 데이터를 받음. 그 응답으로 클라이언트 state가 reset되어 같은 라운드가 다시 시작되는 race condition.

추가로 `queryClient.fetchQuery`가 `setQueryData`로 시드된 캐시를 반환할 수 있어, 페이지 진입 시 시드된 옛 라운드 데이터가 그대로 반환되는 문제도 같이 발생.

### 수정
1. **라운드 마지막 매치는 POST 응답을 기다린 후 transition 노출**
   - 결승 매치와 동일한 패턴 적용
   - POST 응답 도착 = 서버가 다음 라운드로 전환 완료 보장

2. **`advanceToNextRound`에서 캐시 우회하여 fresh 데이터 fetch**
   - `queryClient.fetchQuery` → `getTournament` 직접 호출
   - 응답 받은 후 `setQueryData`로 캐시 갱신

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 토너먼트 라운드 전환 시 화면 업데이트 타이밍을 개선하여 서버 처리 완료 후 안정적으로 다음 라운드로 진행되도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->