### PR TITLE
refactor: mutation 중복 호출 방지 및 Button 로딩 상태 통일

### DIFF
--- a/apps/web/src/app/archive/wish/[id]/_components/ItemEditForm.tsx
+++ b/apps/web/src/app/archive/wish/[id]/_components/ItemEditForm.tsx
@@ -7,7 +7,7 @@ import BottomCta from '@/components/bottom-cta';
 import Button from '@/components/button';
 import Input from '@/components/input';
 import Spacing from '@/components/spacing';
-import Spinner from '@/components/spinner';
+
 import type { ItemStatusT } from '@/types/item';
 import formatPrice from '@/utils/formatPrice';
 
@@ -100,18 +100,25 @@ function ItemEditForm({
 
       <BottomCta className="bg-bg-layer-basement py-3">
         {itemStatus === 'READY' && (
-          <Button variant="secondary" size="lg" className="flex-1" onClick={handleDelete}>
-            {isDeleteWishPending ? <Spinner size={20} /> : '삭제하기'}
+          <Button
+            variant="secondary"
+            size="lg"
+            className="flex-1"
+            isLoading={isDeleteWishPending}
+            onClick={handleDelete}
+          >
+            삭제하기
           </Button>
         )}
         <Button
           variant="primary"
           size="lg"
-          onClick={handleSave}
+          isLoading={isPatchWishPending}
           disabled={isDeleteWishPending || !isValid}
           className="flex-1"
+          onClick={handleSave}
         >
-          {isPatchWishPending ? <Spinner size={20} /> : '저장하기'}
+          저장하기
         </Button>
       </BottomCta>
     </>

--- a/apps/web/src/app/login/_components/LoginButtons.tsx
+++ b/apps/web/src/app/login/_components/LoginButtons.tsx
@@ -12,7 +12,7 @@ import { usePostGuestLogin } from '../_hooks/usePostGuestLogin';
 import SocialLoginButton from './SocialLoginButton';
 
 function LoginButtons() {
-  const { postGuestLoginMutation } = usePostGuestLogin();
+  const { postGuestLoginMutation, isPostGuestLoginPending } = usePostGuestLogin();
   useNativeLoginResult();
 
   const handleKakaoLogin = () => {
@@ -82,6 +82,7 @@ function LoginButtons() {
 
       <button
         type="button"
+        disabled={isPostGuestLoginPending}
         onClick={handleGuestLogin}
         className="mt-7 cursor-pointer body-2-medium text-text-neutral-secondary underline underline-offset-2"
       >

--- a/apps/web/src/app/mypage/_components/LogoutMenuItem.tsx
+++ b/apps/web/src/app/mypage/_components/LogoutMenuItem.tsx
@@ -11,8 +11,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/dialog';
-import Spinner from '@/components/spinner';
-
 import { usePostLogout } from '../_hooks/usePostLogout';
 
 function LogoutMenuItem() {
@@ -44,10 +42,10 @@ function LogoutMenuItem() {
             variant="secondary"
             size="lg"
             className="flex-1"
+            isLoading={isPostLogoutPending}
             onClick={handleLogout}
-            disabled={isPostLogoutPending}
           >
-            {isPostLogoutPending ? <Spinner size={24} /> : '로그아웃'}
+            로그아웃
           </Button>
           <DialogClose asChild>
             <Button variant="primary" size="lg" className="flex-1">

--- a/apps/web/src/app/mypage/edit/_components/EditForm.tsx
+++ b/apps/web/src/app/mypage/edit/_components/EditForm.tsx
@@ -5,7 +5,7 @@ import { type FormEvent, useState } from 'react';
 import BottomCta from '@/components/bottom-cta';
 import Button from '@/components/button';
 import Spacing from '@/components/spacing';
-import Spinner from '@/components/spinner';
+
 import { useGetMe } from '@/hooks/useGetMe';
 
 import { useNicknameValidation } from '../_hooks/useNicknameValidation';
@@ -70,9 +70,10 @@ function EditForm() {
           variant="primary"
           size="lg"
           className="w-full"
+          isLoading={isPatchMePending}
           disabled={isEditDisabled}
         >
-          {isPatchMePending ? <Spinner size={20} /> : '수정하기'}
+          수정하기
         </Button>
       </BottomCta>
     </form>

--- a/apps/web/src/app/mypage/withdraw/_components/WithdrawConfirmDialog.tsx
+++ b/apps/web/src/app/mypage/withdraw/_components/WithdrawConfirmDialog.tsx
@@ -14,7 +14,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/dialog';
-import Spinner from '@/components/spinner';
 
 import { useDeleteMe } from '../_hooks/useDeleteMe';
 
@@ -35,7 +34,7 @@ function WithdrawConfirmDialog() {
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <BottomCta className="bg-bg-layer-basement pb-8">
         <DialogTrigger asChild>
-          <Button variant="secondary" size="lg" className="w-full" disabled={isDeleteMePending}>
+          <Button variant="secondary" size="lg" className="w-full">
             탈퇴하기
           </Button>
         </DialogTrigger>
@@ -52,10 +51,10 @@ function WithdrawConfirmDialog() {
             variant="secondary"
             size="lg"
             className="flex-1"
+            isLoading={isDeleteMePending}
             onClick={handleWithdraw}
-            disabled={isDeleteMePending}
           >
-            {isDeleteMePending ? <Spinner size={24} /> : '탈퇴하기'}
+            탈퇴하기
           </Button>
           <DialogClose asChild>
             <Button variant="primary" size="lg" className="flex-1">

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemFailedDrawer.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemFailedDrawer.tsx
@@ -62,7 +62,7 @@ function TournamentItemFailedModal({
             variant="secondary"
             size="lg"
             className="flex-1"
-            disabled={isDeleteTournamentItemPending}
+            isLoading={isDeleteTournamentItemPending}
             onClick={handleDeleteTournamentItem}
           >
             삭제하기

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemFailedDrawer.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemFailedDrawer.tsx
@@ -29,7 +29,10 @@ function TournamentItemFailedModal({
   onClose,
 }: TournamentItemFailedModalProps) {
   const router = useRouter();
-  const { deleteTournamentItemMutation } = useDeleteTournamentItem(tournamentId, tournamentItemId);
+  const { deleteTournamentItemMutation, isDeleteTournamentItemPending } = useDeleteTournamentItem(
+    tournamentId,
+    tournamentItemId
+  );
 
   const handleDeleteTournamentItem = () => {
     deleteTournamentItemMutation(void 0, {
@@ -59,6 +62,7 @@ function TournamentItemFailedModal({
             variant="secondary"
             size="lg"
             className="flex-1"
+            disabled={isDeleteTournamentItemPending}
             onClick={handleDeleteTournamentItem}
           >
             삭제하기

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/TournamentStartButton.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/TournamentStartButton.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Button from '@/components/button';
-import Spinner from '@/components/spinner';
 
 import { usePostTournamentStart } from '../../_hooks/usePostTournamentStart';
 
@@ -24,10 +23,11 @@ function TournamentStartButton({
     <Button
       variant="primary"
       size="lg"
-      disabled={count < 2 || isPostTournamentStartPending || hasUnreadyItem}
+      disabled={count < 2 || hasUnreadyItem}
+      isLoading={isPostTournamentStartPending}
       onClick={() => postTournamentStartMutation()}
     >
-      {isPostTournamentStartPending ? <Spinner size={20} /> : '토너먼트 시작하기'}
+      토너먼트 시작하기
     </Button>
   );
 }

--- a/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
@@ -77,7 +77,8 @@ function ByWishContent({ tournamentId }: ByWishContentProps) {
         <Button
           variant="primary"
           size="lg"
-          disabled={selectedIds.length === 0 || isPostTournamentItemsByWishPending}
+          disabled={selectedIds.length === 0}
+          isLoading={isPostTournamentItemsByWishPending}
           onClick={handleNext}
         >
           다음

--- a/apps/web/src/app/tournament/[id]/item/[itemId]/_components/ItemEditForm.tsx
+++ b/apps/web/src/app/tournament/[id]/item/[itemId]/_components/ItemEditForm.tsx
@@ -7,7 +7,7 @@ import BottomCta from '@/components/bottom-cta';
 import Button from '@/components/button';
 import Input from '@/components/input';
 import Spacing from '@/components/spacing';
-import Spinner from '@/components/spinner';
+
 import type { ItemStatusT } from '@/types/item';
 import { cn } from '@/utils/cn';
 import formatPrice from '@/utils/formatPrice';
@@ -105,8 +105,14 @@ function ItemEditForm({
         )}
       >
         {itemStatus === 'READY' && (
-          <Button variant="secondary" size="lg" className="flex-1" onClick={handleDelete}>
-            {isDeleteTournamentItemPending ? <Spinner size={20} /> : '삭제하기'}
+          <Button
+            variant="secondary"
+            size="lg"
+            className="flex-1"
+            isLoading={isDeleteTournamentItemPending}
+            onClick={handleDelete}
+          >
+            삭제하기
           </Button>
         )}
         <Button

--- a/apps/web/src/components/button/index.tsx
+++ b/apps/web/src/components/button/index.tsx
@@ -2,6 +2,7 @@
 
 import type { ComponentProps, ReactNode } from 'react';
 
+import Spinner from '@/components/spinner';
 import { cn } from '@/utils/cn';
 
 import { type ButtonStyleProps, buttonStyles } from './button.style';
@@ -10,6 +11,7 @@ type ButtonProps = Omit<ComponentProps<'button'>, 'children'> &
   ButtonStyleProps & {
     leadingIcon?: ReactNode;
     children?: ReactNode;
+    isLoading?: boolean;
   };
 
 function Button({
@@ -19,13 +21,25 @@ function Button({
   leadingIcon,
   className,
   children,
+  isLoading,
   type = 'button',
   ...rest
 }: ButtonProps) {
   return (
-    <button type={type} className={cn(buttonStyles({ variant, size, icon }), className)} {...rest}>
-      {icon === 'leading' && leadingIcon}
-      {children}
+    <button
+      type={type}
+      disabled={isLoading || rest.disabled}
+      className={cn(buttonStyles({ variant, size, icon }), className)}
+      {...rest}
+    >
+      {isLoading ? (
+        <Spinner size={24} />
+      ) : (
+        <>
+          {icon === 'leading' && leadingIcon}
+          {children}
+        </>
+      )}
     </button>
   );
 }

--- a/apps/web/src/components/get-item-dialog/ByImageDialog.tsx
+++ b/apps/web/src/components/get-item-dialog/ByImageDialog.tsx
@@ -14,7 +14,7 @@ import { usePostWishOCR } from '@/hooks/usePostWishOCR';
 import type { ItemTypeT } from '@/types/item';
 
 import Spacing from '../spacing';
-import Spinner from '../spinner';
+
 
 const MAX_IMAGE_COUNT = 5;
 
@@ -98,15 +98,10 @@ function ByImageDialog({ type, open, onOpenChange }: Props) {
         <Button
           size="lg"
           variant="primary"
+          isLoading={isImagePickerPending || isPostWishOCRPending || isPostTournamentOCRPending}
           onClick={openPicker}
-          disabled={isImagePickerPending || isPostWishOCRPending || isPostTournamentOCRPending}
         >
-          {/** TODO: spinner size 임의값. 변경 필요 */}
-          {isImagePickerPending || isPostWishOCRPending || isPostTournamentOCRPending ? (
-            <Spinner size={20} />
-          ) : (
-            '사진 선택하기'
-          )}
+          사진 선택하기
         </Button>
 
         <input

--- a/apps/web/src/components/get-item-dialog/ByLinkDialog.tsx
+++ b/apps/web/src/components/get-item-dialog/ByLinkDialog.tsx
@@ -24,14 +24,16 @@ type ByLinkProps = {
 function ByLinkDialog({ type, open, onOpenChange }: ByLinkProps) {
   const router = useRouter();
   const { id: tournamentId } = useParams<{ id: string }>();
-  const { postWishLinkMutation } = usePostWishLink();
-  const { postTournamentItemLinkMutation } = usePostTournamentItemLink(Number(tournamentId));
+  const { postWishLinkMutation, isPostWishLinkPending } = usePostWishLink();
+  const { postTournamentItemLinkMutation, isPostTournamentItemLinkPending } =
+    usePostTournamentItemLink(Number(tournamentId));
 
   const [url, setUrl] = useState('');
   const [hasError, setHasError] = useState(false);
 
   const trimmedUrl = url.trim();
   const isEmpty = trimmedUrl.length === 0;
+  const isPending = isPostWishLinkPending || isPostTournamentItemLinkPending;
 
   const resetState = () => {
     setUrl('');
@@ -96,7 +98,7 @@ function ByLinkDialog({ type, open, onOpenChange }: ByLinkProps) {
             autoFocus
             inputMode="url"
           />
-          <Button size="lg" variant="primary" disabled={isEmpty} onClick={handleSubmit}>
+          <Button size="lg" variant="primary" disabled={isEmpty || isPending} onClick={handleSubmit}>
             {type === 'wish' && '위시리스트에 담기'}
             {type === 'tournament' && '후보 바구니에 담기'}
           </Button>

--- a/apps/web/src/components/get-item-dialog/ByLinkDialog.tsx
+++ b/apps/web/src/components/get-item-dialog/ByLinkDialog.tsx
@@ -98,7 +98,7 @@ function ByLinkDialog({ type, open, onOpenChange }: ByLinkProps) {
             autoFocus
             inputMode="url"
           />
-          <Button size="lg" variant="primary" disabled={isEmpty || isPending} onClick={handleSubmit}>
+          <Button size="lg" variant="primary" disabled={isEmpty} isLoading={isPending} onClick={handleSubmit}>
             {type === 'wish' && '위시리스트에 담기'}
             {type === 'tournament' && '후보 바구니에 담기'}
           </Button>

--- a/apps/web/src/components/tournament-card/TournamentDeleteDialog.tsx
+++ b/apps/web/src/components/tournament-card/TournamentDeleteDialog.tsx
@@ -10,7 +10,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/dialog';
-import Spinner from '@/components/spinner';
 import { useDeleteTournament } from '@/hooks/useDeleteTournament';
 
 type TournamentDeleteDialogProps = {
@@ -65,10 +64,10 @@ function TournamentDeleteDialog({ open, onOpenChange, tournamentId }: Tournament
             variant="primary"
             size="lg"
             className="flex-1"
+            isLoading={isDeleteTournamentPending}
             onClick={handleDeleteTournament}
-            disabled={isDeleteTournamentPending}
           >
-            {isDeleteTournamentPending ? <Spinner size={20} /> : '삭제하기'}
+            삭제하기
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## 작업 요약

- URL로 상품 추가 등 mutation 진행 중일 때 버튼이 비활성화되지 않아 중복 API 호출이 발생하는 문제를 
- 로딩 스피너 처리 방식이 컴포넌트마다 달라 일관성이 없었습니다.

## 작업 세부 내용


### 문제

- URL로 상품 추가 등 뮤테이션이 진행 중일 때 버튼이 비활성화되지 않아 중복 API 호출 발생
- 로딩 스피너 처리 방식이 컴포넌트마다 달라 일관성 없음

### 해결

#### Button 컴포넌트에 isLoading prop 추가

`<Button isLoading={isPending}>저장하기</Button> 
`
- isLoading=true이면 children 대신 <Spinner size={24} /> 노출
- disabled={isLoading || rest.disabled}로 자동 비활성화
- 기존에 각 컴포넌트에서 직접 구현하던 아래 패턴을 대체

tsx {isPending ? <Spinner /> : '텍스트'} 

#### 누락된 pending 가드 추가

| 컴포넌트 | 내용 |
|----------|------|
| ByLinkDialog | URL 추가 버튼 — isPostWishLinkPending \|\| isPostTournamentItemLinkPending 가드 추가 |
| TournamentItemFailedDrawer | 삭제하기 버튼 — isDeleteTournamentItemPending 가드 추가 |
| LoginButtons | 비회원으로 시작하기 버튼 — isPostGuestLoginPending 가드 추가 |

#### 기존 수동 Spinner 패턴을 isLoading prop으로 통일

| 컴포넌트 | 변경 전 | 변경 후 |
|----------|----------|----------|
| LogoutMenuItem | disabled + {isPending ? <Spinner /> : '로그아웃'} | isLoading={isPostLogoutPending} |
| WithdrawConfirmDialog | disabled + {isPending ? <Spinner /> : '탈퇴하기'} | isLoading={isDeleteMePending} |
| TournamentDeleteDialog | disabled + {isPending ? <Spinner /> : '삭제하기'} | isLoading={isDeleteTournamentPending} |
| TournamentStartButton | disabled + {isPending ? <Spinner /> : '시작하기'} | isLoading={isPostTournamentStartPending} |
| ByImageDialog | disabled + {isPending ? <Spinner /> : '사진 선택하기'} | isLoading={isPending} |
| ByWishContent | disabled={... || isPending}만 적용 | isLoading={isPostTournamentItemsByWishPending} 추가 |
| ItemEditForm (wish) | disabled + {isPending ? <Spinner /> : '삭제/저장하기'} | isLoading prop으로 교체 |
| ItemEditForm (tournament) | disabled + {isPending ? <Spinner /> : '삭제하기'} | isLoading prop으로 교체 |
| EditForm | disabled + {isPending ? <Spinner /> : '수정하기'} | isLoading={isPatchMePending} |

### 변경하지 않은 곳

- `WishlistFabArea` : FAB는 native <button>을 사용하고 있어 기존 방식 유지
- `ItemImageSection` : 이미지 선택 버튼은 native <button>을 사용하고 있어 기존 방식 유지
- `NicknameField` : Spinner가 입력 필드 내부 검증 인디케이터 용도로 사용되어 Button 로딩 상태와 무관
- 토너먼트 매치 (`useTournament`) : 일반 라운드는 낙관적 업데이트를 의도한 설계로 pending 가드를 적용하지 않음
