### PR TITLE
feat: 웹/앱 버전 표시 기능

### DIFF
--- a/apps/app/app.json
+++ b/apps/app/app.json
@@ -42,7 +42,7 @@
       },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
-      "permissions": ["android.permission.RECORD_AUDIO", "android.permission.POST_NOTIFICATIONS"]
+      "permissions": ["android.permission.POST_NOTIFICATIONS"]
     },
     "web": {
       "output": "static",

--- a/apps/app/app/index.tsx
+++ b/apps/app/app/index.tsx
@@ -1,6 +1,5 @@
 import {
   WEBBRIDGE_MESSAGE_TYPE,
-  WEBVIEW_UA_TOKEN,
   WEB_REQ_READY_PAYLOAD_TYPE,
   type WebBridgeMessageT,
 } from '@piki/core';
@@ -9,6 +8,7 @@ import { KeyboardAvoidingView, Linking, Platform } from 'react-native';
 import type { WebView } from 'react-native-webview';
 import Webview from 'react-native-webview';
 
+import { USER_AGENT } from '@/constants/userAgent';
 import { useShareIntent } from '@/hooks/useShareIntent';
 import { useSocialLogin } from '@/hooks/useSocialLogin';
 import { useWebBridgeMessage } from '@/hooks/useWebBridgeMessage';
@@ -88,7 +88,7 @@ function Page() {
         <Webview
           ref={webviewRef}
           style={{ flex: 1 }}
-          applicationNameForUserAgent={WEBVIEW_UA_TOKEN}
+          applicationNameForUserAgent={USER_AGENT}
           source={{ uri: webviewUri }}
           onMessage={onMessage}
           allowsBackForwardNavigationGestures

--- a/apps/app/constants/userAgent.ts
+++ b/apps/app/constants/userAgent.ts
@@ -1,0 +1,7 @@
+import { WEBVIEW_UA_TOKEN } from '@piki/core';
+import Constants from 'expo-constants';
+
+export const USER_AGENT = (() => {
+  const appVersion = Constants.expoConfig?.version;
+  return appVersion ? `${WEBVIEW_UA_TOKEN}/${appVersion}` : `${WEBVIEW_UA_TOKEN}`;
+})();

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "predev": "node scripts/prebuild.mjs",
     "dev": "next dev --port 3000",
+    "prebuild": "node scripts/prebuild.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/apps/web/scripts/prebuild.mjs
+++ b/apps/web/scripts/prebuild.mjs
@@ -1,3 +1,7 @@
+/**
+ * dev/build 전에 웹 버전을 해석해 .env.local에 주입한다.
+ * web-v* git 태그가 없으면 기존 NEXT_PUBLIC_WEB_VERSION을 제거해 stale 버전 표시를 막는다.
+ */
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
@@ -8,22 +12,19 @@ const ENV_KEY = 'NEXT_PUBLIC_WEB_VERSION';
 const WEB_APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const ENV_PATH = resolve(WEB_APP_ROOT, '.env.local');
 
-const parseWebVersionFromRef = ref => {
-  if (!ref?.startsWith(WEB_VERSION_TAG_PREFIX)) return null;
-  return ref.slice(WEB_VERSION_TAG_PREFIX.length);
-};
-
+/** 최신 web-v* git 태그에서 버전 문자열 추출. 없으면 null */
 const getWebVersion = () => {
   try {
     const tag = execSync(`git describe --tags --match "${WEB_VERSION_TAG_PREFIX}*" --abbrev=0`, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'ignore'],
     }).trim();
-    const fromGitTag = parseWebVersionFromRef(tag);
-    if (fromGitTag) {
-      console.log(fromGitTag);
-      return fromGitTag;
-    }
+
+    if (!tag.startsWith(WEB_VERSION_TAG_PREFIX)) return null;
+
+    const webVersion = tag.slice(WEB_VERSION_TAG_PREFIX.length);
+    console.log('[WEB VERSION] ', webVersion);
+    return webVersion;
   } catch {
     /** git unavailable or no matching tag */
   }
@@ -31,22 +32,36 @@ const getWebVersion = () => {
   return null;
 };
 
-const insertWebVersionIntoEnv = webVersion => {
-  const line = `${ENV_KEY}=${webVersion}`;
+const keyPattern = new RegExp(`^${ENV_KEY}=.*\\n?`, 'm');
 
+/**
+ * .env.local의 NEXT_PUBLIC_WEB_VERSION을 동기화한다.
+ * - 버전 있음 → upsert
+ * - 버전 없음 → 키 제거 (이전 값이 남지 않도록)
+ */
+const syncWebVersionIntoEnv = webVersion => {
   if (!existsSync(ENV_PATH)) {
-    writeFileSync(ENV_PATH, `${line}\n`);
+    if (webVersion) writeFileSync(ENV_PATH, `${ENV_KEY}=${webVersion}\n`);
     return;
   }
 
   const content = readFileSync(ENV_PATH, 'utf-8');
-  const keyPattern = new RegExp(`^${ENV_KEY}=.*$`, 'm');
+
+  if (!webVersion) {
+    if (!keyPattern.test(content)) return;
+
+    const nextContent = content.replace(keyPattern, '').trimEnd();
+    writeFileSync(ENV_PATH, nextContent ? `${nextContent}\n` : '');
+    return;
+  }
+
+  const line = `${ENV_KEY}=${webVersion}`;
   const nextContent = keyPattern.test(content)
-    ? content.replace(keyPattern, line)
+    ? content.replace(keyPattern, `${line}\n`)
     : `${content.trimEnd()}\n${line}\n`;
 
   writeFileSync(ENV_PATH, nextContent);
 };
 
 const webVersion = getWebVersion();
-if (webVersion) insertWebVersionIntoEnv(webVersion);
+syncWebVersionIntoEnv(webVersion);

--- a/apps/web/scripts/prebuild.mjs
+++ b/apps/web/scripts/prebuild.mjs
@@ -1,0 +1,58 @@
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const WEB_VERSION_TAG_PREFIX = 'web-v';
+const ENV_KEY = 'NEXT_PUBLIC_WEB_VERSION';
+const WEB_APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const ENV_PATH = resolve(WEB_APP_ROOT, '.env.local');
+
+const parseWebVersionFromRef = ref => {
+  if (!ref?.startsWith(WEB_VERSION_TAG_PREFIX)) return null;
+  return ref.slice(WEB_VERSION_TAG_PREFIX.length);
+};
+
+const getWebVersion = () => {
+  const fromVercelRef = parseWebVersionFromRef(process.env.VERCEL_GIT_COMMIT_REF);
+  if (fromVercelRef) {
+    console.log(fromVercelRef);
+    return fromVercelRef;
+  }
+
+  try {
+    const tag = execSync(
+      `git describe --tags --match "${WEB_VERSION_TAG_PREFIX}*" --abbrev=0`,
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] }
+    ).trim();
+    const fromGitTag = parseWebVersionFromRef(tag);
+    if (fromGitTag) {
+      console.log(fromGitTag);
+      return fromGitTag;
+    }
+  } catch {
+    /** git unavailable or no matching tag */
+  }
+
+  return null;
+};
+
+const insertWebVersionIntoEnv = webVersion => {
+  const line = `${ENV_KEY}=${webVersion}`;
+
+  if (!existsSync(ENV_PATH)) {
+    writeFileSync(ENV_PATH, `${line}\n`);
+    return;
+  }
+
+  const content = readFileSync(ENV_PATH, 'utf-8');
+  const keyPattern = new RegExp(`^${ENV_KEY}=.*$`, 'm');
+  const nextContent = keyPattern.test(content)
+    ? content.replace(keyPattern, line)
+    : `${content.trimEnd()}\n${line}\n`;
+
+  writeFileSync(ENV_PATH, nextContent);
+};
+
+const webVersion = getWebVersion();
+if (webVersion) insertWebVersionIntoEnv(webVersion);

--- a/apps/web/scripts/prebuild.mjs
+++ b/apps/web/scripts/prebuild.mjs
@@ -14,17 +14,11 @@ const parseWebVersionFromRef = ref => {
 };
 
 const getWebVersion = () => {
-  const fromVercelRef = parseWebVersionFromRef(process.env.VERCEL_GIT_COMMIT_REF);
-  if (fromVercelRef) {
-    console.log(fromVercelRef);
-    return fromVercelRef;
-  }
-
   try {
-    const tag = execSync(
-      `git describe --tags --match "${WEB_VERSION_TAG_PREFIX}*" --abbrev=0`,
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] }
-    ).trim();
+    const tag = execSync(`git describe --tags --match "${WEB_VERSION_TAG_PREFIX}*" --abbrev=0`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
     const fromGitTag = parseWebVersionFromRef(tag);
     if (fromGitTag) {
       console.log(fromGitTag);

--- a/apps/web/src/app/login/_components/LoginButtons.tsx
+++ b/apps/web/src/app/login/_components/LoginButtons.tsx
@@ -7,6 +7,7 @@ import GoogleIcon from '@/assets/icons/social/google.svg';
 import KakaoIcon from '@/assets/icons/social/kakao.svg';
 import { useNativeLoginResult } from '@/hooks/useNativeLoginResult';
 import { isValidLoginRedirectPath, setLoginRedirectPath } from '@/utils/loginRedirect';
+import { WebBridge } from '@/utils/webBridge';
 
 import { getAuthUrl } from '../_apis/getAuthUrl';
 import { usePostGuestLogin } from '../_hooks/usePostGuestLogin';
@@ -22,19 +23,10 @@ function LoginButtons({ redirect }: LoginButtonsProps) {
   useNativeLoginResult(validRedirect);
 
   const handleKakaoLogin = async () => {
-    const rnWebView = (
-      window as Window & { ReactNativeWebView?: { postMessage: (msg: string) => void } }
-    ).ReactNativeWebView;
-
-    if (rnWebView) {
-      rnWebView.postMessage(
-        JSON.stringify({
-          type: WEBBRIDGE_MESSAGE_TYPE.REQUEST_SOCIAL_LOGIN,
-          payload: { provider: 'kakao' },
-        })
-      );
-      return;
-    }
+    WebBridge.postMessage({
+      type: WEBBRIDGE_MESSAGE_TYPE.REQUEST_SOCIAL_LOGIN,
+      payload: { provider: 'kakao' },
+    });
 
     setLoginRedirectPath(validRedirect);
     const { url } = await getAuthUrl('kakao', validRedirect);
@@ -42,19 +34,10 @@ function LoginButtons({ redirect }: LoginButtonsProps) {
   };
 
   const handleGoogleLogin = async () => {
-    const rnWebView = (
-      window as Window & { ReactNativeWebView?: { postMessage: (msg: string) => void } }
-    ).ReactNativeWebView;
-
-    if (rnWebView) {
-      rnWebView.postMessage(
-        JSON.stringify({
-          type: WEBBRIDGE_MESSAGE_TYPE.REQUEST_SOCIAL_LOGIN,
-          payload: { provider: 'google' },
-        })
-      );
-      return;
-    }
+    WebBridge.postMessage({
+      type: WEBBRIDGE_MESSAGE_TYPE.REQUEST_SOCIAL_LOGIN,
+      payload: { provider: 'google' },
+    });
 
     setLoginRedirectPath(validRedirect);
     const { url } = await getAuthUrl('google', validRedirect);
@@ -62,19 +45,10 @@ function LoginButtons({ redirect }: LoginButtonsProps) {
   };
 
   const handleAppleLogin = async () => {
-    const rnWebView = (
-      window as Window & { ReactNativeWebView?: { postMessage: (msg: string) => void } }
-    ).ReactNativeWebView;
-
-    if (rnWebView) {
-      rnWebView.postMessage(
-        JSON.stringify({
-          type: WEBBRIDGE_MESSAGE_TYPE.REQUEST_SOCIAL_LOGIN,
-          payload: { provider: 'apple' },
-        })
-      );
-      return;
-    }
+    WebBridge.postMessage({
+      type: WEBBRIDGE_MESSAGE_TYPE.REQUEST_SOCIAL_LOGIN,
+      payload: { provider: 'apple' },
+    });
 
     const { url } = await getAuthUrl('apple', validRedirect);
     window.location.href = url;

--- a/apps/web/src/app/mypage/_components/AppVersionFooter.tsx
+++ b/apps/web/src/app/mypage/_components/AppVersionFooter.tsx
@@ -1,12 +1,28 @@
+import { headers } from 'next/headers';
+
 import { ShoppingBagIconFill } from '@/assets/icons';
+import { isWebview } from '@/utils/webBridge';
 
-import { APP_VERSION_LABEL } from '../_consts/mypage';
+import { getAppVersion } from '../_utils/appVersion';
 
-function AppVersionFooter() {
+async function AppVersionFooter() {
+  const webVersion = process.env.NEXT_PUBLIC_WEB_VERSION;
+  if (!webVersion) return null;
+
+  const headerStore = await headers();
+  const userAgent = headerStore.get('user-agent');
+  const isWebviewEnv = isWebview(userAgent);
+  const appVersion = getAppVersion(userAgent ?? '');
+
+  const versionLabel =
+    isWebviewEnv && appVersion
+      ? `v${appVersion} (w${webVersion})`
+      : `v${webVersion}`;
+
   return (
     <div className="flex h-5 items-center gap-2 pl-5">
       <ShoppingBagIconFill className="size-5 shrink-0 text-text-neutral-tertiary" aria-hidden />
-      <p className="body-2-medium text-text-neutral-tertiary">{APP_VERSION_LABEL}</p>
+      <p className="body-2-medium text-text-neutral-tertiary">{versionLabel}</p>
     </div>
   );
 }

--- a/apps/web/src/app/mypage/_consts/mypage.ts
+++ b/apps/web/src/app/mypage/_consts/mypage.ts
@@ -1,6 +1,3 @@
-/** 앱 버전 표시 라벨 */
-export const APP_VERSION_LABEL = 'v0.6.6 beta';
-
 /** 이용약관·개인정보 처리방침 외부 링크 */
 export const MYPAGE_EXTERNAL_LINKS = {
   TERMS: 'https://piki-service.notion.site/36fc800c72cf808382eee2bae144ad55?source=copy_link',

--- a/apps/web/src/app/mypage/_utils/appVersion.ts
+++ b/apps/web/src/app/mypage/_utils/appVersion.ts
@@ -1,0 +1,8 @@
+import { WEBVIEW_UA_TOKEN } from '@piki/core';
+
+const APP_VERSION_PATTERN = new RegExp(`${WEBVIEW_UA_TOKEN}/([\\d.]+)`, 'i');
+
+export const getAppVersion = (userAgent: string) => {
+  const match = userAgent.match(APP_VERSION_PATTERN);
+  return match?.[1] ?? null;
+};

--- a/apps/web/src/app/mypage/edit/_apis/getNicknameCheck.ts
+++ b/apps/web/src/app/mypage/edit/_apis/getNicknameCheck.ts
@@ -1,9 +1,11 @@
 import { clientApi } from '@/apis/client';
+import { ENDPOINTS } from '@/consts/api';
 import type { ApiResponseT } from '@/types/api';
 
 export const getNicknameCheck = async (nickname: string) => {
   const { data } = await clientApi.get<ApiResponseT<{ available: boolean }>>(
-    `/api/v1/users/nickname/check?nickname=${nickname}`
+    ENDPOINTS.USER_NICKNAME_CHECK,
+    { params: { nickname } }
   );
 
   return { available: data.data.available, detail: data.detail };

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -21,7 +21,7 @@ async function MypagePage() {
       <Header left={<HeaderIcon name="BACK" />} center="설정" centerClassName="title-1" />
       <Spacing size={48} />
 
-      <div className="hide-scrollbar flex flex-1 flex-col overflow-y-auto pb-9">
+      <main className="hide-scrollbar flex flex-1 flex-col overflow-y-auto pb-9">
         {/** 프로필 */}
         <HydrationBoundary state={dehydrate(queryClient)}>
           <ProfileSection />
@@ -34,7 +34,7 @@ async function MypagePage() {
         <Spacing size={24} />
 
         <AppVersionFooter />
-      </div>
+      </main>
     </div>
   );
 }

--- a/apps/web/src/consts/api.ts
+++ b/apps/web/src/consts/api.ts
@@ -2,6 +2,7 @@ export const ENDPOINTS = {
   /** 유저 */
   USER: '/api/v1/users/me',
   USER_PROFILE_IMAGE: '/api/v1/users/me/profile-image',
+  USER_NICKNAME_CHECK: '/api/v1/users/nickname/check',
 
   /** 인증 */
   AUTH_URL: (provider: string) => `/api/v1/auth/${provider}/url`,

--- a/apps/web/src/hooks/useImagePicker.ts
+++ b/apps/web/src/hooks/useImagePicker.ts
@@ -122,10 +122,7 @@ export const useImagePicker = ({
 
     WebBridge.postMessage({
       type: WEBBRIDGE_MESSAGE_TYPE.WEB_REQ_OPEN_IMAGE_PICKER,
-      payload: {
-        requestId,
-        maxCount,
-      },
+      payload: { requestId, maxCount },
     });
 
     void pendingPromise

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "check-types": "turbo run check-types",
     "install:web": "pnpm --filter piki-web install",
     "dev:web": "pnpm --filter piki-web dev",
-    "prebuild:web": "node apps/web/scripts/prebuild.mjs",
     "build:web": "pnpm --filter piki-web build",
     "install:app": "pnpm --filter piki-app install",
     "dev:app": "pnpm --filter piki-app start"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "check-types": "turbo run check-types",
     "install:web": "pnpm --filter piki-web install",
     "dev:web": "pnpm --filter piki-web dev",
+    "prebuild:web": "node apps/web/scripts/prebuild.mjs",
     "build:web": "pnpm --filter piki-web build",
     "install:app": "pnpm --filter piki-app install",
     "dev:app": "pnpm --filter piki-app start"


### PR DESCRIPTION
## 작업 요약

- 마이페이지에서 웹 및 앱 버전 표기 기능 추가

## 작업 세부 내용

### 웹·앱 버전 표시
**웹 버전 추출 방식**
- prebuild 스크립트를 통해 `web-v*` git 태그에서 웹 버전을 추출하여 `.env.local`의 `NEXT_PUBLIC_WEB_VERSION`에 자동 주입
- `dev`/`build` 실행 전 `prebuild` 스크립트 연동 (`apps/web`, 루트 `prebuild:web`)

**앱 버전 추출 방식**
- 앱 User-Agent에 Expo 앱 버전 포함 (`WEBVIEW_UA_TOKEN/{version}`)
- user agent 정보 파싱을 통해 버전 앱 버전 확인  

- 마이페이지 하단 `AppVersionFooter`에서 버전 표시
  - 웹 환경인 경우: `v{webVersion}`
  - 앱 WebView: `v{appVersion} (w{webVersion})`
- 하드코딩된 `APP_VERSION_LABEL` 상수 제거

### 프로필·이미지 관련 수정
- `BaseImage`: `src` 변경 시 이전 로딩/에러 fallback이 계속 노출되던 문제 수정 (`key` 기반 remount)
- 닉네임 중복 체크 API: `ENDPOINTS.USER_NICKNAME_CHECK` 상수 사용 및 `params` 주입 방식으로 변경
- `usePatchMe`: 프로필 수정 성공 후 `invalidateQueries` 비동기 처리 추가

### 기타 리팩토링
- `LoginButtons`: `ReactNativeWebView.postMessage` 직접 호출 → `WebBridge` + `isWebview()` 유틸로 통일
- 마이페이지 본문 컨테이너 `div` → `main` 시맨틱 태그 적용
- Android `RECORD_AUDIO` 권한 제거 (미사용)

## 연관 이슈

closes #179 
