### PR TITLE
feat: 토너먼트 친구 아바타 뱃지 및 참여자 상품 개수 연동

### DIFF
--- a/apps/web/src/app/tournament/[id]/_common/_types/tournamentResponse.ts
+++ b/apps/web/src/app/tournament/[id]/_common/_types/tournamentResponse.ts
@@ -18,6 +18,7 @@ export type TournamentParticipantT = {
 export type TournamentPendingItemT = Partial<TournamentItemT> & {
   tournamentItemId: number;
   itemId: number;
+  userId?: string;
 };
 
 /**

--- a/apps/web/src/app/tournament/[id]/_common/_types/tournamentResponse.ts
+++ b/apps/web/src/app/tournament/[id]/_common/_types/tournamentResponse.ts
@@ -8,6 +8,7 @@ import type {
 export type TournamentParticipantT = {
   userId: string;
   nickname: string;
+  itemCount: number;
   profileImage: string;
 };
 

--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -63,7 +63,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
       profileType: 'blue' as const,
       ...(isGeneratedAvatar(p.profileImage) ? {} : { imageUrl: p.profileImage }),
     },
-    itemCount: 0,
+    itemCount: p.itemCount,
   }));
   const hasFriends = participants.length > 1;
 

--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -67,6 +67,10 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
   }));
   const hasFriends = participants.length > 1;
 
+  const participantImageMap = new Map(
+    (pending?.participants ?? []).map(p => [p.userId, p.profileImage])
+  );
+
   const [confirmPayload, setConfirmPayload] = useState<JoinConfirmPayloadT | null>(() =>
     consumeJoinConfirmFor(tournamentId)
   );
@@ -103,6 +107,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
           scrollToLast={scrollToLast}
           onScrolled={onScrolled}
           isDepositClosed={isDepositClosed}
+          participantImageMap={participantImageMap}
         />
         <TournamentItemBasketStatus
           isProcessing={hasPendingItem}

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentBasketItem.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentBasketItem.tsx
@@ -1,4 +1,7 @@
+import Image from 'next/image';
+
 import ProductImage from '@/app/tournament/[id]/create/_components/product-image';
+import { useGetMe } from '@/hooks/useGetMe';
 import { cn } from '@/utils/cn';
 
 import type { TournamentPendingItemT } from '../../../_common/_types/tournamentResponse';
@@ -7,24 +10,44 @@ type TournamentBasketItemProps = {
   item: TournamentPendingItemT;
   index: number;
   onClick?: () => void;
+  participantImageMap?: Map<string, string>;
 };
 
-function TournamentBasketItem({ item, index, onClick }: TournamentBasketItemProps) {
+function TournamentBasketItem({
+  item,
+  index,
+  onClick,
+  participantImageMap,
+}: TournamentBasketItemProps) {
+  const { userData } = useGetMe();
+  const friendImageUrl =
+    item.userId && item.userId !== userData.id ? participantImageMap?.get(item.userId) : undefined;
+
   return (
     <div
       className={cn(
-        'relative aspect-square w-full overflow-hidden rounded-2xl shadow-[0_0_8px_rgba(0,0,0,0.16)]',
-        item.status === 'READY' || (item.status === 'FAILED' && 'cursor-pointer')
+        'relative aspect-square w-full',
+        (item.status === 'READY' || item.status === 'FAILED') && 'cursor-pointer'
       )}
       onClick={onClick}
     >
-      <ProductImage
-        {...(item.imageUrl ? { src: item.imageUrl } : {})}
-        size="sm"
-        fill
-        alt={`토너먼트 아이템 ${index + 1}`}
-        parsingStatus={item.status}
-      />
+      <div className="absolute inset-0 overflow-hidden rounded-2xl">
+        <ProductImage
+          {...(item.imageUrl ? { src: item.imageUrl } : {})}
+          size="sm"
+          fill
+          alt={`토너먼트 아이템 ${index + 1}`}
+          parsingStatus={item.status}
+        />
+      </div>
+      {friendImageUrl && (
+        <div
+          className="absolute -right-1 -bottom-0.5 overflow-hidden rounded-full border-2 border-white"
+          style={{ width: '35%', height: '35%' }}
+        >
+          <Image src={friendImageUrl} alt="친구 프로필" fill className="object-cover" />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentBasketItem.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentBasketItem.tsx
@@ -21,7 +21,7 @@ function TournamentBasketItem({
 }: TournamentBasketItemProps) {
   const { userData } = useGetMe();
   const friendImageUrl =
-    item.userId && item.userId !== userData.id ? participantImageMap?.get(item.userId) : undefined;
+    item.userId && item.userId !== userData.id ? participantImageMap?.get(item.userId) : null;
 
   return (
     <div

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
@@ -17,6 +17,7 @@ type TournamentItemBasketProps = {
   items: TournamentPendingItemT[];
   maxHeight?: number;
   isDepositClosed?: boolean;
+  participantImageMap?: Map<string, string>;
 };
 
 function TournamentItemBasket({
@@ -24,6 +25,7 @@ function TournamentItemBasket({
   items,
   maxHeight,
   isDepositClosed = false,
+  participantImageMap,
 }: TournamentItemBasketProps) {
   const { id } = useParams<{ id: string }>();
   const tournamentId = Number(id);
@@ -79,6 +81,7 @@ function TournamentItemBasket({
                 item={item}
                 index={index}
                 onClick={() => handleItemClick(item)}
+                participantImageMap={participantImageMap}
               />
             ))}
           </div>

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
@@ -20,6 +20,7 @@ type TournamentItemBasketCarouselProps = {
   scrollToLast?: boolean;
   onScrolled?: () => void;
   isDepositClosed?: boolean;
+  participantImageMap?: Map<string, string>;
 };
 
 function TournamentItemBasketCarousel({
@@ -27,6 +28,7 @@ function TournamentItemBasketCarousel({
   scrollToLast = false,
   onScrolled,
   isDepositClosed = false,
+  participantImageMap,
 }: TournamentItemBasketCarouselProps) {
   const [carouselApi, setCarouselApi] = useState<CarouselApi>();
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -102,6 +104,7 @@ function TournamentItemBasketCarousel({
           items={items}
           isDepositClosed={isDepositClosed}
           maxHeight={basketMaxHeight}
+          participantImageMap={participantImageMap}
         />
       </div>
     );
@@ -130,6 +133,8 @@ function TournamentItemBasketCarousel({
                 items={items.slice(i * ITEMS_PER_BASKET, (i + 1) * ITEMS_PER_BASKET)}
                 isDepositClosed={isDepositClosed}
                 maxHeight={basketMaxHeight}
+                participantImageMap={participantImageMap}
+                currentUserId={currentUserId}
               />
             </CarouselItem>
           ))}

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
@@ -134,7 +134,6 @@ function TournamentItemBasketCarousel({
                 isDepositClosed={isDepositClosed}
                 maxHeight={basketMaxHeight}
                 participantImageMap={participantImageMap}
-                currentUserId={currentUserId}
               />
             </CarouselItem>
           ))}


### PR DESCRIPTION
## 작업 요약

- 참여자 상품 개수 API 연동 및 친구가 담은 아이템 슬롯에 프로필 아바타 뱃지 표시 구현

## 작업 세부 내용
### 참여자 상품 개수 API 연동
- `TournamentParticipantT`에 `itemCount` 필드 추가 (API 응답 반영)
- `TournamentCreateClient`에서 `participants` 맵핑 시 `itemCount: 0` 하드코딩 → `p.itemCount`로 수정
- `ParticipantPanel` / `ParticipantChip`에 실제 담은 상품 수 표시

### 친구 아바타 뱃지 표시
- `TournamentPendingItemT`에 `userId?: string` 추가 
- 친구가 담은 아이템 슬롯 우측 하단에 해당 친구의 프로필 이미지를 원형 뱃지로 표시
- 본인이 담은 아이템에는 뱃지 미노출
- 뱃지 크기는 카드 너비 기준 35%로 반응형 처리 (`%` 단위)

### 버그 수정
- `TournamentBasketItem`의 `cursor-pointer` 조건 오류 수정 (`||` 연산자 우선순위 버그)
- `overflow-hidden`을 이미지 inner div로 분리하여 뱃지가 카드 경계 밖으로 걸쳐 보이도록 구조 개선
## 스크린샷
<img width="437" height="597" alt="image" src="https://github.com/user-attachments/assets/78bc7a47-0a95-4ca8-94b9-056157c44134" />

## 연관 이슈
closes #204 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 토너먼트 장바구니 아이템에 참가자의 프로필 이미지가 원형 배지 형태로 오버레이되어 표시됩니다.

* **개선 사항**
  * 참여자 응답 타입에 아이템 개수(`itemCount`)가 포함되도록 업데이트되었습니다.
  * 대기(pending) 데이터에서 사용자 식별자(`userId`)가 누락될 수 있는 경우를 타입 수준에서 반영해 처리 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->