### PR TITLE
feat: 토너먼트 기록 탭에 바텀 탭 노출

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -14,6 +14,10 @@ const nextConfig = {
         protocol: 'https',
         hostname: '**',
       },
+      {
+        protocol: 'http',
+        hostname: '**.kakaocdn.net',
+      },
     ],
   },
 

--- a/apps/web/src/app/archive/_components/TournamentHistoryContent.tsx
+++ b/apps/web/src/app/archive/_components/TournamentHistoryContent.tsx
@@ -36,19 +36,24 @@ function TournamentHistoryContent() {
   }
 
   return (
-    <main className="hide-scrollbar flex flex-1 flex-col gap-3 overflow-y-auto pb-24">
-      {tournamentListData.map(tournament => (
-        <TournamentCard
-          key={tournament.tournamentId}
-          tournamentId={tournament.tournamentId}
-          status={tournament.status}
-          name={tournament.name}
-          date={tournament.createdAt.slice(0, 10).replaceAll('-', '/')}
-          users={toUsers(tournament.participantProfileImages)}
-          participantCount={tournament.participantProfileImages.length}
-        />
-      ))}
-    </main>
+    <>
+      <main className="hide-scrollbar flex flex-1 flex-col gap-3 overflow-y-auto pb-24">
+        {tournamentListData.map(tournament => (
+          <TournamentCard
+            key={tournament.tournamentId}
+            tournamentId={tournament.tournamentId}
+            status={tournament.status}
+            name={tournament.name}
+            date={tournament.createdAt.slice(0, 10).replaceAll('-', '/')}
+            users={toUsers(tournament.participantProfileImages)}
+            participantCount={tournament.participantProfileImages.length}
+          />
+        ))}
+      </main>
+      <div className="fixed bottom-10 left-1/2 z-20 flex -translate-x-1/2 items-center gap-3">
+        <BottomTabBar />
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## 작업 요약

- 토너먼트 기록 탭에서 바텀 탭이 노출되도록 수정합니다
- 카카오 프로필 이미지 http 호스트를 허용합니다

## 작업 세부 내용

- 토너먼트 기록 목록이 있을 때 바텀 탭이 누락된 문제 수정 (`TournamentHistoryContent.tsx`)
- `next.config.mjs`에 `http://**.kakaocdn.net` 호스트 추가 (카카오 프로필 이미지가 http URL로 내려와 `next/image`에서 오류 발생)

## 스크린샷
<img width="482" height="831" alt="스크린샷 2026-06-16 오후 11 35 42" src="https://github.com/user-attachments/assets/5db9a3da-476a-4aac-8e2b-4abb93786225" />


## 연관 이슈

closes #216


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 외부 이미지 소스에서의 이미지 로딩 지원 범위 확대
  * 토너먼트 목록 조회 시 하단 탭 바 항상 표시되도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->