### PR TITLE
feat: 게스트 유저 토너먼트 준비 화면 위시에서 가져오기 버튼 숨김 처리

### DIFF
--- a/apps/web/src/components/get-item-dialog/index.tsx
+++ b/apps/web/src/components/get-item-dialog/index.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { HeartIconFill, ImageIconFill, LinkIconFill } from '@/assets/icons';
 import { DialogContent, DialogDescription, DialogTitle } from '@/components/dialog';
 import { ROUTES } from '@/consts/route';
+import { useGetMe } from '@/hooks/useGetMe';
 import type { ItemTypeT } from '@/types/item';
 import { parseIdParam } from '@/utils/parseIdParam';
 
@@ -18,6 +19,7 @@ type GetItemDialogContentProps = {
 };
 
 function GetItemDialogContent({ type }: GetItemDialogContentProps) {
+  const { userData } = useGetMe();
   const [isSubDialogOpen, setIsSubDialogOpen] = useState<'link' | 'image' | null>(null);
 
   const { id } = useParams<{ id: string }>();
@@ -36,7 +38,7 @@ function GetItemDialogContent({ type }: GetItemDialogContentProps) {
         </DialogDescription>
 
         <ul className="flex w-full flex-col gap-2">
-          {type === 'tournament' && (
+          {type === 'tournament' && userData.identityType === 'MEMBER' && (
             <OptionButton
               href={ROUTES.TOURNAMENT_ADD_ITEM_BY_WISH(tournamentId ?? -1)}
               label="위시에서 가져오기"


### PR DESCRIPTION
## 작업 요약
- 게스트 유저는 `위시에서 가져오기` 버튼을 숨김 처리

## 작업 세부 내용
- 게스트 유저 여부 확인 후 `위시에서 가져오기` 버튼 숨김 처리
- 멤버 유저일 경우 기존과 동일하게 버튼 노출

## 연관 이슈

closes #213 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선사항**
  * 토너먼트 컨텍스트에서 "위시에서 가져오기" 옵션이 회원에게만 표시되도록 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->