### PR TITLE
feat: 장바구니 상태 라벨 및 친구 초대 패널 UI 개선

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -96,7 +96,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
             participants={participants}
             inviteCode={pending?.inviteCode ?? ''}
             inviteExpiresAt={pending?.inviteExpiresAt ?? ''}
-            depositDeadline={!ownerStarted && !isDepositClosed ? depositDeadline : undefined}
+            {...(!ownerStarted && !isDepositClosed && { depositDeadline })}
           />
         </div>
       </div>

--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -21,6 +21,7 @@ import { useScrollToLast } from '../_hooks/useScrollToLast';
 import MemberJoinConfirmDialog from './member-join-confirm-dialog/MemberJoinConfirmDialog';
 import ParticipantPanel from './participant-panel/ParticipantPanel';
 import TournamentHeader from './tournament-header/TournamentHeader';
+import TournamentItemBasketStatus from './tournament-item-basket-status/TournamentItemBasketStatus';
 import TournamentItemBasketCarousel from './tournament-item-basket/TournamentItemBasketCarousel';
 import TournamentStartButton from './tournament-start-button/TournamentStartButton';
 import WelcomeJoinDialog from './welcome-join-dialog/WelcomeJoinDialog';
@@ -100,11 +101,16 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
         </div>
       </div>
 
-      <div className="mt-[5.9dvh] flex min-h-0 flex-1 flex-col">
+      <div className="mt-[5.9dvh] flex min-h-0 flex-1 flex-col gap-5">
         <TournamentItemBasketCarousel
           items={pending?.items}
           scrollToLast={scrollToLast}
           onScrolled={onScrolled}
+          isDepositClosed={isDepositClosed}
+        />
+        <TournamentItemBasketStatus
+          isProcessing={hasPendingItem}
+          count={pending?.items.length ?? 0}
           isDepositClosed={isDepositClosed}
         />
       </div>

--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -18,7 +18,6 @@ import {
 import { useGetTournament } from '../../_common/_hooks/useGetTournament';
 import { useCountdown } from '../_hooks/useCountdown';
 import { useScrollToLast } from '../_hooks/useScrollToLast';
-import DepositCountdown from './deposit-countdown/DepositCountdown';
 import MemberJoinConfirmDialog from './member-join-confirm-dialog/MemberJoinConfirmDialog';
 import ParticipantPanel from './participant-panel/ParticipantPanel';
 import TournamentHeader from './tournament-header/TournamentHeader';
@@ -96,6 +95,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
             participants={participants}
             inviteCode={pending?.inviteCode ?? ''}
             inviteExpiresAt={pending?.inviteExpiresAt ?? ''}
+            depositDeadline={!ownerStarted && !isDepositClosed ? depositDeadline : undefined}
           />
         </div>
       </div>
@@ -110,9 +110,6 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
       </div>
 
       <div className="flex shrink-0 flex-col gap-3 px-5 pt-[max(6dvh)]">
-        {hasFriends && !ownerStarted && !isDepositClosed && (
-          <DepositCountdown deadline={depositDeadline} />
-        )}
         <TournamentStartButton
           count={pending?.items.length ?? 0}
           tournamentId={tournamentId}

--- a/apps/web/src/app/tournament/[id]/create/_components/deposit-countdown/DepositCountdown.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/deposit-countdown/DepositCountdown.tsx
@@ -14,7 +14,7 @@ function DepositCountdown({ deadline, showLabel = true }: DepositCountdownProps)
 
   return (
     <div className="flex items-center justify-center gap-1.5 text-text-accent">
-      <TimerIconFill className="size-4" />
+      <TimerIconFill className="size-5" />
       <p className="body-2-semibold">
         {remaining ?? '--:--:--'}
         {showLabel && ' 후 담기 종료'}

--- a/apps/web/src/app/tournament/[id]/create/_components/deposit-countdown/DepositCountdown.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/deposit-countdown/DepositCountdown.tsx
@@ -6,15 +6,19 @@ import { useCountdown } from '../../_hooks/useCountdown';
 
 type DepositCountdownProps = {
   deadline: Date | string | number;
+  showLabel?: boolean;
 };
 
-function DepositCountdown({ deadline }: DepositCountdownProps) {
+function DepositCountdown({ deadline, showLabel = true }: DepositCountdownProps) {
   const { remaining } = useCountdown(deadline);
 
   return (
     <div className="flex items-center justify-center gap-1.5 text-text-accent">
       <TimerIconFill className="size-4" />
-      <p className="body-2-semibold">{remaining ?? '--:--:--'} 후 담기 종료</p>
+      <p className="body-2-semibold">
+        {remaining ?? '--:--:--'}
+        {showLabel && ' 후 담기 종료'}
+      </p>
     </div>
   );
 }

--- a/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantPanel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantPanel.tsx
@@ -7,6 +7,7 @@ import { AddIconOutline, ChevronDownIconOutline, ChevronUpIconOutline } from '@/
 import UserProfileGroup from '@/components/user-profile-group';
 import type { UserT } from '@/components/user-profile-group/userProfile.const';
 
+import DepositCountdown from '../deposit-countdown/DepositCountdown';
 import InviteFriendsDialog from '../invite-friends/InviteFriendsDialog';
 import ParticipantChip from './ParticipantChip';
 
@@ -26,6 +27,8 @@ type ParticipantPanelProps = {
   inviteCode?: string;
   /** 초대 코드 만료 시각 (ISO 8601) */
   inviteExpiresAt?: string;
+  /** 담기 마감 시각 — 있을 때만 타이머 노출 */
+  depositDeadline?: string;
 };
 
 const PLACEHOLDER_AVATAR_COUNT = 2;
@@ -39,7 +42,12 @@ const getCollapsedLabel = (participants: ParticipantT[]) => {
   return `${head} 외 ${rest}명`;
 };
 
-function ParticipantPanel({ participants, inviteCode, inviteExpiresAt }: ParticipantPanelProps) {
+function ParticipantPanel({
+  participants,
+  inviteCode,
+  inviteExpiresAt,
+  depositDeadline,
+}: ParticipantPanelProps) {
   const { id: tournamentId } = useParams<{ id: string }>();
   const [isExpanded, setIsExpanded] = useState(false);
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
@@ -71,6 +79,8 @@ function ParticipantPanel({ participants, inviteCode, inviteExpiresAt }: Partici
               <ChevronDownIconOutline className="size-6 shrink-0 text-icon-neutral-secondary" />
             )}
           </button>
+
+          {depositDeadline && <DepositCountdown deadline={depositDeadline} />}
 
           {isExpanded && (
             <div className="flex flex-wrap gap-2">

--- a/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantPanel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantPanel.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { AddIconOutline, ChevronDownIconOutline, ChevronUpIconOutline } from '@/assets/icons';
 import UserProfileGroup from '@/components/user-profile-group';
 import type { UserT } from '@/components/user-profile-group/userProfile.const';
+import { cn } from '@/utils/cn';
 
 import DepositCountdown from '../deposit-countdown/DepositCountdown';
 import InviteFriendsDialog from '../invite-friends/InviteFriendsDialog';
@@ -53,44 +54,53 @@ function ParticipantPanel({
   return (
     <>
       {hasFriends ? (
-        <div className="flex w-full flex-col gap-3 rounded-xl bg-base-50 px-4 py-3">
-          <button
-            type="button"
-            onClick={handleToggleExpand}
-            className="flex w-full cursor-pointer items-center justify-between gap-3"
-          >
-            <div className="flex min-w-0 items-center gap-3">
-              {depositDeadline ? (
-                <div className="shrink-0 rounded-lg bg-blue-50 px-3 py-1.5">
-                  <DepositCountdown deadline={depositDeadline} showLabel={false} />
-                </div>
-              ) : (
-                <UserProfileGroup users={users} max={3} />
-              )}
-              <p className="truncate body-1-semibold text-text-neutral-secondary">
-                {participants.length}명이 함께 담는 중
-              </p>
-            </div>
-            {isExpanded ? (
-              <ChevronUpIconOutline className="size-6 shrink-0 text-icon-neutral-secondary" />
-            ) : (
-              <ChevronDownIconOutline className="size-6 shrink-0 text-icon-neutral-secondary" />
+        <div className="relative w-full">
+          <div
+            className={cn(
+              'flex w-full flex-col bg-base-50 px-4 py-3',
+              isExpanded ? 'rounded-t-xl' : 'rounded-xl'
             )}
-          </button>
+          >
+            <button
+              type="button"
+              onClick={handleToggleExpand}
+              className="flex w-full cursor-pointer items-center justify-between"
+            >
+              <div className="flex min-w-0 items-center gap-3">
+                {depositDeadline ? (
+                  <div className="shrink-0 rounded-lg bg-blue-50 px-3 py-1.5">
+                    <DepositCountdown deadline={depositDeadline} showLabel={false} />
+                  </div>
+                ) : (
+                  <UserProfileGroup users={users} max={3} />
+                )}
+                <p className="truncate body-1-semibold text-text-neutral-secondary">
+                  {participants.length}명이 함께 담는 중
+                </p>
+              </div>
+              {isExpanded ? (
+                <ChevronUpIconOutline className="size-6 shrink-0 text-icon-neutral-secondary" />
+              ) : (
+                <ChevronDownIconOutline className="size-6 shrink-0 text-icon-neutral-secondary" />
+              )}
+            </button>
+          </div>
 
           {isExpanded && (
-            <div className="flex flex-wrap gap-2">
-              {participants.map(({ user, itemCount }) => (
-                <ParticipantChip key={user.id} user={user} itemCount={itemCount} />
-              ))}
-              <button
-                type="button"
-                onClick={handleOpenInvite}
-                className="inline-flex size-9 cursor-pointer items-center justify-center rounded-full border border-border-neutral-muted bg-bg-layer-default"
-                aria-label="친구 초대하기"
-              >
-                <AddIconOutline className="size-4 text-icon-neutral-primary" />
-              </button>
+            <div className="absolute top-full z-10 w-full rounded-b-xl bg-base-50 px-3 pb-3">
+              <div className="flex flex-wrap gap-2">
+                {participants.map(({ user, itemCount }) => (
+                  <ParticipantChip key={user.id} user={user} itemCount={itemCount} />
+                ))}
+                <button
+                  type="button"
+                  onClick={handleOpenInvite}
+                  className="inline-flex size-9 cursor-pointer items-center justify-center rounded-full border border-border-neutral-muted bg-bg-layer-default"
+                  aria-label="친구 초대하기"
+                >
+                  <AddIconOutline className="size-4 text-icon-neutral-primary" />
+                </button>
+              </div>
             </div>
           )}
         </div>

--- a/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantPanel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantPanel.tsx
@@ -59,8 +59,14 @@ function ParticipantPanel({
             onClick={handleToggleExpand}
             className="flex w-full cursor-pointer items-center justify-between gap-3"
           >
-            <div className="flex min-w-0 items-center gap-4">
-              <UserProfileGroup users={users} max={3} />
+            <div className="flex min-w-0 items-center gap-3">
+              {depositDeadline ? (
+                <div className="shrink-0 rounded-lg bg-blue-50 px-3 py-1.5">
+                  <DepositCountdown deadline={depositDeadline} showLabel={false} />
+                </div>
+              ) : (
+                <UserProfileGroup users={users} max={3} />
+              )}
               <p className="truncate body-1-semibold text-text-neutral-secondary">
                 {participants.length}명이 함께 담는 중
               </p>
@@ -71,8 +77,6 @@ function ParticipantPanel({
               <ChevronDownIconOutline className="size-6 shrink-0 text-icon-neutral-secondary" />
             )}
           </button>
-
-          {depositDeadline && <DepositCountdown deadline={depositDeadline} />}
 
           {isExpanded && (
             <div className="flex flex-wrap gap-2">

--- a/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantPanel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantPanel.tsx
@@ -33,15 +33,6 @@ type ParticipantPanelProps = {
 
 const PLACEHOLDER_AVATAR_COUNT = 2;
 
-const getCollapsedLabel = (participants: ParticipantT[]) => {
-  const names = participants.map(p => p.user.name).filter((name): name is string => Boolean(name));
-  if (names.length === 0) return '나';
-  const head = names.slice(0, 3).join(' · ');
-  const rest = names.length - 3;
-  if (rest <= 0) return head;
-  return `${head} 외 ${rest}명`;
-};
-
 function ParticipantPanel({
   participants,
   inviteCode,
@@ -53,7 +44,6 @@ function ParticipantPanel({
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
 
   const hasFriends = participants.length > 1;
-  const label = getCollapsedLabel(participants);
   const users = participants.map(p => p.user);
   const inviteUrl = inviteCode ? buildInviteUrl(tournamentId, inviteCode) : '';
 
@@ -71,7 +61,9 @@ function ParticipantPanel({
           >
             <div className="flex min-w-0 items-center gap-4">
               <UserProfileGroup users={users} max={3} />
-              <p className="truncate body-1-semibold text-text-neutral-primary">{label}</p>
+              <p className="truncate body-1-semibold text-text-neutral-secondary">
+                {participants.length}명이 함께 담는 중
+              </p>
             </div>
             {isExpanded ? (
               <ChevronUpIconOutline className="size-6 shrink-0 text-icon-neutral-secondary" />

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket-status/TournamentItemBasketStatus.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket-status/TournamentItemBasketStatus.tsx
@@ -13,18 +13,21 @@ function TournamentItemBasketStatus({
 }: TournamentItemBasketStatusProps) {
   const label = (() => {
     if (isProcessing) return '담는 중...';
+    if (count === 0) return '후보를 장바구니에 담아보세요';
     if (count < 2) return '최소 2개 이상 담아주세요';
     return `${count}/32`;
   })();
+
+  const isBlue = !isDepositClosed && count < 2;
 
   return (
     <div className="flex items-center justify-center">
       <span
         className={cn(
           'inline-flex h-10 items-center rounded-3xl border px-3 body-2-regular',
-          isDepositClosed
-            ? 'border-transparent bg-transparent text-text-accent'
-            : 'border-gray-100 bg-gray-75 text-gray-600'
+          isDepositClosed && 'border-transparent bg-transparent text-text-accent',
+          isBlue && 'border-blue-100 bg-blue-50 text-text-accent',
+          !isDepositClosed && !isBlue && 'border-gray-100 bg-gray-75 text-gray-600'
         )}
       >
         {label}

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
@@ -95,7 +95,7 @@ function TournamentItemBasketCarousel({
     return (
       <div
         ref={containerRef}
-        className="flex min-h-0 w-full flex-1 flex-col items-center justify-start px-5"
+        className="flex min-h-0 w-full flex-col items-center justify-start px-5"
       >
         <TournamentItemBasket
           basketIndex={0}
@@ -103,11 +103,6 @@ function TournamentItemBasketCarousel({
           isDepositClosed={isDepositClosed}
           maxHeight={basketMaxHeight}
         />
-        {items.length === 0 && (
-          <p className="mt-3 body-2-regular text-text-neutral-tertiary">
-            후보를 장바구니에 담아보세요.
-          </p>
-        )}
       </div>
     );
   }


### PR DESCRIPTION
## 작업 요약

- 장바구니 아이템 수에 따른 상태 라벨 추가 및 친구 초대 패널 UI 개선

## 작업 세부 내용
### `TournamentItemBasketStatus` 추가
장바구니 하단에 아이템 수에 따라 다른 상태 라벨 표시

| 아이템 수 | 문구 | 색상 |
|-----------|------|------|
| 0개 | `후보를 장바구니에 담아보세요` | 파란색 |
| 1개 | `최소 2개 이상 담아주세요` | 파란색 |
| 2개 이상 | `n/32` | 회색 |

### 친구 초대 패널(`ParticipantPanel`) 개선
- `DepositCountdown`(타이머)을 패널 내부로 이동, chip 형태로 한 줄 배치
- 참여자 이름 나열 방식 → `n명이 함께 담는 중` 텍스트로 변경
- 친구 목록 펼침 시 오버레이 처리로 장바구니 레이아웃 밀림 방지
## 스크린샷
<img width="452" height="775" alt="image" src="https://github.com/user-attachments/assets/178287d5-6ce1-43b5-821f-1b6438d07d6c" />

## 연관 이슈

closes #203 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 토너먼트 창작 페이지에서 담기 마감 카운트다운 표시 추가
  * 참여자 패널에 마감 시간 정보 통합 표시

* **Style**
  * 토너먼트 항목 바구니 상태 배지 스타일 및 텍스트 표시 개선
  * 아이콘 크기 및 UI 레이아웃 미세 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->