### PR TITLE
fix: 로그인 성공 시 다시 로그인 페이지로 리다이렉트되는 오류 수정

### DIFF
--- a/apps/web/src/components/notification-sse-provider/index.tsx
+++ b/apps/web/src/components/notification-sse-provider/index.tsx
@@ -9,9 +9,12 @@ import { useNotificationSSE } from '@/hooks/useNotificationSSE';
 
 const AUTH_EXCLUDED_PATHS = [ROUTES.LOGIN, ROUTES.ROOT] as const;
 
+const isAuthCallbackPath = (pathname: string) => /^\/auth\/callback\/[^/]+$/.test(pathname);
+
 function NotificationSSEProvider() {
   const pathname = usePathname();
-  const isAuthPage = AUTH_EXCLUDED_PATHS.some(path => pathname === path);
+  const isAuthPage =
+    AUTH_EXCLUDED_PATHS.some(path => pathname === path) || isAuthCallbackPath(pathname);
 
   const { data: meData } = useQuery({
     queryKey: ['me'],


### PR DESCRIPTION
## 작업 요약

- 소셜 로그인 성공 시 로그인 페이지로 리다이렉트되는 오류 수정

## 작업 내용

### 문제

소셜 로그인(OAuth) 콜백(`/auth/callback/{provider}`) 도착 후 `postSocialLogin`이 완료되기 전에 로그인 페이지로 리다이렉트되어, 로그인이 반복 실패하는 현상이 발생했습니다.

증상:

- Google/Kakao 로그인 후 `/login?redirect=/auth/callback/google?...` 으로 이동
- OAuth `code`가 1회용이라 재시도해도 로그인 불가
- dev 환경에서는 로그인 성공 후 "로그인에 실패했습니다" 토스트가 잠깐 뜨는 경우도 있음

### 원인

소셜 로그인 콜백 페이지에서 `NotificationSSEProvider`가 `getMe()`를 호출하고 있었습니다.

```
/auth/callback/google 도착
  → NotificationSSEProvider: getMe() 호출 (아직 인증 쿠키 없음)
  → 401 응답
  → clientApi 401 인터셉터: refresh 실패 시 /login?redirect={현재 URL} 로 리다이렉트
  → redirect URL에 콜백 URL(/auth/callback/google?code=...) 이 그대로 저장됨
  → postSocialLogin 완료 전에 페이지 이탈 → code 소진 → 로그인 실패 루프
```

`/login`, `/`만 `getMe` 호출을 제외하고 있었고, `/auth/callback/*`는 제외 대상에 포함되지 않았습니다.

### 해결

`NotificationSSEProvider`에서 소셜 로그인 콜백 경로(`/auth/callback/{provider}`)도 인증 API 호출 제외 대상에 추가했습니다.

- 콜백 페이지에서는 `getMe` query `enabled: false`
- `postSocialLogin`이 끝날 때까지 외부 API 호출·401 리다이렉트가 끼어들지 않도록 차단



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* 인증 페이지 판정 로직을 개선했습니다. 기존의 로그인 페이지, 루트 경로와 함께 인증 콜백 페이지가 인증 페이지로 간주되어 알림 기능이 일관되게 제한됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->