### PR TITLE
fix: URL 등록 시 http:// 입력 허용 버그 수정

### DIFF
--- a/apps/web/src/components/get-item-dialog/ByLinkDialog.tsx
+++ b/apps/web/src/components/get-item-dialog/ByLinkDialog.tsx
@@ -12,7 +12,7 @@ import { ROUTES } from '@/consts/route';
 import { usePostWishLink } from '@/hooks/usePostWishLink';
 import type { ItemTypeT } from '@/types/item';
 
-const URL_PATTERN = /^https?:\/\/.+/i;
+const URL_PATTERN = /^https:\/\/.+/i;
 
 type ByLinkProps = {
   type: ItemTypeT;
@@ -91,7 +91,7 @@ function ByLinkDialog({ type, open, onOpenChange }: ByLinkProps) {
             onChange={event => handleChange(event.target.value)}
             left={<LinkIconFill className="size-5" />}
             aria-invalid={hasError}
-            {...(hasError ? { helperText: '올바른 URL 형식으로 입력해주세요.' } : {})}
+            {...(hasError ? { helperText: 'https://로 시작하는 URL을 입력해주세요.' } : {})}
             autoFocus
             inputMode="url"
           />


### PR DESCRIPTION
## 작업 요약

- `https://`만 허용하도록 정규식 변경

## 작업 세부 내용
- `http://`로 시작하는 URL이 유효성 검사를 통과하여 빨간 오류 문구가 노출되지 않던 문제 수정
```ts
// before
const URL_PATTERN = /^https?:\/\/.+/i;

// after
const URL_PATTERN = /^https:\/\/.+/i;
```
## 스크린샷

## 연관 이슈

closes #214 
