### PR TITLE
fix: FCM 토큰 갱신 관련 프록시 버그 수정

### DIFF
--- a/apps/app/utils/pushNotification.ts
+++ b/apps/app/utils/pushNotification.ts
@@ -116,8 +116,7 @@ export const initializePushNotification = async () => {
 
 /** 앱 백그라운드/포그라운드 FCM 메시지 수신 처리 */
 export const setupMessagingListeners = () => {
-  const unsubscribeOnMessage = onMessage(messaging, async remoteMessage => {
-    console.log('[FCM] Foreground message:', remoteMessage.messageId);
+  const unsubscribeOnMessage = onMessage(messaging, async _remoteMessage => {
     // 💡 나중에 Notifee가 들어오면 바로 여기에 Notifee.displayNotification() 코드를 넣으면 됩니다!
   });
 

--- a/apps/app/utils/webBridge.ts
+++ b/apps/app/utils/webBridge.ts
@@ -33,6 +33,5 @@ export const WebBridge = {
       .join('\n');
 
     target.injectJavaScript(`${js}\ntrue;`);
-    console.log('[WEBVIEW] 쿠키 주입 완료:', Object.keys(cookies).join(', '));
   },
 };

--- a/apps/web/src/apis/client.ts
+++ b/apps/web/src/apis/client.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 
 import { CLIENT_TYPE } from '@/consts/webBridge';
 import type { ApiErrorResponseT } from '@/types/api';
-import { getCookie } from '@/utils/cookie';
+import { getCookie, setCookie } from '@/utils/cookie';
 import { isWebview } from '@/utils/webBridge';
 
 // 재시도 여부 플래그를 포함한 요청 타입
@@ -63,9 +63,13 @@ clientApi.interceptors.response.use(
       isRefreshing = true;
 
       try {
-        await axios.post('/api/v1/auth/token/refresh', null, {
+        const { data } = await axios.post('/api/v1/auth/token/refresh', null, {
           withCredentials: true,
         });
+        // 웹뷰 환경은 Bearer 토큰 방식이므로 refresh 후 새 토큰을 쿠키에 저장
+        if (isWebview() && data?.data?.accessToken) {
+          setCookie('access_token', data.data.accessToken);
+        }
         processQueue(null);
         return clientApi(originalRequest);
       } catch (refreshError) {

--- a/apps/web/src/app/api/v1/[...path]/route.ts
+++ b/apps/web/src/app/api/v1/[...path]/route.ts
@@ -20,11 +20,19 @@ async function handler(request: NextRequest, { params }: { params: Promise<{ pat
   forwardHeaders.delete('origin');
   forwardHeaders.delete('referer');
 
+  // request.body(ReadableStream)를 직접 전달하면 undici가 "expected non-null body source" 에러를 던질 수 있음
+  const isBodyMethod = !['GET', 'HEAD'].includes(request.method);
+  let body: ArrayBuffer | null = null;
+  if (isBodyMethod) {
+    const buffer = await request.arrayBuffer();
+    body = buffer.byteLength > 0 ? buffer : null;
+  }
+
   const response = await fetch(backendUrl, {
     method: request.method,
     headers: forwardHeaders,
-    body: ['GET', 'HEAD'].includes(request.method) ? null : request.body,
-    duplex: 'half',
+    body,
+    ...(body ? { duplex: 'half' } : {}),
   } as RequestInit);
 
   return new NextResponse(response.body, {

--- a/apps/web/src/app/api/v1/[...path]/route.ts
+++ b/apps/web/src/app/api/v1/[...path]/route.ts
@@ -28,6 +28,11 @@ async function handler(request: NextRequest, { params }: { params: Promise<{ pat
     body = buffer.byteLength > 0 ? buffer : null;
   }
 
+  // body가 없는데 Content-Type이 전달되면 백엔드가 415를 반환하므로 제거
+  if (!body) {
+    forwardHeaders.delete('content-type');
+  }
+
   const response = await fetch(backendUrl, {
     method: request.method,
     headers: forwardHeaders,


### PR DESCRIPTION
## 작업 요약
- 프록시에서 `request.body` 스트림을 그대로 전달해 발생하던 FCM 토큰 등록 500 에러 수정
- body 없는 요청에 `Content-Type: application/json`이 전달되어 발생하던 토큰 갱신 415 에러 수정
- refresh 성공 후 새 `accessToken`이 쿠키에 저장되지 않아 FCM 재시도에서도 401이 발생하던 문제 수정

## 작업 세부 내용

### FCM 토큰 등록 500 에러
**파일**: `apps/web/src/app/api/v1/[...path]/route.ts`

- `request.body`(ReadableStream)를 그대로 백엔드 fetch에 넘기면 undici가 스트림을 처리하다 500 에러를 던지는 문제
- `arrayBuffer()`로 데이터를 먼저 모두 읽어 메모리에 올린 뒤 전달하도록 수정. body가 비어있으면 `null`을 명시

```ts
// before
body: ['GET', 'HEAD'].includes(request.method) ? null : request.body,
duplex: 'half',

// after
const isBodyMethod = !['GET', 'HEAD'].includes(request.method);
let body: ArrayBuffer | null = null;
if (isBodyMethod) {
  const buffer = await request.arrayBuffer();
  body = buffer.byteLength > 0 ? buffer : null;
}
```

---

### 토큰 갱신 415 에러
**파일**: `apps/web/src/app/api/v1/[...path]/route.ts`

- Axios가 body 없는 요청에도 `Content-Type: application/json`을 자동으로 추가하고 프록시가 이를 그대로 전달하면 백엔드가 415를 반환하는 문제
- body가 없다고 판단되면 프록시 단에서 `Content-Type` 헤더를 제거하고 전달하도록 수정

**에러 발생 흐름**

```
FCM 토큰 요청
  → 401 (access_token 만료)
  → 인터셉터 자동 refresh 시도
  → POST /api/v1/auth/token/refresh (body 없음)
  → Axios가 Content-Type: application/json 자동 추가
  → 프록시가 헤더 그대로 전달
  → 백엔드: body 없는데 Content-Type이 JSON → 415
```

```ts
// body가 없는데 Content-Type이 전달되면 백엔드가 415를 반환하므로 제거
if (!body) {
  forwardHeaders.delete('content-type');
}
```

---

### refresh 성공 후 FCM 재시도 401 에러
**파일**: `client.ts`

- WebView 환경은 Bearer 토큰 방식인데, refresh 후 새 `accessToken`을 쿠키에 저장하지 않아 retry 시 만료된 토큰을 그대로 사용하는 문제
- 인터셉터에서 refresh 응답의 `accessToken`을 쿠키에 저장하도록 수정



## 연관 이슈

closes #180 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 웹뷰 환경에서 토큰 갱신 후 쿠키가 정상적으로 업데이트되도록 개선했습니다.
  * API 요청 전달 방식을 개선하여 요청 처리 안정성을 강화했습니다.

* **기타**
  * 개발 디버그 로그를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->