### PR TITLE
hotfix: API 프록시 hop-by-hop 헤더 제거로 Vercel 500 에러 해결

### DIFF
--- a/apps/web/src/app/api/v1/[...path]/route.ts
+++ b/apps/web/src/app/api/v1/[...path]/route.ts
@@ -16,6 +16,7 @@ async function handler(request: NextRequest, { params }: { params: Promise<{ pat
   const forwardHeaders = new Headers(request.headers);
   forwardHeaders.set('Cookie', cookieStore.toString());
   forwardHeaders.delete('host');
+  forwardHeaders.delete('transfer-encoding');
   forwardHeaders.delete('origin');
   forwardHeaders.delete('referer');
 


### PR DESCRIPTION
## 작업 요약

- Vercel 배포 환경(`dev.piki.day`)에서 API Route 프록시 호출 시 발생하던 500 Internal Server Error를 해결합니다.

## 작업 세부 내용

### 배경 및 문제 상황

프론트엔드에서 `/api/v1/...` 경로로 요청할 때, Next.js API Route 서버리스 함수 내부에서 백엔드 호출 도중 `fetch failed` 에러가 발생하며 500이 반환되었습니다.

**Vercel 배포 로그**

```text
[TypeError: fetch failed] {
  [cause]: Error [InvalidArgumentError]: invalid transfer-encoding header
      at new Promise (<anonymous>) {
    code: 'UND_ERR_INVALID_ARG'
  }
}
```

### 원인 분석

1. 브라우저 요청에 `transfer-encoding: chunked` 헤더가 자동으로 포함됩니다.
2. API Route에서 `new Headers(request.headers)`로 브라우저 헤더를 그대로 복사해 백엔드 `fetch`에 전달했습니다.
3. Vercel(Node.js)의 fetch 엔진(undici)은 `transfer-encoding`을 수동으로 설정하는 것을 금지하므로 `InvalidArgumentError`가 발생했습니다.

### 변경 사항

* 백엔드로 `fetch` 요청을 대리 전송하기 전, 프록시 헤더 객체(`forwardHeaders`)에서 에러를 유발하는 `transfer-encoding` 헤더를 삭제했습니다.

```typescript
const forwardHeaders = new Headers(request.headers);
forwardHeaders.set('Cookie', cookieStore.toString());
forwardHeaders.delete('host');
forwardHeaders.delete('transfer-encoding'); << 추가
forwardHeaders.delete('origin');
forwardHeaders.delete('referer');
```