### PR TITLE
style: 위시에서 가져오기·보관함 체크박스 흰색 배경 적용 및 토너먼트 로딩 레이아웃 수정

### DIFF
--- a/apps/web/src/app/archive/_components/WishlistLayout.tsx
+++ b/apps/web/src/app/archive/_components/WishlistLayout.tsx
@@ -11,7 +11,7 @@ type WishlistLayoutProps = {
 function WishlistLayout({ children }: WishlistLayoutProps) {
   return (
     <div className="flex min-h-dvh flex-col bg-bg-layer-basement px-5">
-      <div className="sticky top-0 z-10 inline-flex w-full flex-col items-start gap-5 bg-bg-layer-basement pt-padding-top pb-6">
+      <div className="sticky top-0 z-20 inline-flex w-full flex-col items-start gap-5 bg-bg-layer-basement pt-padding-top pb-6">
         <div className="flex w-full flex-col gap-[5px]">
           <Header
             right={

--- a/apps/web/src/app/archive/_components/wish-grid/index.tsx
+++ b/apps/web/src/app/archive/_components/wish-grid/index.tsx
@@ -36,10 +36,11 @@ function WishGrid({ items, isDeleteMode = false, selectedIds, onToggleSelect }: 
             >
               <WishCard name={item.name} price={item.price} imageUrl={item.imageUrl} />
               <span className="pointer-events-none absolute top-3 left-3 z-10 size-6">
+                <span className="absolute inset-[3px] rounded-[3px] bg-white" />
                 {isSelected ? (
-                  <CheckboxSelectedIconFill className="size-6 text-uac-light" />
+                  <CheckboxSelectedIconFill className="relative size-6 text-uac-light" />
                 ) : (
-                  <CheckboxEmptyIconFill className="size-6 text-[#636366]" />
+                  <CheckboxEmptyIconFill className="relative size-6 text-[#636366]" />
                 )}
               </span>
             </button>

--- a/apps/web/src/app/archive/_components/wish-grid/index.tsx
+++ b/apps/web/src/app/archive/_components/wish-grid/index.tsx
@@ -32,7 +32,7 @@ function WishGrid({ items, isDeleteMode = false, selectedIds, onToggleSelect }: 
               type="button"
               onClick={() => onToggleSelect?.(item.id)}
               aria-pressed={isSelected}
-              className="relative text-left transition-opacity active:opacity-80"
+              className="relative cursor-pointer text-left transition-opacity active:opacity-80"
             >
               <WishCard name={item.name} price={item.price} imageUrl={item.imageUrl} />
               <span className="pointer-events-none absolute top-3 left-3 z-10 size-6">

--- a/apps/web/src/app/tournament/[id]/create/by-wish/_components/WishSelectCard.tsx
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_components/WishSelectCard.tsx
@@ -19,13 +19,14 @@ function WishSelectCard({ name, price, imageUrl, isSelected, onSelect }: WishSel
       className="relative h-full w-full text-left"
     >
       <WishCard name={name} price={price} imageUrl={imageUrl} />
-      <div className="absolute top-2 left-2 z-10">
+      <span className="pointer-events-none absolute top-3 left-3 z-10 size-6">
+        <span className="absolute inset-[3px] rounded-[3px] bg-white" />
         {isSelected ? (
-          <CheckboxSelectedIconFill width={30.317} height={30.317} className="text-uac-light" />
+          <CheckboxSelectedIconFill className="relative size-6 text-uac-light" />
         ) : (
-          <CheckboxEmptyIconFill width={30.317} height={30.317} className="text-[#636366]" />
+          <CheckboxEmptyIconFill className="relative size-6 text-[#636366]" />
         )}
-      </div>
+      </span>
     </button>
   );
 }

--- a/apps/web/src/app/tournament/[id]/create/by-wish/_components/WishSelectCard.tsx
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_components/WishSelectCard.tsx
@@ -16,7 +16,7 @@ function WishSelectCard({ name, price, imageUrl, isSelected, onSelect }: WishSel
       type="button"
       onClick={onSelect}
       aria-pressed={isSelected}
-      className="relative h-full w-full text-left"
+      className="relative h-full w-full cursor-pointer text-left"
     >
       <WishCard name={name} price={price} imageUrl={imageUrl} />
       <span className="pointer-events-none absolute top-3 left-3 z-10 size-6">

--- a/apps/web/src/app/tournament/[id]/loading/page.tsx
+++ b/apps/web/src/app/tournament/[id]/loading/page.tsx
@@ -23,7 +23,7 @@ function TournamentLoadingPage() {
   }, [router, tournamentId]);
 
   return (
-    <main className="flex min-h-dvh flex-col pt-6 pb-6">
+    <main className="flex min-h-dvh flex-col justify-center px-5 pt-padding-top pb-6">
       <header className="flex flex-col gap-2 text-center tracking-[-0.6px]">
         <h1 className="text-[24px] leading-8 font-bold text-text-neutral-primary">
           대진표 만드는 중...
@@ -33,7 +33,7 @@ function TournamentLoadingPage() {
         </p>
       </header>
 
-      <div className="mt-15">
+      <div className="mt-11">
         <LoadingBar />
       </div>
 


### PR DESCRIPTION
## 작업 요약

- 위시에서 가져오기·보관함 체크박스 흰색 배경 적용 및 보관함 헤더 z-index 수정
- 토너먼트 로딩 페이지 상단 여백 수정

## 작업 세부 내용

- 위시에서 가져오기(`WishSelectCard`), 보관함(`WishGrid`) 체크박스 SVG 내부에 흰색 배경 추가
  - 체크박스 SVG가 evenodd fill rule을 사용해 체크마크 영역이 투명하게 보이는 문제 수정
  - 체크박스 테두리 안쪽(`inset-[3px]`)에 흰색 배경 스팬 삽입
- 보관함 sticky 헤더 z-index `z-10` → `z-20` 상향
  - 삭제 모드에서 스크롤 시 체크박스(`z-10`)가 헤더 위로 올라오던 문제 수정
- 토너먼트 로딩 페이지 `pt-6` → `pt-padding-top`, `px-5` 추가 (추가 작업)
  - 노치/상태바 safe area 확보 및 좌우 여백 통일

## 스크린샷
<img width="480" height="832" alt="스크린샷 2026-06-18 오전 9 24 30" src="https://github.com/user-attachments/assets/103cf132-4276-40c5-83ce-4db40b1184d7" />

## 연관 이슈



closes #237


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 위시리스트 레이아웃의 상단 영역 렌더링 순서 개선
  * 삭제 모드 체크박스 UI 시각성 향상
  * 위시 선택 카드의 체크박스 디자인 개선
  * 토너먼트 로딩 화면 레이아웃 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->