### PR TITLE
feat: 아이템 슬롯 상품 이미지 뒤 흰색 박스 노출 수정

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentBasketItem.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentBasketItem.tsx
@@ -13,7 +13,7 @@ function TournamentBasketItem({ item, index, onClick }: TournamentBasketItemProp
   return (
     <div
       className={cn(
-        'relative aspect-square w-full overflow-hidden shadow-[0_0_8px_rgba(0,0,0,0.16)]',
+        'relative aspect-square w-full overflow-hidden rounded-2xl shadow-[0_0_8px_rgba(0,0,0,0.16)]',
         item.status === 'READY' || (item.status === 'FAILED' && 'cursor-pointer')
       )}
       onClick={onClick}


### PR DESCRIPTION
## 작업 요약

- 아이템 슬롯 상품 이미지 뒤 흰색 박스 노출 수정

## 작업 세부 내용
- `TournamentBasketItem` 컨테이너에 `rounded-2xl` 추가
- `overflow-hidden`이 둥근 모서리 기준으로 클리핑되면서 `ProductImage` 내부의 `bg-gray-50` 배경이 장바구니 배경 이미지 밖으로 비치는 현상 수정

## 스크린샷
| Before | After |
|---------|---------|
| <img width="351" height="332" alt="image" src="https://github.com/user-attachments/assets/e1701d63-e02c-4288-b273-335c5346bb5a" />| <img width="354" height="330" alt="image" src="https://github.com/user-attachments/assets/e678597c-4e7a-4bfc-983f-c9a99f058680" /> |
| 상품 이미지 뒤에 흰색 네모 박스가 노출됨 | 불필요한 흰색 배경 제거 및 이미지 영역 정리 |
## 연관 이슈

closes #215
