### PR TITLE
fix: 버튼 중복 요청 방지 및 알림 읽음 처리 중복 호출 수정

### DIFF
--- a/apps/web/src/app/notification/_components/NotificationContent.tsx
+++ b/apps/web/src/app/notification/_components/NotificationContent.tsx
@@ -21,12 +21,14 @@ function NotificationContent() {
   const { openNotificationSettings, isPushEnabled } = usePushPermission();
   const { notificationsData, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useGetNotifications();
-  const { postNotificationsReadMutation } = usePostNotificationsRead();
+  const { postNotificationsReadMutation, isPostNotificationsReadPending } =
+    usePostNotificationsRead();
   const isEmpty = !isPending && notificationsData.length === 0;
 
   const bottomRef = useIntersectionObserver(fetchNextPage, !!hasNextPage && !isFetchingNextPage);
 
   const handleNotificationClick = (notification: (typeof notificationsData)[number]) => {
+    if (isPostNotificationsReadPending) return;
     const route = getNotificationRoute(notification.type, notification.refId, {
       kind: notification.kind,
       tournamentId: notification.tournamentId,

--- a/apps/web/src/components/button/index.tsx
+++ b/apps/web/src/components/button/index.tsx
@@ -22,15 +22,16 @@ function Button({
   className,
   children,
   isLoading,
+  disabled,
   type = 'button',
   ...rest
 }: ButtonProps) {
   return (
     <button
       type={type}
-      disabled={isLoading || rest.disabled}
       className={cn(buttonStyles({ variant, size, icon }), className)}
       {...rest}
+      disabled={isLoading || disabled}
     >
       {isLoading ? (
         <Spinner size={24} />


### PR DESCRIPTION
## 작업 요약
- `Button` 컴포넌트의 `isLoading` 시 `disabled`가 적용되지 않던 버그 수정
- 알림 아이템 연속 클릭 시 읽음 처리 요청이 중복 발생하던 문제 수정

## 작업 세부 내용

### `Button` 컴포넌트 `disabled` 버그 수정
**원인**

`disabled={isLoading || rest.disabled}`를 설정하더라도 바로 뒤 `{...rest}` 스프레드가 `disabled={false}`로 덮어씌워 실제로는 비활성화되지 않는 문제
> 요청 진행 중에도 버튼을 연속 클릭할 수 있어 중복 요청이 발생할 수 있었음
```tsx
<button
  disabled={isLoading || rest.disabled}  // true로 설정해도
  {...rest}                               // rest.disabled=false가 덮어씌움
>
```
**수정**

`disabled`를 `...rest`에서 분리해 destructure하고, `{...rest}` 이후에 명시하여 최종값 보장

```tsx
<button
  {...rest}
  disabled={isLoading || disabled}  // 마지막에 명시해 최종값 보장
>
```
---
### 알림 읽음 처리 중복 요청 방지
- 알림 목록에서 아이템을 빠르게 연속 클릭 시 읽음 처리 POST 요청이 중복으로 발생하는 문제 수정
- `handleNotificationClick`에 `isPostNotificationsReadPending` 가드를 추가하여 요청 진행 중 재클릭 차단

## 연관 이슈

closes #229 
