### PR TITLE
style: 위시/아이템 수정 페이지 스타일 오류 수정 및 Layout 정리

### DIFF
--- a/apps/web/src/app/archive/_components/WishlistLayout.tsx
+++ b/apps/web/src/app/archive/_components/WishlistLayout.tsx
@@ -11,7 +11,7 @@ type WishlistLayoutProps = {
 function WishlistLayout({ children }: WishlistLayoutProps) {
   return (
     <div className="flex min-h-dvh flex-col bg-bg-layer-basement px-5">
-      <div className="sticky top-0 z-10 inline-flex w-full flex-col items-start gap-5 bg-bg-layer-basement pt-status pb-6">
+      <div className="sticky top-0 z-10 inline-flex w-full flex-col items-start gap-5 bg-bg-layer-basement pt-padding-top pb-6">
         <div className="flex w-full flex-col gap-[5px]">
           <Header
             right={

--- a/apps/web/src/app/archive/wish/[id]/_components/EditContent.tsx
+++ b/apps/web/src/app/archive/wish/[id]/_components/EditContent.tsx
@@ -14,7 +14,7 @@ function EditContent({ wishId }: EditContentProps) {
   const { wishData } = useGetWish(wishId);
 
   return (
-    <div className="hide-scrollbar overflow-y-auto bg-bg-layer-basement pb-[78px]">
+    <div className="hide-scrollbar overflow-y-auto bg-bg-layer-basement px-5 pt-padding-top pb-[78px]">
       <Header left={<HeaderIcon name="BACK" />} />
       <main>
         <header className="mt-3 flex flex-col items-center gap-2 text-center">

--- a/apps/web/src/app/auth/callback/[provider]/_components/CallbackHandler.tsx
+++ b/apps/web/src/app/auth/callback/[provider]/_components/CallbackHandler.tsx
@@ -70,7 +70,7 @@ function CallbackHandler() {
   }, [isValidProvider, postSocialLoginMutation, provider, router, searchParams]);
 
   return (
-    <div className="flex h-dvh flex-col items-center justify-center gap-3">
+    <div className="flex h-dvh flex-col items-center justify-center gap-3 pt-padding-top">
       <Spinner size={32} />
       <p className="text-sm text-text-neutral-secondary">로그인 중...</p>
     </div>

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -16,7 +16,7 @@ export default function Error({ error, reset }: Props) {
   const isClientError = statusCode >= 400 && statusCode < 500;
 
   return (
-    <div className="flex h-full w-full flex-col items-center justify-center gap-8 bg-white px-5">
+    <div className="flex h-full w-full flex-col items-center justify-center gap-8 bg-white px-5 pt-padding-top">
       <div className="w-full text-center">
         <p className="title-lg mb-2">
           {isClientError ? '요청 오류가 발생했습니다' : '서버 오류가 발생했습니다'}

--- a/apps/web/src/app/home/page.tsx
+++ b/apps/web/src/app/home/page.tsx
@@ -20,7 +20,7 @@ async function HomePage() {
   });
 
   return (
-    <div className="relative flex min-h-dvh flex-col bg-gray-50 px-5 pt-status pb-32">
+    <div className="relative flex min-h-dvh flex-col bg-gray-50 px-5 pt-padding-top pb-32">
       {/* 상단 헤더 */}
       <Header
         right={

--- a/apps/web/src/app/invite/[id]/_components/InviteClient.tsx
+++ b/apps/web/src/app/invite/[id]/_components/InviteClient.tsx
@@ -51,7 +51,7 @@ function InviteClient({ tournamentId, inviteCode }: InviteClientProps) {
 
   if (state === 'loading') {
     return (
-      <main className="flex min-h-dvh items-center justify-center bg-bg-layer-basement">
+      <main className="flex min-h-dvh items-center justify-center bg-bg-layer-basement pt-padding-top">
         <div className="flex flex-col items-center gap-3">
           <Spinner size={32} />
           <p className="body-1-medium text-text-neutral-tertiary">초대 정보를 확인하고 있어요...</p>
@@ -61,7 +61,7 @@ function InviteClient({ tournamentId, inviteCode }: InviteClientProps) {
   }
 
   return (
-    <main className="flex min-h-dvh flex-col items-center justify-center gap-6 bg-bg-layer-basement px-5">
+    <main className="flex min-h-dvh flex-col items-center justify-center gap-6 bg-bg-layer-basement px-5 pt-padding-top">
       <div className="flex flex-col items-center gap-2">
         <p className="heading-1 text-text-neutral-primary">초대 링크가 유효하지 않아요</p>
         <p className="text-center body-1-medium text-text-neutral-tertiary">

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
 /**
  * iOS 26 Safari 부터 `<meta name="theme-color">` 가 무시돼 노치/홈 인디케이터 영역이
  * body 배경색을 따른다. 이 영역까지 우리 콘텐츠가 칠해지도록 viewport-fit=cover 를 켜고,
- * 페이지에서는 `env(safe-area-inset-*)` 로 패딩을 잡는다.
+ * 페이지에서는 `pt-padding-top` 으로 패딩을 잡는다.
  */
 export const viewport: Viewport = {
   width: 'device-width',
@@ -71,10 +71,10 @@ async function RootLayout({
           </>
         )}
       </head>
-      <body className="h-full overflow-hidden" suppressHydrationWarning>
+      <body className="h-full overflow-hidden">
         <Providers>
           {/** TEMP: max width 임시 값 */}
-          <div className="mx-auto hide-scrollbar h-full max-w-120 overflow-y-auto pt-[max(env(safe-area-inset-top),47px)] pb-[max(env(safe-area-inset-bottom),0px)] [scrollbar-gutter:stable]">
+          <div className="mx-auto hide-scrollbar h-full max-w-120 overflow-y-auto pb-[max(env(safe-area-inset-bottom),0px)] [scrollbar-gutter:stable]">
             {children}
           </div>
         </Providers>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -10,7 +10,7 @@ async function LoginPage({ searchParams }: LoginPageProps) {
   const { redirect } = await searchParams;
 
   return (
-    <div className="flex min-h-full flex-col items-center bg-gray-50 pt-28">
+    <div className="flex min-h-full flex-col items-center bg-gray-50 pt-padding-top">
       <div className="flex flex-col items-center gap-6">
         <PikiLogo aria-label="PIKI" />
         <p className="text-center body-1-bold whitespace-pre-line text-text-neutral-secondary">

--- a/apps/web/src/app/mypage/edit/page.tsx
+++ b/apps/web/src/app/mypage/edit/page.tsx
@@ -15,7 +15,7 @@ async function MypageEditPage() {
   });
 
   return (
-    <div className="flex h-dvh flex-col bg-bg-layer-basement px-5 pt-status">
+    <div className="flex h-dvh flex-col bg-bg-layer-basement px-5 pt-padding-top">
       <Header
         left={<HeaderIcon name="BACK" className="size-7.5" />}
         center="내 프로필 수정"

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -17,7 +17,7 @@ async function MypagePage() {
   });
 
   return (
-    <div className="flex h-dvh flex-col bg-bg-layer-basement px-5 pt-status">
+    <div className="flex h-dvh flex-col bg-bg-layer-basement px-5 pt-padding-top">
       <Header left={<HeaderIcon name="BACK" />} center="설정" centerClassName="title-1" />
       <Spacing size={48} />
 

--- a/apps/web/src/app/mypage/withdraw/page.tsx
+++ b/apps/web/src/app/mypage/withdraw/page.tsx
@@ -11,7 +11,7 @@ async function MypageWithdrawPage() {
   const userData = await getMe();
 
   return (
-    <div className="flex h-dvh flex-col items-center bg-bg-layer-basement px-5 pt-status">
+    <div className="flex h-dvh flex-col items-center bg-bg-layer-basement px-5 pt-padding-top">
       <Header
         left={<HeaderIcon name="BACK" />}
         center="회원탈퇴"

--- a/apps/web/src/app/notification/_components/NotificationContent.tsx
+++ b/apps/web/src/app/notification/_components/NotificationContent.tsx
@@ -36,7 +36,7 @@ function NotificationContent() {
   };
 
   return (
-    <div className="flex h-dvh flex-col bg-gray-50 px-7 pt-20">
+    <div className="flex h-dvh flex-col bg-gray-50 px-5 pt-padding-top">
       <Header left={<HeaderIcon name="BACK" />} center="알림 히스토리" centerClassName="title-1" />
       <Spacing size={16} />
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -12,7 +12,7 @@ async function Page() {
   }
 
   return (
-    <div className="flex h-screen flex-col items-center justify-center gap-8 bg-white px-5">
+    <div className="flex h-screen flex-col items-center justify-center gap-8 bg-white px-5 pt-padding-top">
       <h1 className="title-1">PIKI</h1>
 
       {user && (

--- a/apps/web/src/app/play/[id]/_components/PlayClient.tsx
+++ b/apps/web/src/app/play/[id]/_components/PlayClient.tsx
@@ -84,7 +84,7 @@ function PlayClient({ sourceTournamentId }: PlayClientProps) {
 
   if (state === 'loading') {
     return (
-      <main className="flex min-h-dvh items-center justify-center bg-bg-layer-basement">
+      <main className="flex min-h-dvh items-center justify-center bg-bg-layer-basement pt-padding-top">
         <div className="flex flex-col items-center gap-3">
           <Spinner size={32} />
           <p className="body-1-medium text-text-neutral-tertiary">토너먼트를 준비하고 있어요...</p>
@@ -94,7 +94,7 @@ function PlayClient({ sourceTournamentId }: PlayClientProps) {
   }
 
   return (
-    <main className="flex min-h-dvh flex-col items-center justify-center gap-6 bg-bg-layer-basement px-5">
+    <main className="flex min-h-dvh flex-col items-center justify-center gap-6 bg-bg-layer-basement px-5 pt-padding-top">
       <div className="flex flex-col items-center gap-2">
         <p className="heading-1 text-text-neutral-primary">플레이 링크가 유효하지 않아요</p>
         <p className="text-center body-1-medium text-text-neutral-tertiary">

--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -89,7 +89,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
   const handleCloseConfirm = () => setConfirmPayload(null);
 
   return (
-    <div className="flex h-dvh min-h-0 flex-col gap-4 bg-bg-layer-basement pt-status pb-8">
+    <div className="flex h-dvh min-h-0 flex-col gap-4 bg-bg-layer-basement pt-padding-top pb-8">
       <div className="space-y-4 px-5">
         <TournamentHeader name={tournamentData.name} hasFriends={hasFriends} />
         <ParticipantPanel

--- a/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
@@ -48,7 +48,7 @@ function ByWishContent({ tournamentId }: ByWishContentProps) {
   };
 
   return (
-    <div className="flex h-full flex-col bg-bg-layer-basement px-5">
+    <div className="flex h-full flex-col bg-bg-layer-basement px-5 pt-padding-top">
       <WishSelectHeader
         selectedCount={selectedIds.length}
         totalCount={items.length}

--- a/apps/web/src/app/tournament/[id]/create/by-wish/_components/WishSelectHeader.tsx
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_components/WishSelectHeader.tsx
@@ -35,7 +35,7 @@ function WishSelectHeader({
   };
 
   return (
-    <div className="mt-20 flex flex-col gap-[25px]">
+    <div className="flex flex-col gap-[25px]">
       <div className="flex flex-col gap-2">
         <h1 className="title-1 text-gray-950">비교할 위시템을 선택해주세요</h1>
         <div className="min-h-[52px]">{renderSubtitle()}</div>

--- a/apps/web/src/app/tournament/[id]/create/layout.tsx
+++ b/apps/web/src/app/tournament/[id]/create/layout.tsx
@@ -4,8 +4,8 @@ import Skeleton from '@/components/skeleton';
 
 function LoadingFallback() {
   return (
-    <div className="flex min-h-screen flex-col bg-gray-50 px-5">
-      <div className="flex flex-1 flex-col gap-4 pt-status">
+    <div className="flex min-h-screen flex-col bg-gray-50 px-5 pt-padding-top">
+      <div className="flex flex-1 flex-col gap-4">
         <div className="flex flex-col items-center">
           <Skeleton className="h-7 w-48" />
         </div>

--- a/apps/web/src/app/tournament/[id]/item/[itemId]/_components/EditContent.tsx
+++ b/apps/web/src/app/tournament/[id]/item/[itemId]/_components/EditContent.tsx
@@ -18,7 +18,7 @@ function EditContent({ tournamentId, tournamentItemId }: EditContentProps) {
   return (
     <div
       className={cn(
-        'hide-scrollbar min-h-dvh overflow-y-auto px-5 pb-[78px]',
+        'hide-scrollbar min-h-dvh overflow-y-auto px-5 pt-padding-top pb-[78px]',
         tournamentItemData.status === 'FAILED' ? 'bg-bg-layer-basement' : 'bg-bg-layer-default'
       )}
     >

--- a/apps/web/src/app/tournament/[id]/loading/page.tsx
+++ b/apps/web/src/app/tournament/[id]/loading/page.tsx
@@ -21,7 +21,7 @@ function TournamentLoadingPage() {
   }, [router]);
 
   return (
-    <main className="flex min-h-dvh flex-col pt-6 pb-6">
+    <main className="flex min-h-dvh flex-col pt-padding-top pb-6">
       <header className="flex flex-col gap-2 tracking-[-0.6px]">
         <h1 className="text-[28px] leading-10 font-bold text-text-neutral-primary">
           대진표를 만드는 중이에요

--- a/apps/web/src/app/tournament/[id]/match/_components/RoundTransition.tsx
+++ b/apps/web/src/app/tournament/[id]/match/_components/RoundTransition.tsx
@@ -54,7 +54,7 @@ function RoundTransition({
 
   return (
     <main
-      className={`flex min-h-dvh w-full flex-col items-center px-5 pt-12 ${containerClassName}`}
+      className={`flex min-h-dvh w-full flex-col items-center px-5 pt-padding-top ${containerClassName}`}
     >
       <div className="flex flex-col items-center gap-4">
         {isFinal ? (

--- a/apps/web/src/app/tournament/[id]/match/_components/TournamentClient.tsx
+++ b/apps/web/src/app/tournament/[id]/match/_components/TournamentClient.tsx
@@ -42,7 +42,7 @@ function TournamentClient({ tournamentId, tournamentName, inProgress }: Tourname
 
   return (
     <main
-      className={`hide-scrollbar flex min-h-dvh flex-col items-center overflow-y-auto px-5 pt-12 pb-6 ${backgroundClassName}`}
+      className={`hide-scrollbar flex min-h-dvh flex-col items-center overflow-y-auto px-5 pt-padding-top pb-6 ${backgroundClassName}`}
     >
       <div className="flex flex-col items-center gap-6">
         <div className="flex flex-col items-center gap-4">

--- a/apps/web/src/app/tournament/[id]/match/loading.tsx
+++ b/apps/web/src/app/tournament/[id]/match/loading.tsx
@@ -1,6 +1,6 @@
 function TournamentLoading() {
   return (
-    <main className="flex min-h-dvh items-center justify-center bg-bg-layer-basement">
+    <main className="flex min-h-dvh items-center justify-center bg-bg-layer-basement pt-padding-top">
       <p className="body-1-medium text-text-neutral-tertiary">토너먼트 준비 중...</p>
     </main>
   );

--- a/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
@@ -4,9 +4,9 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
-import { ChevronBackwardIconFill } from '@/assets/icons/fill';
 import ReceiptIcon from '@/assets/images/tournament/result/receipt-icon.svg';
 import SmileIcon from '@/assets/images/tournament/result/smile-icon.svg';
+import { Header, HeaderIcon } from '@/components/header';
 import { ROUTES } from '@/consts/route';
 import { cn } from '@/utils/cn';
 
@@ -38,7 +38,7 @@ function ResultClient({ tournamentId }: ResultClientProps) {
 
   if (tournamentData.status !== 'COMPLETED') {
     return (
-      <main className="flex min-h-dvh items-center justify-center bg-bg-layer-basement">
+      <main className="flex min-h-dvh items-center justify-center bg-bg-layer-basement pt-padding-top">
         <p className="body-1-medium text-text-neutral-tertiary">결과를 불러오는 중...</p>
       </main>
     );
@@ -74,22 +74,10 @@ function ResultClient({ tournamentId }: ResultClientProps) {
   };
 
   return (
-    <main className="flex min-h-dvh flex-col overflow-x-hidden bg-bg-layer-basement pt-status pb-30">
-      <header className="relative flex h-7.5 w-full shrink-0 items-center px-5">
-        <button
-          type="button"
-          aria-label="뒤로가기"
-          onClick={() => router.back()}
-          className="cursor-pointer p-0.75"
-        >
-          <ChevronBackwardIconFill className="size-6 text-icon-neutral-secondary" />
-        </button>
-        <h1 className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 heading-1 text-text-neutral-primary">
-          토너먼트 결과
-        </h1>
-      </header>
+    <main className="flex min-h-dvh flex-col overflow-x-hidden bg-bg-layer-basement pt-padding-top pb-30">
+      <Header center="토너먼트 결과" centerClassName="title-1" left={<HeaderIcon name="BACK" />} />
 
-      <div className="mx-auto mt-3 flex min-h-0 w-full max-w-105 flex-1 flex-col gap-3 px-5">
+      <div className="mx-auto mt-3 flex min-h-0 w-full max-w-105 flex-1 flex-col gap-3">
         <ReceiptDrawMachine
           ref={receiptMachineRef}
           tournamentName={tournamentName}

--- a/apps/web/src/app/tournament/[id]/result/group/_components/GroupResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/group/_components/GroupResultClient.tsx
@@ -61,7 +61,7 @@ function GroupResultClient({ tournamentId }: GroupResultClientProps) {
   // 친구가 아직 본인 매치를 시작 안 했거나, 권한 없음 등으로 데이터를 받지 못한 경우.
   if (isGroupResultPending || isGroupResultError || !groupResultData) {
     return (
-      <main className="flex min-h-dvh flex-col bg-bg-layer-basement pt-status pb-8">
+      <main className="flex min-h-dvh flex-col bg-bg-layer-basement pt-padding-top pb-8">
         <header className="relative flex h-7.5 w-full shrink-0 items-center px-5">
           <button
             type="button"
@@ -92,7 +92,7 @@ function GroupResultClient({ tournamentId }: GroupResultClientProps) {
   const otherItems = sortedItems.filter(item => item.rank !== 1);
 
   return (
-    <main className="flex min-h-dvh flex-col bg-bg-layer-basement pt-status pb-8">
+    <main className="flex min-h-dvh flex-col bg-bg-layer-basement pt-padding-top pb-8">
       <header className="relative flex h-7.5 w-full shrink-0 items-center px-5">
         <button
           type="button"

--- a/apps/web/src/app/tournament/join/[id]/_components/JoinPreviewClient.tsx
+++ b/apps/web/src/app/tournament/join/[id]/_components/JoinPreviewClient.tsx
@@ -67,7 +67,7 @@ function JoinPreviewClient({ tournamentId, inviteCode }: JoinPreviewClientProps)
   };
 
   return (
-    <main className="flex min-h-dvh flex-col bg-bg-layer-default pt-status pb-8">
+    <main className="flex min-h-dvh flex-col bg-bg-layer-default pt-padding-top pb-8">
       <Header
         center="초대 참여하기"
         centerClassName="heading-1 text-text-neutral-primary"

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -134,7 +134,7 @@
   --color-icon-accent: var(--color-blue-500);
 
   /** User Accent Color */
-  --color-uac-light: #0A7AFF;
+  --color-uac-light: #0a7aff;
   --color-icon-warning: var(--color-yellow-600);
   --color-icon-error: var(--color-red-600);
   --color-icon-success: var(--color-green-600);
@@ -143,6 +143,8 @@
   --color-icon-neutral-primary: var(--color-gray-600);
   --color-icon-neutral-secondary: var(--color-gray-300);
   --color-icon-neutral-inverse: var(--color-base-50);
+
+  --spacing-padding-top: max(env(safe-area-inset-top), 47px);
 }
 
 @utility hide-scrollbar {
@@ -173,14 +175,6 @@ body {
  *   디자인이 의도한 추가 여백만 더한다.
  * - bottom: 12px (콘텐츠와 홈 인디케이터/내비게이션 사이 마진)
  */
-@utility pt-status {
-  padding-top: 0;
-}
-
-html[data-app] .pt-status {
-  padding-top: 14px;
-}
-
-@utility pb-bottom {
-  padding-bottom: 12px;
+html[data-app] {
+  --spacing-padding-top: max(env(safe-area-inset-top) + 14px, 47px);
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -161,7 +161,7 @@
  */
 html,
 body {
-  background-color: var(--color-bg-layer-basement);
+  background-color: var(--color-neutral-50);
 }
 
 /**


### PR DESCRIPTION
## 작업 요약
- 

## 작업 세부 내용
<img width="688" height="667" alt="image" src="https://github.com/user-attachments/assets/5536692c-5ca1-4a21-b042-28eaeafb6c3c" />

1. pt 값을 root layout에서 적용하여 root layout에 적용된 bg 값과 페이지의 bg값이 다른 경우, padding top 부분만 색이 다른 경우가 존재했습니다. 이를 방지하기 위해 root layout에서 제어하던 페이지 pt 값을 css variable로 생성하고, 각 페이지에서 적용하도록 변경했습니다. 

2. 위시/토너먼트 아이템 수정 페이지에서 레이아웃이 무너지는 문제를 해결했습니다.

## 스크린샷

<img width="619" height="799" alt="스크린샷 2026-06-15 오후 4 04 46" src="https://github.com/user-attachments/assets/9769dd08-bc9a-400c-9f30-811590bdfcb0" />

## 연관 이슈

close #192 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 스타일
- 앱 전반에서 상단 여백 처리를 안전 영역(safe-area) 기준으로 표준화해, 홈·로그인·마이페이지·알림·토너먼트·초대/위시리스트 등 다양한 화면의 상단 배치가 더 일관되게 표시됩니다.
- iOS Safari의 노치/홈 인디케이터 영역에서 상단 여백 적용이 개선되었습니다.
- 전역 배경색 및 디자인 토큰을 업데이트해 시각적 일관성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->