### PR TITLE
fix: 토너먼트 라운드 전환 바텀시트(준결승/결승) 미노출 버그 수정

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -16,7 +16,7 @@ const nextConfig = {
       },
       {
         protocol: 'http',
-        hostname: '**.kakaocdn.net',
+        hostname: '*.kakaocdn.net',
       },
     ],
   },

--- a/apps/web/src/apis/getWishlist.ts
+++ b/apps/web/src/apis/getWishlist.ts
@@ -6,8 +6,22 @@ import { ENDPOINTS } from '@/consts/api';
 import type { ApiResponseT } from '@/types/api';
 
 import type { WishlistEntryT } from '../app/archive/_types/wish';
+import type { WishItemT } from '../app/archive/_types/wish';
 
-const mapWishlist = (entries: WishlistEntryT[]) =>
+type WishlistApiResponseT = ApiResponseT<WishlistEntryT[]> & {
+  pageResponse: {
+    nextCursor: string | null;
+    hasNext: boolean;
+  };
+};
+
+export type WishlistPageT = {
+  items: WishItemT[];
+  nextCursor: string | null;
+  hasNext: boolean;
+};
+
+const mapWishlist = (entries: WishlistEntryT[]): WishItemT[] =>
   entries.map(({ wish, item }) => ({
     id: wish.id,
     itemId: item.id,
@@ -17,12 +31,22 @@ const mapWishlist = (entries: WishlistEntryT[]) =>
     imageUrl: item.imageUrl ?? null,
   }));
 
-export const getWishlist = async () => {
+export const getWishlist = async (cursor: string | null = null): Promise<WishlistPageT> => {
+  const params = { size: 20, ...(cursor ? { cursor } : {}) };
+
   if (environmentManager.isServer()) {
-    const { data } = await serverApi.get<ApiResponseT<WishlistEntryT[]>>(ENDPOINTS.WISHLISTS);
-    return mapWishlist(data.data);
+    const { data } = await serverApi.get<WishlistApiResponseT>(ENDPOINTS.WISHLISTS, { params });
+    return {
+      items: mapWishlist(data.data),
+      nextCursor: data.pageResponse.nextCursor,
+      hasNext: data.pageResponse.hasNext,
+    };
   }
 
-  const { data } = await clientApi.get<ApiResponseT<WishlistEntryT[]>>(ENDPOINTS.WISHLISTS);
-  return mapWishlist(data.data);
+  const { data } = await clientApi.get<WishlistApiResponseT>(ENDPOINTS.WISHLISTS, { params });
+  return {
+    items: mapWishlist(data.data),
+    nextCursor: data.pageResponse.nextCursor,
+    hasNext: data.pageResponse.hasNext,
+  };
 };

--- a/apps/web/src/app/archive/_components/WishlistContent.tsx
+++ b/apps/web/src/app/archive/_components/WishlistContent.tsx
@@ -17,7 +17,7 @@ function WishlistContent() {
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
 
   useShareIntentWish();
-  const { wishlistData, fetchNextPage, hasNextPage } = useGetWishlist();
+  const { wishlistData, fetchNextPage, hasNextPage, isFetchingNextPage } = useGetWishlist();
 
   const hasPendingItem = hasParsingItems(wishlistData);
 
@@ -38,14 +38,14 @@ function WishlistContent() {
     if (!el) return;
 
     const observer = new IntersectionObserver(entries => {
-      if (entries[0]?.isIntersecting && hasNextPage) {
+      if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
         fetchNextPage();
       }
     });
 
     observer.observe(el);
     return () => observer.disconnect();
-  }, [hasNextPage, fetchNextPage]);
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   return (
     <>

--- a/apps/web/src/app/archive/_components/WishlistContent.tsx
+++ b/apps/web/src/app/archive/_components/WishlistContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useGetWishlist } from '@/hooks/useGetWishlist';
 import { useSSEFallback } from '@/hooks/useSSEFallback';
@@ -17,7 +17,7 @@ function WishlistContent() {
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
 
   useShareIntentWish();
-  const { data: wishlistData } = useGetWishlist();
+  const { wishlistData, fetchNextPage, hasNextPage } = useGetWishlist();
 
   const hasPendingItem = hasParsingItems(wishlistData);
 
@@ -31,6 +31,22 @@ function WishlistContent() {
     handleConfirmDelete,
   } = useWishlistDelete();
 
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(entries => {
+      if (entries[0]?.isIntersecting && hasNextPage) {
+        fetchNextPage();
+      }
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, fetchNextPage]);
+
   return (
     <>
       <main className="flex flex-1 flex-col pb-24">
@@ -40,6 +56,7 @@ function WishlistContent() {
           selectedIds={selectedIds}
           onToggleSelect={handleToggleSelect}
         />
+        <div ref={sentinelRef} />
       </main>
 
       <WishlistBottomBar isDeleteMode={isDeleteMode} selectedCount={selectedIds.size} />

--- a/apps/web/src/app/archive/page.tsx
+++ b/apps/web/src/app/archive/page.tsx
@@ -31,7 +31,7 @@ async function WishlistPage({ searchParams }: WishlistPageProps) {
       queryKey: ['wishlists'],
       queryFn: ({ pageParam }) => getWishlist(pageParam as string | null),
       initialPageParam: null as string | null,
-      getNextPageParam: (page: WishlistPageT) => (page.hasNext ? page.nextCursor : undefined),
+      getNextPageParam: (page: WishlistPageT) => (page.hasNext ? page.nextCursor : null),
     });
   } else if (activeTab === '토너먼트 기록')
     await queryClient.prefetchQuery({

--- a/apps/web/src/app/archive/page.tsx
+++ b/apps/web/src/app/archive/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react';
 
 import { getTournamentList } from '@/apis/getTournamentList';
 import { getWishlist } from '@/apis/getWishlist';
+import type { WishlistPageT } from '@/apis/getWishlist';
 import { getQueryClient } from '@/utils/queryClient';
 
 import TournamentHistoryContent from './_components/TournamentHistoryContent';
@@ -26,9 +27,11 @@ async function WishlistPage({ searchParams }: WishlistPageProps) {
   const queryClient = getQueryClient();
 
   if (activeTab === '저장한 위시템') {
-    await queryClient.prefetchQuery({
+    await queryClient.prefetchInfiniteQuery({
       queryKey: ['wishlists'],
-      queryFn: getWishlist,
+      queryFn: ({ pageParam }) => getWishlist(pageParam as string | null),
+      initialPageParam: null as string | null,
+      getNextPageParam: (page: WishlistPageT) => (page.hasNext ? page.nextCursor : undefined),
     });
   } else if (activeTab === '토너먼트 기록')
     await queryClient.prefetchQuery({

--- a/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
@@ -19,7 +19,7 @@ type ByWishContentProps = {
 
 function ByWishContent({ tournamentId }: ByWishContentProps) {
   const { selectedIds, isMaxExceeded, handleSelect } = useWishSelection(MAX_SELECT);
-  const { wishlistData, fetchNextPage, hasNextPage } = useGetWishlist();
+  const { wishlistData, fetchNextPage, hasNextPage, isFetchingNextPage } = useGetWishlist();
   const { tournamentData } = useGetTournament(tournamentId);
   const { postTournamentItemsByWishMutation, isPostTournamentItemsByWishPending } =
     usePostTournamentItemsByWish(tournamentId);
@@ -41,10 +41,10 @@ function ByWishContent({ tournamentId }: ByWishContentProps) {
 
   // 위시에서 가져오기는 전체 목록 기준으로 카운트를 표시해야 하므로 마운트 시 전체 로드
   useEffect(() => {
-    if (hasNextPage) {
+    if (hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
     }
-  }, [hasNextPage, fetchNextPage]);
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const handleNext = () => {
     const itemIds = items

--- a/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
@@ -19,26 +19,32 @@ type ByWishContentProps = {
 
 function ByWishContent({ tournamentId }: ByWishContentProps) {
   const { selectedIds, isMaxExceeded, handleSelect } = useWishSelection(MAX_SELECT);
-  const { data: wishlistData } = useGetWishlist();
+  const { wishlistData, fetchNextPage, hasNextPage } = useGetWishlist();
   const { tournamentData } = useGetTournament(tournamentId);
   const { postTournamentItemsByWishMutation, isPostTournamentItemsByWishPending } =
     usePostTournamentItemsByWish(tournamentId);
 
   const pending = 'pending' in tournamentData ? tournamentData.pending : null;
   const existingItemIds = new Set(pending?.items.map(i => i.itemId) ?? []);
-  const items =
-    wishlistData?.filter(
-      item =>
-        item.status !== 'FAILED' &&
-        item.status !== 'PROCESSING' &&
-        item.itemId != null &&
-        !existingItemIds.has(item.itemId)
-    ) ?? [];
+  const items = wishlistData.filter(
+    item =>
+      item.status !== 'FAILED' &&
+      item.status !== 'PROCESSING' &&
+      item.itemId != null &&
+      !existingItemIds.has(item.itemId)
+  );
 
   useEffect(() => {
     if (!isMaxExceeded) return;
     toast.warning(`최대 ${MAX_SELECT}개까지 상품을 담을 수 있어요.`);
   }, [isMaxExceeded]);
+
+  // 위시에서 가져오기는 전체 목록 기준으로 카운트를 표시해야 하므로 마운트 시 전체 로드
+  useEffect(() => {
+    if (hasNextPage) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, fetchNextPage]);
 
   const handleNext = () => {
     const itemIds = items
@@ -69,6 +75,7 @@ function ByWishContent({ tournamentId }: ByWishContentProps) {
             />
           ))}
         </div>
+
       </main>
 
       <div className="fixed bottom-0 left-1/2 z-10 flex w-full max-w-120 -translate-x-1/2 gap-[10px] bg-white px-5 py-3">

--- a/apps/web/src/app/tournament/[id]/match/_components/RoundTransitionSheet.tsx
+++ b/apps/web/src/app/tournament/[id]/match/_components/RoundTransitionSheet.tsx
@@ -326,7 +326,7 @@ function RoundTransitionSheet({ stage, onComplete }: RoundTransitionSheetProps) 
         role="dialog"
         aria-modal="true"
         aria-label={title}
-        className={`fixed bottom-0 left-1/2 z-50 w-full max-w-[402px] -translate-x-1/2 cursor-pointer overflow-hidden ${isExiting ? 'rs-sheet-exit' : 'rs-sheet'}`}
+        className={`fixed bottom-0 left-1/2 z-50 w-full max-w-120 -translate-x-1/2 cursor-pointer overflow-hidden ${isExiting ? 'rs-sheet-exit' : 'rs-sheet'}`}
         style={{
           height: 540,
           borderRadius: '24px 24px 0 0',
@@ -341,8 +341,8 @@ function RoundTransitionSheet({ stage, onComplete }: RoundTransitionSheetProps) 
             position: 'absolute',
             top: 15,
             left: 0,
-            width: 402,
-            height: 402,
+            right: 0,
+            aspectRatio: '1 / 1',
             borderRadius: '50%',
             background: '#FFF',
           }}

--- a/apps/web/src/app/tournament/[id]/match/_consts/rounds.ts
+++ b/apps/web/src/app/tournament/[id]/match/_consts/rounds.ts
@@ -22,7 +22,7 @@ export const ROUND_TRANSITION_COPY: Record<
 // 2 → 결승 진입, 4 → 준결승 진입, 그 외 → 일반 다음 라운드
 export const getTransitionStage = (nextRoundItemCount: number): TransitionStageT => {
   if (nextRoundItemCount === 2) return 'toFinal';
-  if (nextRoundItemCount === 4) return 'toSemi';
+  if (nextRoundItemCount > 2 && nextRoundItemCount <= 4) return 'toSemi';
   return 'toNext';
 };
 

--- a/apps/web/src/app/tournament/[id]/match/_hooks/useTournament.ts
+++ b/apps/web/src/app/tournament/[id]/match/_hooks/useTournament.ts
@@ -2,7 +2,7 @@
 
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { useMemo, useState, useSyncExternalStore } from 'react';
+import { useMemo, useRef, useState, useSyncExternalStore } from 'react';
 
 import { ROUTES } from '@/consts/route';
 import type { TournamentItemT } from '@/types/tournament';
@@ -19,6 +19,8 @@ type UseTournamentArgs = {
   tournamentName: string;
   inProgress: GetTournamentInProgressResponseT['inProgress'];
 };
+
+type InProgressT = NonNullable<GetTournamentInProgressResponseT['inProgress']>;
 
 const useTournament = ({ tournamentId, inProgress }: UseTournamentArgs) => {
   const router = useRouter();
@@ -49,6 +51,9 @@ const useTournament = ({ tournamentId, inProgress }: UseTournamentArgs) => {
     () => false
   );
 
+  // 준결승/결승 바텀시트 표시 중 재조회 없이 적용할 다음 라운드 데이터
+  const pendingNextRoundRef = useRef<InProgressT | null>(null);
+
   // 페어 생성 — SSR/첫 렌더: 가격 오름차순 그대로, 마운트 후: 셔플 적용
   const pairs = useMemo(() => {
     const sorted = pairByPriceAsc(remainingItems);
@@ -61,17 +66,6 @@ const useTournament = ({ tournamentId, inProgress }: UseTournamentArgs) => {
   const roundLabel = getRoundLabel(currentRound, matchIndex);
   const isFinalRound = currentRound === 2;
   const isLastMatchInRound = pairs.length === 1;
-
-  const advanceToNextRound = async () => {
-    // 라운드 종료 후 서버에서 다음 라운드 정보 가져오기
-    // queryClient.fetchQuery는 setQueryData로 시드된 캐시를 반환할 수 있어 직접 fetch
-    const next = await getTournament(tournamentId);
-    queryClient.setQueryData(['tournament', tournamentId], next);
-
-    if (next.status !== 'IN_PROGRESS' || !next.inProgress) return;
-    setCurrentRound(next.inProgress.currentRound);
-    setRemainingItems(next.inProgress.remainingItems);
-  };
 
   const handleSelect = (winner: TournamentItemT) => {
     if (!currentMatch) return;
@@ -93,22 +87,31 @@ const useTournament = ({ tournamentId, inProgress }: UseTournamentArgs) => {
       return;
     }
 
-    // 라운드 마지막 매치 → POST 응답 기다린 후 전환 화면 노출
-    // (응답 안 기다리고 advance 시 서버가 아직 다음 라운드로 전환 못해 같은 라운드 다시 받는 race 방지)
+    // 라운드 마지막 매치 — 서버의 실제 다음 라운드 수 기준으로 바텀시트 판단
+    // (currentRound / 2 계산은 홀수 강에서 틀릴 수 있어 서버 응답만 신뢰)
     if (isLastMatchInRound) {
       postRecordMatchMutation(matchBody, {
         onSuccess: async () => {
-          const nextRoundItemCount = currentRound / 2;
-          const stage = getTransitionStage(nextRoundItemCount);
-          if (stage === 'toNext') {
-            // toSemi/toFinal만 바텀시트 표시 — 일반 라운드는 바로 진입
-            try {
-              await advanceToNextRound();
-            } catch {
-              // 네트워크 오류 등으로 실패해도 UI가 멈추지 않도록 — 다음 매치 진입 시 재조회됨
+          try {
+            const next = await getTournament(tournamentId);
+            queryClient.setQueryData(['tournament', tournamentId], next);
+
+            if (next.status !== 'IN_PROGRESS' || !next.inProgress) return;
+
+            const nextInProgress = next.inProgress;
+            const stage = getTransitionStage(nextInProgress.currentRound);
+
+            if (stage === 'toNext') {
+              setCurrentRound(nextInProgress.currentRound);
+              setRemainingItems(nextInProgress.remainingItems);
+              return;
             }
-          } else {
+
+            // 준결승/결승 바텀시트 — ref에 저장하고 시트 표시
+            pendingNextRoundRef.current = nextInProgress;
             setTransitionStage(stage);
+          } catch {
+            // 네트워크 오류 등으로 실패해도 UI가 멈추지 않도록 — 다음 매치 진입 시 재조회됨
           }
         },
       });
@@ -128,8 +131,15 @@ const useTournament = ({ tournamentId, inProgress }: UseTournamentArgs) => {
     );
   };
 
-  const handleTransitionComplete = async () => {
-    await advanceToNextRound();
+  const handleTransitionComplete = () => {
+    const pendingNextRound = pendingNextRoundRef.current;
+
+    if (pendingNextRound) {
+      setCurrentRound(pendingNextRound.currentRound);
+      setRemainingItems(pendingNextRound.remainingItems);
+      pendingNextRoundRef.current = null;
+    }
+
     setTransitionStage(null);
   };
 

--- a/apps/web/src/app/tournament/[id]/match/_hooks/useTournament.ts
+++ b/apps/web/src/app/tournament/[id]/match/_hooks/useTournament.ts
@@ -110,8 +110,9 @@ const useTournament = ({ tournamentId, inProgress }: UseTournamentArgs) => {
             // 준결승/결승 바텀시트 — ref에 저장하고 시트 표시
             pendingNextRoundRef.current = nextInProgress;
             setTransitionStage(stage);
-          } catch {
-            // 네트워크 오류 등으로 실패해도 UI가 멈추지 않도록 — 다음 매치 진입 시 재조회됨
+          } catch (error) {
+            // 네트워크 오류 등으로 실패해도 UI가 멈추지 않도록 — 사용자가 다시 시도하면 재조회됨
+            console.error('[useTournament] 라운드 전환 데이터 조회 실패:', error);
           }
         },
       });

--- a/apps/web/src/hooks/useGetWishlist.ts
+++ b/apps/web/src/hooks/useGetWishlist.ts
@@ -7,7 +7,7 @@ export const useGetWishlist = () => {
     queryKey: ['wishlists'],
     queryFn: ({ pageParam }) => getWishlist(pageParam),
     initialPageParam: null as string | null,
-    getNextPageParam: page => (page.hasNext ? page.nextCursor : undefined),
+    getNextPageParam: page => (page.hasNext ? page.nextCursor : null),
   });
 
   const wishlistData = data.pages.flatMap(page => page.items);

--- a/apps/web/src/hooks/useGetWishlist.ts
+++ b/apps/web/src/hooks/useGetWishlist.ts
@@ -1,10 +1,16 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
 import { getWishlist } from '@/apis/getWishlist';
 
 export const useGetWishlist = () => {
-  return useSuspenseQuery({
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useSuspenseInfiniteQuery({
     queryKey: ['wishlists'],
-    queryFn: getWishlist,
+    queryFn: ({ pageParam }) => getWishlist(pageParam),
+    initialPageParam: null as string | null,
+    getNextPageParam: page => (page.hasNext ? page.nextCursor : undefined),
   });
+
+  const wishlistData = data.pages.flatMap(page => page.items);
+
+  return { wishlistData, fetchNextPage, hasNextPage, isFetchingNextPage };
 };


### PR DESCRIPTION
## 작업 요약

- 토너먼트 라운드 전환 바텀시트(준결승/결승) 미노출 버그를 수정합니다

## 작업 세부 내용

- **라운드 전환 바텀시트 미노출 버그 수정**
  - `currentRound / 2` 계산 방식이 홀수 강(5강 등)에서 틀려 준결승·결승 바텀시트가 표시되지 않던 문제 수정
  - 라운드 종료 시 서버에서 다음 라운드 데이터를 직접 조회해 `getTransitionStage` 판단에 사용하도록 변경
  - 바텀시트 너비 및 장식 반원을 레이아웃 컨테이너에 맞게 수정
- **위시 보관함 무한스크롤 구현** (본작업 중 발견)
  - 커서 기반 페이지네이션 적용 (`useSuspenseInfiniteQuery`)
  - 보관함: `IntersectionObserver`로 스크롤 시 다음 페이지 로드
  - 위시에서 가져오기: 마운트 시 전체 페이지 선로드 (총 개수 카운트 정확도)
- **카카오 CDN 이미지 로드 실패 수정** (본작업 중 발견)
  - `next.config.mjs` HTTP 카카오 CDN hostname 패턴 오류(`**.kakaocdn.net` → `*.kakaocdn.net`) 수정

## 연관 이슈

closes #217


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 위시리스트에 무한 스크롤 기능 추가 - 스크롤 시 자동으로 더 많은 아이템 로드

* **개선 사항**
  * 토너먼트 라운드 전환 화면 스타일 최적화
  * 토너먼트 라운드 진행 로직 개선으로 3개 아이템 진행 시 정상 동작
  * 이미지 호스트 설정 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->