### PR TITLE
refactor: 상수화된 라우트 사용하도록 일괄 교체

### DIFF
--- a/apps/web/src/app/_components/LogoutButton.tsx
+++ b/apps/web/src/app/_components/LogoutButton.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation';
 
 import Button from '@/components/common/button';
+import { ROUTES } from '@/consts/route';
 
 import { logout } from '../_actions/logout';
 
@@ -11,7 +12,7 @@ function LogoutButton() {
 
   const handleLogout = async () => {
     await logout();
-    router.replace('/login');
+    router.replace(ROUTES.LOGIN);
   };
 
   return (

--- a/apps/web/src/app/auth/callback/[provider]/_components/CallbackHandler.tsx
+++ b/apps/web/src/app/auth/callback/[provider]/_components/CallbackHandler.tsx
@@ -1,9 +1,9 @@
 'use client';
 
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 
-import { useParams, useRouter, useSearchParams } from 'next/navigation';
-
+import { ROUTES } from '@/consts/route';
 import type { SocialProviderT } from '@/types/auth';
 
 import { usePostSocialLogin } from '../_hooks/usePostSocialLogin';
@@ -23,27 +23,25 @@ function CallbackHandler() {
   const provider = params.provider;
   const isValidProvider = isSocialProvider(provider);
 
-  const { postSocialLoginMutation } = usePostSocialLogin(
-    isValidProvider ? provider : 'kakao'
-  );
+  const { postSocialLoginMutation } = usePostSocialLogin(isValidProvider ? provider : 'kakao');
 
   useEffect(() => {
     if (hasCalled.current) return;
 
     if (!isValidProvider) {
-      router.replace('/login');
+      router.replace(ROUTES.LOGIN);
       return;
     }
 
     const code = searchParams.get('code');
     if (!code) {
-      router.replace('/login');
+      router.replace(ROUTES.LOGIN);
       return;
     }
 
     const state = searchParams.get('state');
     if (!state) {
-      router.replace('/login');
+      router.replace(ROUTES.LOGIN);
       return;
     }
 

--- a/apps/web/src/app/auth/callback/[provider]/_hooks/usePostSocialLogin.ts
+++ b/apps/web/src/app/auth/callback/[provider]/_hooks/usePostSocialLogin.ts
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
+import { ROUTES } from '@/consts/route';
 import type { SocialProviderT } from '@/types/auth';
 
 import { postSocialLogin } from '../_apis/postSocialLogin';
@@ -20,11 +21,11 @@ export const usePostSocialLogin = (provider: SocialProviderT) => {
       state: string;
     }) => postSocialLogin(provider, { code, redirectUri, state }),
     onSuccess: () => {
-      router.replace('/home');
+      router.replace(ROUTES.HOME);
     },
     onError: () => {
       toast.error('로그인에 실패했습니다. 다시 시도해 주세요.');
-      router.replace('/login');
+      router.replace(ROUTES.LOGIN);
     },
   });
 

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -2,6 +2,8 @@
 
 import Link from 'next/link';
 
+import { ROUTES } from '@/consts/route';
+
 type Props = {
   error: Error & { digest?: string; statusCode?: number };
   reset: () => void;
@@ -45,12 +47,12 @@ export default function Error({ error, reset }: Props) {
         <button
           type="button"
           onClick={reset}
-          className="body-lg flex-1 rounded-3xl bg-black py-3 text-center font-medium text-white"
+          className="body-lg flex-1 rounded-3xl bg-gray-900 py-3 text-center font-medium text-white"
         >
           다시 시도
         </button>
         <Link
-          href="/home"
+          href={ROUTES.HOME}
           className="body-lg flex-1 rounded-3xl bg-gray-100 py-3 text-center font-medium text-gray-900"
         >
           홈으로

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 
+import { ROUTES } from '@/consts/route';
 import '@/styles/globals.css';
 
 type Props = {
@@ -33,12 +34,12 @@ export default function GlobalError({ error, reset }: Props) {
             <button
               type="button"
               onClick={reset}
-              className="bg-primary body-lg flex-1 rounded-3xl py-3 text-center font-medium text-white"
+              className="body-lg flex-1 rounded-3xl bg-gray-900 py-3 text-center font-medium text-white"
             >
               다시 시도
             </button>
             <Link
-              href="/home"
+              href={ROUTES.HOME}
               className="body-lg flex-1 rounded-3xl bg-gray-100 py-3 text-center font-medium text-gray-900"
             >
               홈으로

--- a/apps/web/src/app/home/_hooks/usePostCreateTournament.ts
+++ b/apps/web/src/app/home/_hooks/usePostCreateTournament.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
+import { ROUTES } from '@/consts/route';
+
 import { postCreateTournament } from '../_apis/postCreateTournament';
 
 export const usePostCreateTournament = () => {
@@ -13,8 +15,7 @@ export const usePostCreateTournament = () => {
       onSuccess: ({ tournamentId }) => {
         // 홈의 진행 중인 토너먼트 리스트 갱신
         queryClient.invalidateQueries({ queryKey: ['tournamentList'] });
-        // TODO: 토너먼트 히스토리 쿼리 연결되면 함께 invalidate
-        router.push(`/tournament/${tournamentId}/create`);
+        router.push(ROUTES.TOURNAMENT_CREATE(tournamentId));
       },
     });
 

--- a/apps/web/src/app/login/_hooks/usePostGuestLogin.ts
+++ b/apps/web/src/app/login/_hooks/usePostGuestLogin.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
+import { ROUTES } from '@/consts/route';
 import { setCookie } from '@/utils/cookie';
 import { isWebview } from '@/utils/webBridge';
 
@@ -12,7 +13,7 @@ export const usePostGuestLogin = () => {
   const { mutate: postGuestLoginMutation, isPending: isPostGuestLoginPending } = useMutation({
     mutationFn: postGuestLogin,
     onSuccess: data => {
-      router.push('/home');
+      router.push(ROUTES.HOME);
 
       if (isWebview() && data.accessToken && data.refreshToken) {
         setCookie('access_token', data.accessToken);

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { getMe } from '@/apis/getMe';
 import ButtonLink from '@/components/common/button/ButtonLink';
+import { ROUTES } from '@/consts/route';
 
 import LogoutButton from './_components/LogoutButton';
 
@@ -52,11 +53,11 @@ async function Page() {
       )}
 
       <div className="flex w-full max-w-sm flex-col gap-2">
-        <ButtonLink href="/login" size="lg">
+        <ButtonLink href={ROUTES.LOGIN} size="lg">
           로그인
         </ButtonLink>
         {user && <LogoutButton />}
-        <ButtonLink href="/home" size="lg">
+        <ButtonLink href={ROUTES.HOME} size="lg">
           홈으로
         </ButtonLink>
       </div>

--- a/apps/web/src/app/tournament/[id]/_common/_hooks/useDeleteTournamentItem.ts
+++ b/apps/web/src/app/tournament/[id]/_common/_hooks/useDeleteTournamentItem.ts
@@ -3,6 +3,7 @@ import { isAxiosError } from 'axios';
 import { usePathname, useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
+import { ROUTES } from '@/consts/route';
 import type { ApiErrorResponseT } from '@/types/api';
 
 import { deleteTournamentItem } from '../_apis/deleteTournamentItem';
@@ -12,8 +13,6 @@ export const useDeleteTournamentItem = (tournamentId: number, tournamentItemId: 
   const pathname = usePathname();
   const queryClient = useQueryClient();
 
-  const tournamentCreatePage = `/tournament/${tournamentId}/create`;
-
   const { mutate: deleteTournamentItemMutation, isPending: isDeleteTournamentItemPending } =
     useMutation({
       mutationFn: () => deleteTournamentItem(tournamentId, tournamentItemId),
@@ -22,7 +21,8 @@ export const useDeleteTournamentItem = (tournamentId: number, tournamentItemId: 
         queryClient.invalidateQueries({
           queryKey: ['tournamentItem', tournamentId, tournamentItemId],
         });
-        if (pathname !== tournamentCreatePage) router.replace(tournamentCreatePage);
+        if (pathname !== ROUTES.TOURNAMENT_CREATE(tournamentId))
+          router.replace(ROUTES.TOURNAMENT_CREATE(tournamentId));
       },
       onError: error => {
         if (!isAxiosError<ApiErrorResponseT>(error) || !error.response) return;
@@ -41,7 +41,8 @@ export const useDeleteTournamentItem = (tournamentId: number, tournamentItemId: 
          */
         if (status === 403 || status === 404 || status === 409) {
           toast.error(clientErrorMessage);
-          if (pathname !== tournamentCreatePage) router.replace(tournamentCreatePage);
+          if (pathname !== ROUTES.TOURNAMENT_CREATE(tournamentId))
+            router.replace(ROUTES.TOURNAMENT_CREATE(tournamentId));
         } else if (status === 500) {
           toast.error('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
         }

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
@@ -32,7 +32,7 @@ function TournamentItemBasket({ basketIndex, items, maxHeight }: TournamentItemB
     if (!tournamentId) return;
 
     // if (item.status === 'READY')
-    // router.push(`/tournament/${tournamentId}/item/${item.tournamentItemId}`); // TODO: 변경된 디자인에 맞춰 수정 필요
+    // router.push(ROUTES.TOURNAMENT_ITEM_EDIT(String(tournamentId), String(item.tournamentItemId))); // TODO: 변경된 디자인에 맞춰 수정 필요
 
     if (item.status === 'FAILED') setFailedItem(item);
   };

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemFailedDrawer.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemFailedDrawer.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/common/dialog';
+import { ROUTES } from '@/consts/route';
 
 import { useDeleteTournamentItem } from '../../../_common/_hooks/useDeleteTournamentItem';
 
@@ -38,7 +39,7 @@ function TournamentItemFailedModal({
 
   const handleEdit = () => {
     onClose();
-    router.push(`/tournament/${tournamentId}/item/${tournamentItemId}`);
+    router.push(ROUTES.TOURNAMENT_ITEM_EDIT(tournamentId, tournamentItemId));
   };
 
   return (

--- a/apps/web/src/app/tournament/[id]/create/_hooks/usePostTournamentStart.ts
+++ b/apps/web/src/app/tournament/[id]/create/_hooks/usePostTournamentStart.ts
@@ -1,6 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
+import { ROUTES } from '@/consts/route';
+
 import { postTournamentStart } from '../_apis/postTournamentStart';
 
 export const usePostTournamentStart = (tournamentId: number) => {
@@ -10,7 +12,7 @@ export const usePostTournamentStart = (tournamentId: number) => {
     useMutation({
       mutationFn: () => postTournamentStart(tournamentId),
       onSuccess: () => {
-        router.push(`/tournament/${tournamentId}/match`);
+        router.push(ROUTES.TOURNAMENT_MATCH(tournamentId));
       },
     });
 

--- a/apps/web/src/app/tournament/[id]/create/by-wish/_hooks/usePostTournamentItemsByWish.ts
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_hooks/usePostTournamentItemsByWish.ts
@@ -2,6 +2,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
+import { ROUTES } from '@/consts/route';
+
 import { postTournamentItemsByWish } from '../_apis/postTournamentItemsByWish';
 
 export const usePostTournamentItemsByWish = (tournamentId: number) => {
@@ -15,7 +17,7 @@ export const usePostTournamentItemsByWish = (tournamentId: number) => {
     mutationFn: (itemIds: number[]) => postTournamentItemsByWish(tournamentId, { itemIds }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tournament', tournamentId] });
-      router.push(`/tournament/${tournamentId}/create?scrollToLast=true`);
+      router.push(`${ROUTES.TOURNAMENT_CREATE(tournamentId)}?scrollToLast=true`);
     },
     onError: () => {
       toast.error('위시템 추가에 실패했어요. 잠시 후 다시 시도해주세요.');

--- a/apps/web/src/app/tournament/[id]/item/[itemId]/page.tsx
+++ b/apps/web/src/app/tournament/[id]/item/[itemId]/page.tsx
@@ -3,6 +3,7 @@ import { isAxiosError } from 'axios';
 import { notFound, redirect } from 'next/navigation';
 
 import { getTournamentItem } from '@/app/tournament/[id]/item/[itemId]/_apis/getTournamentItem';
+import { ROUTES } from '@/consts/route';
 import type { ApiErrorResponseT } from '@/types/api';
 import { parseIdParam } from '@/utils/parseIdParam';
 import { getQueryClient } from '@/utils/queryClient';
@@ -34,9 +35,9 @@ async function TournamentItemEditPage({ params }: TournamentItemEditPageProps) {
       const { status } = state.error.response;
 
       /** 토너먼트 권한 없는 경우 */
-      if (status === 403) redirect('/home');
+      if (status === 403) redirect(ROUTES.HOME);
       /** 토너먼트 or 토너먼트 아이템이 존재하지 않는 경우 */ else if (status === 404)
-        redirect(`/tournament/${tournamentId}/create`);
+        redirect(ROUTES.TOURNAMENT_CREATE(tournamentId));
     }
   }
 
@@ -46,7 +47,7 @@ async function TournamentItemEditPage({ params }: TournamentItemEditPageProps) {
   );
   if (tournamentItemData?.status === 'PROCESSING') {
     // TEMP: 아직 PROCESSING 일 때 어떻게 처리해야하는지 정해지지 않았음
-    redirect(`/tournament/${tournamentId}/create`);
+    redirect(ROUTES.TOURNAMENT_CREATE(tournamentId));
   }
 
   return (

--- a/apps/web/src/app/tournament/[id]/match/_hooks/useTournament.ts
+++ b/apps/web/src/app/tournament/[id]/match/_hooks/useTournament.ts
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useMemo, useState, useSyncExternalStore } from 'react';
 
+import { ROUTES } from '@/consts/route';
 import type { TournamentItemT } from '@/types/tournament';
 
 import { getTournament } from '../../_common/_apis/getTournament';
@@ -93,7 +94,7 @@ const useTournament = ({ tournamentId, tournamentName, inProgress }: UseTourname
     // 결승전 — onSuccess(캐시를 COMPLETED로 시드)까지 기다린 후 결과 페이지로 이동
     if (isFinalRound) {
       postRecordMatchMutation(matchBody, {
-        onSuccess: () => router.push(`/tournament/${tournamentId}/result`),
+        onSuccess: () => router.push(ROUTES.TOURNAMENT_RESULT(tournamentId)),
       });
       return;
     }

--- a/apps/web/src/app/tournament/[id]/match/page.tsx
+++ b/apps/web/src/app/tournament/[id]/match/page.tsx
@@ -2,6 +2,7 @@ import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { notFound, redirect } from 'next/navigation';
 
+import { ROUTES } from '@/consts/route';
 import { getQueryClient } from '@/utils/queryClient';
 
 import { getTournament } from '../_common/_apis/getTournament';
@@ -25,7 +26,7 @@ async function TournamentPage({ params }: TournamentPageProps) {
   const tournamentData = await getTournament(tournamentId);
 
   if (tournamentData.status === 'COMPLETED') {
-    redirect(`/tournament/${tournamentId}/result`);
+    redirect(ROUTES.TOURNAMENT_RESULT(tournamentId));
   }
 
   let hydratedTournament: GetTournamentInProgressResponseT;
@@ -50,7 +51,7 @@ async function TournamentPage({ params }: TournamentPageProps) {
 
       const latest = await getTournament(tournamentId);
       if (latest.status === 'COMPLETED') {
-        redirect(`/tournament/${tournamentId}/result`);
+        redirect(ROUTES.TOURNAMENT_RESULT(tournamentId));
       }
       if (latest.status === 'PENDING') {
         // 409이면서 여전히 PENDING — 예상 밖, 그대로 던짐

--- a/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
@@ -4,6 +4,8 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
+import { ROUTES } from '@/consts/route';
+
 import { useGetTournament } from '../../_common/_hooks/useGetTournament';
 import ReceiptDrawMachine from './ReceiptDrawMachine';
 
@@ -19,7 +21,7 @@ function ResultClient({ tournamentId }: ResultClientProps) {
   // RSC에서 status 검사를 하지만, 클라에서 status가 바뀐 경우 방어
   useEffect(() => {
     if (tournamentData.status === 'COMPLETED') return;
-    router.replace(`/tournament/${tournamentId}/match`);
+    router.replace(ROUTES.TOURNAMENT_MATCH(tournamentId));
   }, [tournamentData.status, router, tournamentId]);
 
   if (tournamentData.status !== 'COMPLETED') {
@@ -34,7 +36,7 @@ function ResultClient({ tournamentId }: ResultClientProps) {
   const result = tournamentData.completed.result;
 
   const handleGoHome = () => {
-    router.push('/home');
+    router.push(ROUTES.HOME);
   };
 
   const handleSaveResult = () => {

--- a/apps/web/src/app/tournament/[id]/result/page.tsx
+++ b/apps/web/src/app/tournament/[id]/result/page.tsx
@@ -1,6 +1,7 @@
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 import { notFound, redirect } from 'next/navigation';
 
+import { ROUTES } from '@/consts/route';
 import { getQueryClient } from '@/utils/queryClient';
 
 import { getTournament } from '../_common/_apis/getTournament';
@@ -32,7 +33,7 @@ async function TournamentResultPage({ params }: TournamentResultPageProps) {
   ]);
 
   if (tournamentData && tournamentData.status !== 'COMPLETED') {
-    redirect(`/tournament/${tournamentId}/match`);
+    redirect(ROUTES.TOURNAMENT_MATCH(tournamentId));
   }
 
   return (

--- a/apps/web/src/app/wishlist/[id]/_hooks/useDeleteWish.ts
+++ b/apps/web/src/app/wishlist/[id]/_hooks/useDeleteWish.ts
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
 import { deleteWish } from '@/apis/deleteWish';
+import { ROUTES } from '@/consts/route';
 import type { ApiErrorResponseT } from '@/types/api';
 
 /** 위시 단건 삭제 */
@@ -16,7 +17,7 @@ export const useDeleteWish = (wishId: number) => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['wishlists'] });
       queryClient.invalidateQueries({ queryKey: ['wish', wishId] });
-      router.replace(`/wishlist`);
+      router.replace(ROUTES.ARCHIVE());
     },
     onError: error => {
       if (!isAxiosError<ApiErrorResponseT>(error) || !error.response) return;

--- a/apps/web/src/app/wishlist/[id]/_hooks/usePatchWish.ts
+++ b/apps/web/src/app/wishlist/[id]/_hooks/usePatchWish.ts
@@ -3,6 +3,7 @@ import { isAxiosError } from 'axios';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
+import { ROUTES } from '@/consts/route';
 import type { ApiErrorResponseT } from '@/types/api';
 
 import { patchWish } from '../_apis/patchWish';
@@ -43,7 +44,7 @@ export const usePatchWish = (wishId: number) => {
        */
       if (status === 403 || status === 404 || status === 409) {
         toast.error(clientErrorMessage);
-        router.replace(`/wishlist`);
+        router.replace(ROUTES.ARCHIVE());
       } else if (status === 500) {
         toast.error('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
       }

--- a/apps/web/src/app/wishlist/[id]/page.tsx
+++ b/apps/web/src/app/wishlist/[id]/page.tsx
@@ -2,6 +2,7 @@ import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { notFound, redirect } from 'next/navigation';
 
+import { ROUTES } from '@/consts/route';
 import type { ApiErrorResponseT } from '@/types/api';
 import { parseIdParam } from '@/utils/parseIdParam';
 import { getQueryClient } from '@/utils/queryClient';
@@ -33,9 +34,9 @@ async function WishEditPage({ params }: WishEditPageProps) {
       const { status } = state.error.response;
 
       /** 토너먼트 권한 없는 경우 */
-      if (status === 403) redirect('/home');
+      if (status === 403) redirect(ROUTES.HOME);
       /** 토너먼트 or 토너먼트 아이템이 존재하지 않는 경우 */ else if (status === 404)
-        redirect(`/wishlist`);
+        redirect(ROUTES.ARCHIVE('wish'));
     }
   }
 
@@ -43,7 +44,7 @@ async function WishEditPage({ params }: WishEditPageProps) {
   const wishData = queryClient.getQueryData<GetWishResponseT>(GET_WISH_QUERY_KEY);
   if (wishData?.item.status === 'PROCESSING') {
     // TEMP: 아직 PROCESSING 일 때 어떻게 처리해야하는지 정해지지 않았음
-    redirect(`/wishlist`);
+    redirect(ROUTES.ARCHIVE());
   }
 
   return (

--- a/apps/web/src/app/wishlist/_components/WishTab.tsx
+++ b/apps/web/src/app/wishlist/_components/WishTab.tsx
@@ -2,18 +2,20 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 
+import { ROUTES } from '@/consts/route';
+import type { ItemTypeT } from '@/types/item';
 import { cn } from '@/utils/cn';
 
 import type { WishTabT } from '../_types/wish';
 
 const TABS: WishTabT[] = ['저장한 위시템', '토너먼트 기록'];
 
-const TAB_PARAM: Record<WishTabT, string> = {
+const TAB_TYPE: Record<WishTabT, ItemTypeT> = {
   '저장한 위시템': 'wish',
   '토너먼트 기록': 'tournament',
 };
 
-const PARAM_TAB: Record<string, WishTabT> = {
+const TYPE_TAB: Record<ItemTypeT, WishTabT> = {
   wish: '저장한 위시템',
   tournament: '토너먼트 기록',
 };
@@ -21,12 +23,12 @@ const PARAM_TAB: Record<string, WishTabT> = {
 function WishTab() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const activeTab: WishTabT = PARAM_TAB[searchParams.get('tab') ?? ''] ?? '저장한 위시템';
+  const tabParam = searchParams.get('tab');
+  const activeTab: WishTabT =
+    tabParam === 'wish' || tabParam === 'tournament' ? TYPE_TAB[tabParam] : '저장한 위시템';
 
   const handleTabChange = (tab: WishTabT) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('tab', TAB_PARAM[tab]);
-    router.replace(`?${params.toString()}`);
+    router.replace(ROUTES.ARCHIVE(TAB_TYPE[tab]));
   };
 
   return (

--- a/apps/web/src/app/wishlist/_components/wish-grid/WishFailedCard.tsx
+++ b/apps/web/src/app/wishlist/_components/wish-grid/WishFailedCard.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 
 import { WarningIconFill } from '@/assets/icons';
+import { ROUTES } from '@/consts/route';
 
 type WishFailedCardProps = {
   wishId: number;
@@ -12,7 +13,7 @@ function WishFailedCard({ wishId }: WishFailedCardProps) {
       <WarningIconFill className="size-6 text-icon-neutral-secondary" />
       <p className="body-2-semibold text-text-neutral-secondary">가져오는데 실패했어요</p>
       <Link
-        href={`/wishlist/${wishId}`}
+        href={ROUTES.WISH_EDIT(wishId)}
         className="body-2-medium text-text-neutral-secondary underline underline-offset-[3px]"
       >
         직접 입력하기

--- a/apps/web/src/components/common/bottom-tab-bar/index.tsx
+++ b/apps/web/src/components/common/bottom-tab-bar/index.tsx
@@ -4,10 +4,11 @@ import { usePathname, useRouter } from 'next/navigation';
 
 import HeartIconFill from '@/assets/icons/fill/heart.svg';
 import HomeIconFill from '@/assets/icons/fill/home.svg';
+import { ROUTES } from '@/consts/route';
 
 const TABS = [
-  { label: '홈', icon: HomeIconFill, href: '/home' },
-  { label: '보관', icon: HeartIconFill, href: '/wishlist' },
+  { label: '홈', icon: HomeIconFill, href: ROUTES.HOME },
+  { label: '보관', icon: HeartIconFill, href: ROUTES.ARCHIVE() },
 ] as const;
 
 function BottomTabBar() {
@@ -17,7 +18,10 @@ function BottomTabBar() {
   return (
     <div className="inline-flex items-center rounded-[100px] bg-white p-1 shadow-[0_0_8px_0_rgba(0,0,0,0.04)]">
       {TABS.map(({ label, icon: Icon, href }) => {
-        const isActive = pathname === href || pathname.startsWith(`${href}/`);
+        const isActive =
+          label === '보관'
+            ? pathname.startsWith(ROUTES.ARCHIVE_BASE)
+            : pathname === href || pathname.startsWith(`${href}/`);
         return (
           <button
             key={label}

--- a/apps/web/src/components/common/get-item-dialog/ByLinkDialog.tsx
+++ b/apps/web/src/components/common/get-item-dialog/ByLinkDialog.tsx
@@ -9,6 +9,7 @@ import { LinkIconFill } from '@/assets/icons';
 import Button from '@/components/common/button';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/common/dialog';
 import Input from '@/components/common/input';
+import { ROUTES } from '@/consts/route';
 import { usePostWishLink } from '@/hooks/usePostWishLink';
 import type { ItemTypeT } from '@/types/item';
 
@@ -52,7 +53,7 @@ function ByLinkDialog({ type, open, onOpenChange }: ByLinkProps) {
           resetState();
         },
         onSuccess: () => {
-          router.push('/wishlist');
+          router.push(ROUTES.ARCHIVE('wish'));
           // 라우팅 완료 후 토스트 노출 (페이지 전환 중 토스트가 잠깐 떴다 사라지는 것 방지)
           setTimeout(() => toast.success('위시에 상품을 담았어요'), 100);
         },

--- a/apps/web/src/components/common/get-item-dialog/index.tsx
+++ b/apps/web/src/components/common/get-item-dialog/index.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState } from 'react';
-
 import { useParams } from 'next/navigation';
+import { useState } from 'react';
 
 import { HeartIconFill, ImageIconFill, LinkIconFill } from '@/assets/icons';
 import { DialogContent, DialogDescription, DialogTitle } from '@/components/common/dialog';
+import { ROUTES } from '@/consts/route';
 import type { ItemTypeT } from '@/types/item';
+import { parseIdParam } from '@/utils/parseIdParam';
 
 import ByImageDialog from './ByImageDialog';
 import ByLinkDialog from './ByLinkDialog';
@@ -18,7 +19,11 @@ type GetItemDialogContentProps = {
 
 function GetItemDialogContent({ type }: GetItemDialogContentProps) {
   const [isSubDialogOpen, setIsSubDialogOpen] = useState<'link' | 'image' | null>(null);
+
   const { id } = useParams<{ id: string }>();
+  const tournamentId = parseIdParam(id);
+
+  if (type === 'tournament' && !tournamentId) return null;
 
   return (
     <>
@@ -33,7 +38,7 @@ function GetItemDialogContent({ type }: GetItemDialogContentProps) {
         <ul className="flex w-full flex-col gap-2">
           {type === 'tournament' && (
             <OptionButton
-              href={`/tournament/${id}/create/by-wish`}
+              href={ROUTES.TOURNAMENT_ADD_ITEM_BY_WISH(tournamentId ?? -1)}
               label="위시에서 가져오기"
               description="내 위시리스트에서 상품을 가져와요"
               Icon={HeartIconFill}

--- a/apps/web/src/components/common/header/index.tsx
+++ b/apps/web/src/components/common/header/index.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import type React from 'react';
 
 import { NotificationIconFill } from '@/assets/icons/fill';
+import { ROUTES } from '@/consts/route';
 import { cn } from '@/utils/cn';
 
 import BackHeaderIcon from './BackHeaderIcon';
@@ -81,7 +82,7 @@ function HeaderIcon({
       return (
         // TODO: href 수정 필요
         <Link
-          href="/"
+          href={ROUTES.ROOT}
           aria-label="알림"
           className={cn(ICON_BASE_STYLE, className)}
           onClick={onClick}

--- a/apps/web/src/components/common/tournament-card/MorePopover.tsx
+++ b/apps/web/src/components/common/tournament-card/MorePopover.tsx
@@ -11,6 +11,7 @@ import {
   TrashIconFill,
 } from '@/assets/icons';
 import { QUERY_ACTION } from '@/consts/queryAction';
+import { ROUTES } from '@/consts/route';
 import { TOURNAMENT_STATUS } from '@/consts/tournament';
 import type { TournamentStatusT } from '@/types/tournament';
 
@@ -30,7 +31,7 @@ function MorePopover({ status, tournamentId }: MorePopoverProps) {
   const handleAddTournamentItem = () => {
     setIsPopoverOpen(false);
     router.push(
-      `/tournament/${tournamentId}/create?${QUERY_ACTION.KEY}=${QUERY_ACTION.VALUE.OPEN_GET_ITEM_DIALOG}`
+      `${ROUTES.TOURNAMENT_CREATE(tournamentId)}?${QUERY_ACTION.KEY}=${QUERY_ACTION.VALUE.OPEN_GET_ITEM_DIALOG}`
     );
   };
 

--- a/apps/web/src/consts/route.ts
+++ b/apps/web/src/consts/route.ts
@@ -1,0 +1,25 @@
+import type { ItemTypeT } from '@/types/item';
+
+export const ROUTES = {
+  /** 1. Public */
+  ROOT: '/',
+  HOME: '/home',
+  LOGIN: '/login',
+  TOURNAMENT_JOIN_BY_CODE: '/tournament/join',
+  TOURNAMENT_JOIN_BY_LINK: (id: number) => `/tournament/join/${id}`,
+
+  /** 2. Member Only */
+  ARCHIVE_BASE: '/archive',
+  ARCHIVE: (tab: ItemTypeT = 'wish') => `/archive?tab=${tab}`,
+  WISH_EDIT: (wishId: number) => `/archive/wish/${wishId}`,
+
+  /** 3. Authorized Guest or Member */
+  TOURNAMENT_CREATE: (tournamentId: number) => `/tournament/${tournamentId}/create`,
+  TOURNAMENT_ADD_ITEM_BY_WISH: (tournamentId: number) =>
+    `/tournament/${tournamentId}/create/by-wish`,
+  TOURNAMENT_ITEM_EDIT: (tournamentId: number, itemId: number) =>
+    `/tournament/${tournamentId}/item/${itemId}`,
+  TOURNAMENT_LOADING: (tournamentId: number) => `/tournament/${tournamentId}/loading`,
+  TOURNAMENT_MATCH: (tournamentId: number) => `/tournament/${tournamentId}/match`,
+  TOURNAMENT_RESULT: (tournamentId: number) => `/tournament/${tournamentId}/result`,
+} as const;

--- a/apps/web/src/hooks/usePostTournamentOCR.ts
+++ b/apps/web/src/hooks/usePostTournamentOCR.ts
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
 import { postTournamentOCR } from '@/apis/postTournamentOCR';
+import { ROUTES } from '@/consts/route';
 import type { ApiErrorResponseT } from '@/types/api';
 
 export const usePostTournamentOCR = (tournamentId: number) => {
@@ -38,7 +39,7 @@ export const usePostTournamentOCR = (tournamentId: number) => {
       if (status === 400) toast.error(clientErrorMessage);
       else if (status === 403 || status === 404 || status === 409) {
         toast.error(clientErrorMessage);
-        router.replace('/home');
+        router.replace(ROUTES.HOME);
       } else if (status === 500) {
         toast.error('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
       }

--- a/apps/web/src/hooks/usePostWishLink.ts
+++ b/apps/web/src/hooks/usePostWishLink.ts
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
 import { postWishLink } from '@/apis/postWishLink';
+import { ROUTES } from '@/consts/route';
 import type { ApiErrorResponseT } from '@/types/api';
 
 export const usePostWishLink = () => {
@@ -18,7 +19,7 @@ export const usePostWishLink = () => {
     mutationFn: (url: string) => postWishLink(url),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['wishlists'] });
-      router.push('/wishlist');
+      router.push(ROUTES.ARCHIVE('wish'));
     },
     onError: error => {
       if (!isAxiosError<ApiErrorResponseT>(error) || !error.response) return;
@@ -30,7 +31,7 @@ export const usePostWishLink = () => {
       if (error.response.status === 400) toast.error(error.response.data.detail);
       else if (error.response.status === 403) {
         toast.error(error.response.data.detail);
-        router.replace('/login');
+        router.replace(ROUTES.LOGIN);
       }
     },
   });

--- a/apps/web/src/hooks/usePostWishOCR.ts
+++ b/apps/web/src/hooks/usePostWishOCR.ts
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
 import { postWishOCR } from '@/apis/postWishOCR';
+import { ROUTES } from '@/consts/route';
 import type { ApiErrorResponseT } from '@/types/api';
 
 export const usePostWishOCR = () => {
@@ -18,7 +19,7 @@ export const usePostWishOCR = () => {
     mutationFn: (formData: FormData) => postWishOCR(formData),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['wishlists'] });
-      router.push('/wishlist');
+      router.push(ROUTES.ARCHIVE('wish'));
     },
     onError: error => {
       if (!isAxiosError<ApiErrorResponseT>(error) || !error.response) return;
@@ -30,7 +31,7 @@ export const usePostWishOCR = () => {
       if (error.response.status === 400) toast.error(error.response.data.detail);
       else if (error.response.status === 403) {
         toast.error(error.response.data.detail);
-        router.replace('/login');
+        router.replace(ROUTES.LOGIN);
       }
     },
   });


### PR DESCRIPTION
## 작업 요약
- 하드코딩되어 있는 라우트 경로를 하나의 파일에서 관리할 수 있도록 상수화(Constant)를 진행
- 기획 변경에 따라 기존 /wishlist 경로를 /archive로 변경

## 작업 세부 내용

- 라우트 경로 상수화
  - [x] 프로젝트 내 모든 라우트 경로를 관리하는 상수 파일 생성 (예: src/constants/routes.js 또는 routes.ts)
  - [x] 기존 컴포넌트 및 링크(<Link>, MapsTo 등)에 하드코딩된 문자열을 상수로 대체
- 경로 변경 (/wishlist ➡️ /archive)
  - [x] 라우터 설정 파일에서 /wishlist 경로를 /archive로 수정
  
## 연관 이슈

close #146


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일 개선**
  * 에러 페이지의 버튼 색상을 업데이트했습니다.

* **개선사항**
  * 앱 전체의 내비게이션 경로 관리를 개선하여 일관성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->