### PR TITLE
fix: QA 통합 — 토너먼트 시작 흐름 모달 / 영수증 캡처 / 초대 마감 보정 (#236)

### DIFF
--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -26,13 +26,13 @@ function Error({ reset }: Props) {
         <button
           type="button"
           onClick={reset}
-          className="body-1-semibold inline-flex cursor-pointer items-center justify-center rounded-[12px] border-[1.2px] border-gray-200 bg-bg-layer-floating px-[18px] py-[10px] text-text-neutral-primary"
+          className="inline-flex cursor-pointer items-center justify-center rounded-[12px] border-[1.2px] border-gray-200 bg-bg-layer-floating px-[18px] py-[10px] body-1-semibold text-text-neutral-primary"
         >
           다시 시도
         </button>
         <Link
           href={ROUTES.HOME}
-          className="body-1-semibold inline-flex cursor-pointer items-center justify-center rounded-[12px] border border-bg-neutral-primary bg-bg-neutral-primary px-[18px] py-[10px] text-text-neutral-inverse"
+          className="inline-flex cursor-pointer items-center justify-center rounded-[12px] border border-bg-neutral-primary bg-bg-neutral-primary px-[18px] py-[10px] body-1-semibold text-text-neutral-inverse"
         >
           홈으로 가기
         </Link>

--- a/apps/web/src/app/home/_components/CreateTournamentDialog.tsx
+++ b/apps/web/src/app/home/_components/CreateTournamentDialog.tsx
@@ -9,6 +9,9 @@ import Input from '@/components/input';
 
 import { usePostCreateTournament } from '../_hooks/usePostCreateTournament';
 
+/** 토너먼트 생성 시 기본 초대 마감 시각 — 현재 + 30분. */
+const DEFAULT_INVITE_DURATION_MINUTES = 30;
+
 function CreateTournamentDialog() {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState('');
@@ -20,7 +23,7 @@ function CreateTournamentDialog() {
   const handleCreate = () => {
     if (isDisabled) return;
     postCreateTournamentMutation(
-      { name: trimmedName },
+      { name: trimmedName, inviteDurationMinutes: DEFAULT_INVITE_DURATION_MINUTES },
       {
         onSuccess: () => {
           setOpen(false);

--- a/apps/web/src/app/home/_types/tournament.ts
+++ b/apps/web/src/app/home/_types/tournament.ts
@@ -1,5 +1,7 @@
 export type PostCreateTournamentRequestT = {
   name: string;
+  /** 초대 마감까지 남은 분 단위 시간 (1~1440). 미지정 시 서버 기본값 사용. */
+  inviteDurationMinutes?: number;
 };
 
 export type PostCreateTournamentResponseT = {

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -5,7 +5,7 @@ import { ROUTES } from '@/consts/route';
 
 function NotFound() {
   return (
-    <div className="flex h-full flex-col items-center bg-bg-layer-basement pt-40 gap-6">
+    <div className="flex h-full flex-col items-center gap-6 bg-bg-layer-basement pt-40">
       <div className="flex flex-col items-center gap-4">
         <CloseCircularIconFill className="size-20 text-icon-neutral-secondary" />
         <div className="flex flex-col items-center gap-2">
@@ -17,7 +17,7 @@ function NotFound() {
       </div>
       <Link
         href={ROUTES.HOME}
-        className="body-1-semibold inline-flex cursor-pointer items-center justify-center rounded-[12px] border-[1.2px] border-gray-200 bg-bg-layer-floating px-[18px] py-[10px] text-text-neutral-primary"
+        className="inline-flex cursor-pointer items-center justify-center rounded-[12px] border-[1.2px] border-gray-200 bg-bg-layer-floating px-[18px] py-[10px] body-1-semibold text-text-neutral-primary"
       >
         홈으로 가기
       </Link>

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -17,7 +17,7 @@ function NotFound() {
       </div>
       <Link
         href={ROUTES.HOME}
-        className="inline-flex cursor-pointer items-center justify-center rounded-[12px] border-[1.2px] border-gray-200 bg-bg-layer-floating px-[18px] py-[10px] body-1-semibold text-text-neutral-primary"
+        className="inline-flex items-center justify-center rounded-xl border-[1.2px] border-gray-200 bg-bg-layer-floating px-4.5 py-2.5 body-1-semibold text-text-neutral-primary"
       >
         홈으로 가기
       </Link>

--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -12,8 +12,10 @@ import { hasParsingItems } from '@/utils/item';
 
 import { type JoinConfirmPayloadT, consumeJoinConfirmFor } from '../../../join/_utils/joinSession';
 import { useGetTournament } from '../../_common/_hooks/useGetTournament';
+import { usePostTournamentStart } from '../_hooks/usePostTournamentStart';
 import { useCountdown } from '../_hooks/useCountdown';
 import { useScrollToLast } from '../_hooks/useScrollToLast';
+import DepositClosedDialog from './deposit-closed-dialog/DepositClosedDialog';
 import MemberJoinConfirmDialog from './member-join-confirm-dialog/MemberJoinConfirmDialog';
 import ParticipantPanel from './participant-panel/ParticipantPanel';
 import TournamentHeader from './tournament-header/TournamentHeader';
@@ -85,6 +87,29 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
     action: QUERY_ACTION.VALUE.WELCOME_JOIN,
   });
 
+  // 담기 마감 직후 주최자에게 노출되는 자동 안내 모달.
+  // 만료 시점에 자동 오픈, 사용자가 닫으면 다시 띄우지 않는다.
+  const [isDepositClosedDialogOpen, setIsDepositClosedDialogOpen] = useState(false);
+  const [hasDismissedDepositClosed, setHasDismissedDepositClosed] = useState(false);
+  const shouldShowDepositClosedDialog =
+    tournamentData.isOwner && !ownerStarted && isExpired && !hasDismissedDepositClosed;
+  if (shouldShowDepositClosedDialog && !isDepositClosedDialogOpen) {
+    setIsDepositClosedDialogOpen(true);
+  }
+  const { postTournamentStartMutation } = usePostTournamentStart(tournamentId);
+  const itemCount = pending?.items.length ?? 0;
+
+  const handleStartFromDepositClosed = () => {
+    setIsDepositClosedDialogOpen(false);
+    setHasDismissedDepositClosed(true);
+    postTournamentStartMutation();
+  };
+
+  const handleDepositClosedOpenChange = (open: boolean) => {
+    setIsDepositClosedDialogOpen(open);
+    if (!open) setHasDismissedDepositClosed(true);
+  };
+
   const handleCloseConfirm = () => setConfirmPayload(null);
 
   return (
@@ -133,6 +158,13 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
       <Dialog open={isGetItemDialogOpen} onOpenChange={setIsGetItemDialogOpen}>
         <GetItemDialogContent type="tournament" />
       </Dialog>
+
+      <DepositClosedDialog
+        open={isDepositClosedDialogOpen}
+        onOpenChange={handleDepositClosedOpenChange}
+        onStart={handleStartFromDepositClosed}
+        itemCount={itemCount}
+      />
 
       {isWelcomeOpen && (
         <WelcomeJoinDialog

--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { Dialog } from '@/components/dialog';
 import GetItemDialogContent from '@/components/get-item-dialog';
@@ -17,6 +17,7 @@ import { useCountdown } from '../_hooks/useCountdown';
 import { useScrollToLast } from '../_hooks/useScrollToLast';
 import DepositClosedDialog from './deposit-closed-dialog/DepositClosedDialog';
 import MemberJoinConfirmDialog from './member-join-confirm-dialog/MemberJoinConfirmDialog';
+import OwnerStartedDialog from './owner-started-dialog/OwnerStartedDialog';
 import ParticipantPanel from './participant-panel/ParticipantPanel';
 import TournamentHeader from './tournament-header/TournamentHeader';
 import TournamentItemBasketStatus from './tournament-item-basket-status/TournamentItemBasketStatus';
@@ -110,6 +111,33 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
     if (!open) setHasDismissedDepositClosed(true);
   };
 
+  // 참여자에게 노출되는 "주최자가 토너먼트를 시작했어요!" 모달.
+  // SSE(TOURNAMENT_STARTED) 또는 폴링으로 ownerStarted 가 false→true 로 바뀌는 순간 자동 오픈.
+  // 사용자가 닫거나 시작하면 다시 띄우지 않는다.
+  const [isOwnerStartedDialogOpen, setIsOwnerStartedDialogOpen] = useState(false);
+  const [hasDismissedOwnerStarted, setHasDismissedOwnerStarted] = useState(false);
+  const prevOwnerStartedRef = useRef(ownerStarted);
+
+  useEffect(() => {
+    const wasNotStarted = !prevOwnerStartedRef.current;
+    prevOwnerStartedRef.current = ownerStarted;
+    if (!isParticipant) return;
+    if (wasNotStarted && ownerStarted && !hasDismissedOwnerStarted) {
+      setIsOwnerStartedDialogOpen(true);
+    }
+  }, [ownerStarted, isParticipant, hasDismissedOwnerStarted]);
+
+  const handleStartFromOwnerStarted = () => {
+    setIsOwnerStartedDialogOpen(false);
+    setHasDismissedOwnerStarted(true);
+    postTournamentStartMutation();
+  };
+
+  const handleOwnerStartedOpenChange = (open: boolean) => {
+    setIsOwnerStartedDialogOpen(open);
+    if (!open) setHasDismissedOwnerStarted(true);
+  };
+
   const handleCloseConfirm = () => setConfirmPayload(null);
 
   return (
@@ -163,6 +191,13 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
         open={isDepositClosedDialogOpen}
         onOpenChange={handleDepositClosedOpenChange}
         onStart={handleStartFromDepositClosed}
+        itemCount={itemCount}
+      />
+
+      <OwnerStartedDialog
+        open={isOwnerStartedDialogOpen}
+        onOpenChange={handleOwnerStartedOpenChange}
+        onStart={handleStartFromOwnerStarted}
         itemCount={itemCount}
       />
 

--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
 import { Dialog } from '@/components/dialog';
 import GetItemDialogContent from '@/components/get-item-dialog';
@@ -114,18 +114,16 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
   // 참여자에게 노출되는 "주최자가 토너먼트를 시작했어요!" 모달.
   // SSE(TOURNAMENT_STARTED) 또는 폴링으로 ownerStarted 가 false→true 로 바뀌는 순간 자동 오픈.
   // 사용자가 닫거나 시작하면 다시 띄우지 않는다.
+  // React 공식 권장: 이전 값을 state 로 보관해 렌더 중 비교 → effect 불필요.
   const [isOwnerStartedDialogOpen, setIsOwnerStartedDialogOpen] = useState(false);
   const [hasDismissedOwnerStarted, setHasDismissedOwnerStarted] = useState(false);
-  const prevOwnerStartedRef = useRef(ownerStarted);
-
-  useEffect(() => {
-    const wasNotStarted = !prevOwnerStartedRef.current;
-    prevOwnerStartedRef.current = ownerStarted;
-    if (!isParticipant) return;
-    if (wasNotStarted && ownerStarted && !hasDismissedOwnerStarted) {
+  const [prevOwnerStarted, setPrevOwnerStarted] = useState(ownerStarted);
+  if (prevOwnerStarted !== ownerStarted) {
+    setPrevOwnerStarted(ownerStarted);
+    if (isParticipant && !prevOwnerStarted && ownerStarted && !hasDismissedOwnerStarted) {
       setIsOwnerStartedDialogOpen(true);
     }
-  }, [ownerStarted, isParticipant, hasDismissedOwnerStarted]);
+  }
 
   const handleStartFromOwnerStarted = () => {
     setIsOwnerStartedDialogOpen(false);

--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -12,8 +12,8 @@ import { hasParsingItems } from '@/utils/item';
 
 import { type JoinConfirmPayloadT, consumeJoinConfirmFor } from '../../../join/_utils/joinSession';
 import { useGetTournament } from '../../_common/_hooks/useGetTournament';
-import { usePostTournamentStart } from '../_hooks/usePostTournamentStart';
 import { useCountdown } from '../_hooks/useCountdown';
+import { usePostTournamentStart } from '../_hooks/usePostTournamentStart';
 import { useScrollToLast } from '../_hooks/useScrollToLast';
 import DepositClosedDialog from './deposit-closed-dialog/DepositClosedDialog';
 import MemberJoinConfirmDialog from './member-join-confirm-dialog/MemberJoinConfirmDialog';

--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -97,10 +97,12 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
   if (shouldShowDepositClosedDialog && !isDepositClosedDialogOpen) {
     setIsDepositClosedDialogOpen(true);
   }
-  const { postTournamentStartMutation } = usePostTournamentStart(tournamentId);
+  const { postTournamentStartMutation, isPostTournamentStartPending } =
+    usePostTournamentStart(tournamentId);
   const itemCount = pending?.items.length ?? 0;
 
   const handleStartFromDepositClosed = () => {
+    if (isPostTournamentStartPending) return;
     setIsDepositClosedDialogOpen(false);
     setHasDismissedDepositClosed(true);
     postTournamentStartMutation();
@@ -126,6 +128,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
   }
 
   const handleStartFromOwnerStarted = () => {
+    if (isPostTournamentStartPending) return;
     setIsOwnerStartedDialogOpen(false);
     setHasDismissedOwnerStarted(true);
     postTournamentStartMutation();
@@ -190,6 +193,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
         onOpenChange={handleDepositClosedOpenChange}
         onStart={handleStartFromDepositClosed}
         itemCount={itemCount}
+        isPending={isPostTournamentStartPending}
       />
 
       <OwnerStartedDialog
@@ -197,6 +201,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
         onOpenChange={handleOwnerStartedOpenChange}
         onStart={handleStartFromOwnerStarted}
         itemCount={itemCount}
+        isPending={isPostTournamentStartPending}
       />
 
       {isWelcomeOpen && (

--- a/apps/web/src/app/tournament/[id]/create/_components/deposit-closed-dialog/DepositClosedDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/deposit-closed-dialog/DepositClosedDialog.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { SandTimerIconFill } from '@/assets/icons/fill';
+import Button from '@/components/button';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/dialog';
+
+type DepositClosedDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** "토너먼트 시작하기" — 시작 흐름 진입 */
+  onStart: () => void;
+  /** 담긴 후보 수 — "N강" 표시에 그대로 사용 */
+  itemCount: number;
+};
+
+/**
+ * 담기 마감 시각이 지난 직후 주최자에게 노출되는 자동 안내 모달.
+ * 시스템이 자동으로 담기를 종료했음을 알리고 토너먼트 시작을 유도한다.
+ */
+function DepositClosedDialog({ open, onOpenChange, onStart, itemCount }: DepositClosedDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton={false} className="flex flex-col items-center gap-5 p-5">
+        <SandTimerIconFill className="size-10 text-icon-accent" aria-hidden />
+
+        <div className="flex flex-col items-center gap-2">
+          <DialogTitle className="text-center heading-1 text-text-neutral-primary">
+            담기 시간이 종료됐어요.
+          </DialogTitle>
+          <DialogDescription className="text-center body-1-medium text-text-neutral-tertiary">
+            지금 바로 {itemCount}강 토너먼트를 시작해 보세요.
+          </DialogDescription>
+        </div>
+
+        <Button variant="primary" size="lg" className="w-full" onClick={onStart}>
+          토너먼트 시작하기
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default DepositClosedDialog;

--- a/apps/web/src/app/tournament/[id]/create/_components/deposit-closed-dialog/DepositClosedDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/deposit-closed-dialog/DepositClosedDialog.tsx
@@ -11,13 +11,21 @@ type DepositClosedDialogProps = {
   onStart: () => void;
   /** 담긴 후보 수 — "N강" 표시에 그대로 사용 */
   itemCount: number;
+  /** 시작 mutation 진행 중 여부 — 빠른 연타로 인한 중복 호출을 막기 위해 버튼을 비활성한다. */
+  isPending?: boolean;
 };
 
 /**
  * 담기 마감 시각이 지난 직후 주최자에게 노출되는 자동 안내 모달.
  * 시스템이 자동으로 담기를 종료했음을 알리고 토너먼트 시작을 유도한다.
  */
-function DepositClosedDialog({ open, onOpenChange, onStart, itemCount }: DepositClosedDialogProps) {
+function DepositClosedDialog({
+  open,
+  onOpenChange,
+  onStart,
+  itemCount,
+  isPending = false,
+}: DepositClosedDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent showCloseButton={false} className="flex flex-col items-center gap-5 p-5">
@@ -32,7 +40,13 @@ function DepositClosedDialog({ open, onOpenChange, onStart, itemCount }: Deposit
           </DialogDescription>
         </div>
 
-        <Button variant="primary" size="lg" className="w-full" onClick={onStart}>
+        <Button
+          variant="primary"
+          size="lg"
+          className="w-full"
+          onClick={onStart}
+          disabled={isPending}
+        >
           토너먼트 시작하기
         </Button>
       </DialogContent>

--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteExpiresPicker.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteExpiresPicker.tsx
@@ -25,20 +25,11 @@ const MERIDIEMS = ['AM', 'PM'] as const;
 type MeridiemT = (typeof MERIDIEMS)[number];
 
 /**
- * Date → 로컬 LocalDateTime 문자열 (시간대 정보 없는 ISO).
- * 서버가 `LocalDateTime` 으로 받으므로 `toISOString()` 의 UTC `Z` 접미사를 피한다.
- * 예: "2026-06-18T14:30:00"
+ * Date → ISO 8601 UTC 문자열 (Z 접미사 포함).
+ * 서버가 `OffsetDateTime`/`Instant` 로 받으면 시간대 명시 형식이 안전하다.
+ * 예: KST 02:26 선택 → "2026-06-17T17:26:00.000Z"
  */
-const toLocalDateTimeString = (date: Date) => {
-  const pad = (n: number) => String(n).padStart(2, '0');
-  const yyyy = date.getFullYear();
-  const mm = pad(date.getMonth() + 1);
-  const dd = pad(date.getDate());
-  const hh = pad(date.getHours());
-  const mi = pad(date.getMinutes());
-  const ss = pad(date.getSeconds());
-  return `${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}`;
-};
+const toServerDateTimeString = (date: Date) => date.toISOString();
 
 /** 12시간제 시(1~12) + AM/PM → 0~23 시 */
 const to24Hour = (hour12: number, meridiem: MeridiemT) => {
@@ -106,7 +97,7 @@ function InviteExpiresPicker({
     if (next.getTime() <= now.getTime()) {
       next.setDate(next.getDate() + 1);
     }
-    onConfirm(toLocalDateTimeString(next));
+    onConfirm(toServerDateTimeString(next));
   };
 
   return (

--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
@@ -34,12 +34,6 @@ const formatExpiresInfo = (expiresAt: string | undefined) => {
 
   const now = new Date();
   const remainingMs = expires.getTime() - now.getTime();
-  console.warn('[formatExpiresInfo]', {
-    rawFromServer: expiresAt,
-    parsedKST: expires.toString(),
-    nowKST: now.toString(),
-    remainingMinutes: Math.round(remainingMs / 60_000),
-  });
   if (remainingMs <= 0) return { remainingLabel: '마감', absoluteLabel: '만료됨' };
 
   const totalMinutes = Math.floor(remainingMs / 60_000);
@@ -80,21 +74,14 @@ function InviteFriendsDialog({
   const handleOpenPicker = () => setIsPickerOpen(true);
 
   const handleConfirmExpires = (newExpiresAt: string) => {
-    console.warn('[PATCH 보내는 값]', {
-      newExpiresAt,
-      nowLocalKST: new Date().toString(),
-      currentInviteExpiresAt: inviteExpiresAt,
-    });
     patchInviteExpiryMutation(
       { newExpiresAt },
       {
         onSuccess: () => {
-          console.warn('[PATCH 성공 — 새로고침된 inviteExpiresAt 은 GET 응답에서 확인]');
           toast.success('초대 마감 시각이 변경되었어요.');
           setIsPickerOpen(false);
         },
-        onError: error => {
-          console.error('[PATCH 실패]', error);
+        onError: () => {
           toast.error('마감 시각을 변경하지 못했어요.');
         },
       }

--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
@@ -170,7 +170,10 @@ function InviteFriendsDialog({
       </DrawerContent>
 
       <InviteExpiresPicker
-        key={isPickerOpen ? `picker-${inviteExpiresAt ?? ''}` : 'picker-closed'}
+        // picker 가 열릴 때만 새 인스턴스로 마운트해 initialExpiresAt 을 다시 잡는다.
+        // inviteExpiresAt 변화는 key 에 반영하지 않는다 — 드래그 중 react-query refetch 등으로
+        // 새 값이 들어와도 picker 가 통째로 remount 되어 사용자가 끌던 위치가 0 으로 리셋된다.
+        key={isPickerOpen ? 'picker-open' : 'picker-closed'}
         open={isPickerOpen}
         onOpenChange={setIsPickerOpen}
         initialExpiresAt={inviteExpiresAt}

--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
@@ -34,6 +34,12 @@ const formatExpiresInfo = (expiresAt: string | undefined) => {
 
   const now = new Date();
   const remainingMs = expires.getTime() - now.getTime();
+  console.warn('[formatExpiresInfo]', {
+    rawFromServer: expiresAt,
+    parsedKST: expires.toString(),
+    nowKST: now.toString(),
+    remainingMinutes: Math.round(remainingMs / 60_000),
+  });
   if (remainingMs <= 0) return { remainingLabel: '마감', absoluteLabel: '만료됨' };
 
   const totalMinutes = Math.floor(remainingMs / 60_000);
@@ -74,14 +80,21 @@ function InviteFriendsDialog({
   const handleOpenPicker = () => setIsPickerOpen(true);
 
   const handleConfirmExpires = (newExpiresAt: string) => {
+    console.warn('[PATCH 보내는 값]', {
+      newExpiresAt,
+      nowLocalKST: new Date().toString(),
+      currentInviteExpiresAt: inviteExpiresAt,
+    });
     patchInviteExpiryMutation(
       { newExpiresAt },
       {
         onSuccess: () => {
+          console.warn('[PATCH 성공 — 새로고침된 inviteExpiresAt 은 GET 응답에서 확인]');
           toast.success('초대 마감 시각이 변경되었어요.');
           setIsPickerOpen(false);
         },
-        onError: () => {
+        onError: error => {
+          console.error('[PATCH 실패]', error);
           toast.error('마감 시각을 변경하지 못했어요.');
         },
       }

--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/WheelColumn.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/WheelColumn.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 
 import { cn } from '@/utils/cn';
 
@@ -41,12 +41,16 @@ const WheelColumn = forwardRef<WheelColumnHandleT, WheelColumnProps>(function Wh
   const padRows = Math.floor(visibleRows / 2);
   const containerHeight = itemHeight * visibleRows;
 
-  // 외부 selectedIndex 가 바뀌면 스크롤 위치를 맞춤 (초기 진입 포함).
+  // 첫 마운트에서만 selectedIndex 에 맞춰 스크롤 위치 초기화.
+  // 이후엔 사용자 인터랙션(드래그/클릭) 으로만 위치가 바뀌고, 외부 selectedIndex 는 따라온다.
+  // (effect 가 selectedIndex 변경 시마다 강제 리셋하면 드래그 직후 위치가 되돌아간다.)
+  const hasInitializedRef = useRef(false);
   useEffect(() => {
     const el = containerRef.current;
-    if (!el) return;
+    if (!el || hasInitializedRef.current) return;
     el.scrollTop = selectedIndex * itemHeight;
     lastEmittedIndexRef.current = selectedIndex;
+    hasInitializedRef.current = true;
   }, [selectedIndex, itemHeight]);
 
   const handleScroll = () => {
@@ -75,6 +79,75 @@ const WheelColumn = forwardRef<WheelColumnHandleT, WheelColumnProps>(function Wh
     },
   }));
 
+  // 클릭한 항목으로 부드럽게 스크롤. native scroll-snap 이 가운데 정렬 마무리.
+  const handleItemClick = (index: number) => {
+    const el = containerRef.current;
+    if (!el || index === selectedIndex) return;
+    const clamped = Math.max(0, Math.min(items.length - 1, index));
+    el.scrollTo({ top: clamped * itemHeight, behavior: 'smooth' });
+  };
+
+  /**
+   * 마우스/펜으로 컨테이너를 직접 드래그해 휠을 굴리는 인터랙션.
+   * 드래그 중에는 scroll-snap 을 꺼서 자유롭게 끌고, 떼면 다시 켜서 가까운 항목에 스냅한다.
+   * touch 는 native momentum scroll 이 더 자연스러우니 mouse/pen 만 가로챈다.
+   */
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStateRef = useRef<{ startY: number; startScrollTop: number; moved: boolean } | null>(
+    null
+  );
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === 'touch') return; // touch 는 native 처리
+    const el = containerRef.current;
+    if (!el) return;
+    event.preventDefault();
+    dragStateRef.current = {
+      startY: event.clientY,
+      startScrollTop: el.scrollTop,
+      moved: false,
+    };
+    el.setPointerCapture(event.pointerId);
+    setIsDragging(true);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const state = dragStateRef.current;
+    const el = containerRef.current;
+    if (!state || !el) return;
+    const dy = event.clientY - state.startY;
+    if (Math.abs(dy) > 2) state.moved = true;
+    el.scrollTop = state.startScrollTop - dy;
+  };
+
+  const handlePointerEnd = (event: React.PointerEvent<HTMLDivElement>) => {
+    const state = dragStateRef.current;
+    const el = containerRef.current;
+    if (!state || !el) return;
+    if (el.hasPointerCapture(event.pointerId)) el.releasePointerCapture(event.pointerId);
+    const finalScrollTop = el.scrollTop;
+    dragStateRef.current = null;
+    setIsDragging(false);
+    // 드래그 후 가장 가까운 항목으로 스냅 + 즉시 onChange 호출 (디바운스 의존 X).
+    const nextIndex = Math.round(finalScrollTop / itemHeight);
+    const clamped = Math.max(0, Math.min(items.length - 1, nextIndex));
+    el.scrollTo({ top: clamped * itemHeight, behavior: 'smooth' });
+    if (clamped !== lastEmittedIndexRef.current) {
+      lastEmittedIndexRef.current = clamped;
+      onChange(clamped);
+    }
+  };
+
+  /** 드래그 직후 발생하는 click 이벤트 차단 (드래그 종료를 click 으로 오해하지 않도록). */
+  const handleItemMouseClick = (event: React.MouseEvent<HTMLDivElement>, index: number) => {
+    const state = dragStateRef.current;
+    if (state?.moved) {
+      event.preventDefault();
+      return;
+    }
+    handleItemClick(index);
+  };
+
   const getOpacity = (distance: number) => {
     if (distance === 0) return 1;
     if (distance === 1) return 0.4;
@@ -86,7 +159,16 @@ const WheelColumn = forwardRef<WheelColumnHandleT, WheelColumnProps>(function Wh
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="hide-scrollbar h-full snap-y snap-mandatory overflow-y-scroll"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerEnd}
+        onPointerCancel={handlePointerEnd}
+        className={cn(
+          'hide-scrollbar h-full overflow-y-scroll',
+          // snap 은 컨테이너 차원에서 안 쓴다 — 우리가 scrollTo(N*itemHeight) 로 직접 정렬.
+          // (snap-mandatory 가 들어가면 사용자가 끝까지 끌어도 가장 가까운 항목으로 되돌아간다.)
+          isDragging ? 'cursor-grabbing' : 'cursor-grab'
+        )}
       >
         {/* 위/아래 패딩 — 첫·마지막 항목도 가운데 정렬되도록 */}
         <div style={{ height: itemHeight * padRows }} />
@@ -95,7 +177,8 @@ const WheelColumn = forwardRef<WheelColumnHandleT, WheelColumnProps>(function Wh
           return (
             <div
               key={`${item}-${index}`}
-              className="flex snap-center items-center justify-center body-1-bold text-text-neutral-primary"
+              onClick={event => handleItemMouseClick(event, index)}
+              className="flex w-full select-none items-center justify-center body-1-bold text-text-neutral-primary"
               style={{ height: itemHeight, opacity: getOpacity(distance) }}
             >
               {item}

--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/WheelColumn.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/WheelColumn.tsx
@@ -96,6 +96,9 @@ const WheelColumn = forwardRef<WheelColumnHandleT, WheelColumnProps>(function Wh
   const dragStateRef = useRef<{ startY: number; startScrollTop: number; moved: boolean } | null>(
     null
   );
+  // pointerup 후 발생하는 click 을 차단하기 위한 플래그 — pointerEnd 에서 true,
+  // 그 직후의 click 핸들러에서 한 번 소비하면 false 로 되돌린다.
+  const suppressNextClickRef = useRef(false);
 
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
     if (event.pointerType === 'touch') return; // touch 는 native 처리
@@ -126,8 +129,11 @@ const WheelColumn = forwardRef<WheelColumnHandleT, WheelColumnProps>(function Wh
     if (!state || !el) return;
     if (el.hasPointerCapture(event.pointerId)) el.releasePointerCapture(event.pointerId);
     const finalScrollTop = el.scrollTop;
+    const wasMoved = state.moved;
     dragStateRef.current = null;
     setIsDragging(false);
+    // 드래그였다면 뒤이어 발생할 click 이벤트를 한 번만 차단해 의도치 않은 점프를 막는다.
+    if (wasMoved) suppressNextClickRef.current = true;
     // 드래그 후 가장 가까운 항목으로 스냅 + 즉시 onChange 호출 (디바운스 의존 X).
     const nextIndex = Math.round(finalScrollTop / itemHeight);
     const clamped = Math.max(0, Math.min(items.length - 1, nextIndex));
@@ -138,10 +144,10 @@ const WheelColumn = forwardRef<WheelColumnHandleT, WheelColumnProps>(function Wh
     }
   };
 
-  /** 드래그 직후 발생하는 click 이벤트 차단 (드래그 종료를 click 으로 오해하지 않도록). */
+  /** 드래그 직후 발생하는 click 이벤트 차단 (pointerup 의 suppress 플래그를 한 번만 소비). */
   const handleItemMouseClick = (event: React.MouseEvent<HTMLDivElement>, index: number) => {
-    const state = dragStateRef.current;
-    if (state?.moved) {
+    if (suppressNextClickRef.current) {
+      suppressNextClickRef.current = false;
       event.preventDefault();
       return;
     }

--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/WheelColumn.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/WheelColumn.tsx
@@ -178,7 +178,7 @@ const WheelColumn = forwardRef<WheelColumnHandleT, WheelColumnProps>(function Wh
             <div
               key={`${item}-${index}`}
               onClick={event => handleItemMouseClick(event, index)}
-              className="flex w-full select-none items-center justify-center body-1-bold text-text-neutral-primary"
+              className="flex w-full items-center justify-center body-1-bold text-text-neutral-primary select-none"
               style={{ height: itemHeight, opacity: getOpacity(distance) }}
             >
               {item}

--- a/apps/web/src/app/tournament/[id]/create/_components/owner-started-dialog/OwnerStartedDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/owner-started-dialog/OwnerStartedDialog.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { FireIconFill } from '@/assets/icons/fill';
+import Button from '@/components/button';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/dialog';
+
+type OwnerStartedDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** "토너먼트 시작하기" — 본인(CLONE) 시작 흐름 진입 */
+  onStart: () => void;
+  /** 담긴 후보 수 — "N강" 표시에 그대로 사용 */
+  itemCount: number;
+};
+
+/**
+ * 주최자가 ROOT 토너먼트를 시작한 사실을 참여자에게 알리는 모달.
+ * SSE(TOURNAMENT_STARTED) 또는 폴링으로 `ownerStarted: false → true` 변화를 감지해 자동 노출된다.
+ */
+function OwnerStartedDialog({
+  open,
+  onOpenChange,
+  onStart,
+  itemCount,
+}: OwnerStartedDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton={false} className="flex flex-col items-center gap-5 p-5">
+        <FireIconFill className="size-10 text-icon-accent" aria-hidden />
+
+        <div className="flex flex-col items-center gap-2">
+          <DialogTitle className="text-center heading-1 text-text-neutral-primary">
+            주최자가 토너먼트를 시작했어요!
+          </DialogTitle>
+          <DialogDescription className="text-center body-1-medium text-text-neutral-tertiary">
+            지금 바로 {itemCount}강 토너먼트를 시작해 보세요.
+          </DialogDescription>
+        </div>
+
+        <Button variant="primary" size="lg" className="w-full" onClick={onStart}>
+          토너먼트 시작하기
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default OwnerStartedDialog;

--- a/apps/web/src/app/tournament/[id]/create/_components/owner-started-dialog/OwnerStartedDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/owner-started-dialog/OwnerStartedDialog.tsx
@@ -17,12 +17,7 @@ type OwnerStartedDialogProps = {
  * 주최자가 ROOT 토너먼트를 시작한 사실을 참여자에게 알리는 모달.
  * SSE(TOURNAMENT_STARTED) 또는 폴링으로 `ownerStarted: false → true` 변화를 감지해 자동 노출된다.
  */
-function OwnerStartedDialog({
-  open,
-  onOpenChange,
-  onStart,
-  itemCount,
-}: OwnerStartedDialogProps) {
+function OwnerStartedDialog({ open, onOpenChange, onStart, itemCount }: OwnerStartedDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent showCloseButton={false} className="flex flex-col items-center gap-5 p-5">

--- a/apps/web/src/app/tournament/[id]/create/_components/owner-started-dialog/OwnerStartedDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/owner-started-dialog/OwnerStartedDialog.tsx
@@ -11,13 +11,21 @@ type OwnerStartedDialogProps = {
   onStart: () => void;
   /** 담긴 후보 수 — "N강" 표시에 그대로 사용 */
   itemCount: number;
+  /** 시작 mutation 진행 중 여부 — 빠른 연타로 인한 중복 호출을 막기 위해 버튼을 비활성한다. */
+  isPending?: boolean;
 };
 
 /**
  * 주최자가 ROOT 토너먼트를 시작한 사실을 참여자에게 알리는 모달.
  * SSE(TOURNAMENT_STARTED) 또는 폴링으로 `ownerStarted: false → true` 변화를 감지해 자동 노출된다.
  */
-function OwnerStartedDialog({ open, onOpenChange, onStart, itemCount }: OwnerStartedDialogProps) {
+function OwnerStartedDialog({
+  open,
+  onOpenChange,
+  onStart,
+  itemCount,
+  isPending = false,
+}: OwnerStartedDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent showCloseButton={false} className="flex flex-col items-center gap-5 p-5">
@@ -32,7 +40,13 @@ function OwnerStartedDialog({ open, onOpenChange, onStart, itemCount }: OwnerSta
           </DialogDescription>
         </div>
 
-        <Button variant="primary" size="lg" className="w-full" onClick={onStart}>
+        <Button
+          variant="primary"
+          size="lg"
+          className="w-full"
+          onClick={onStart}
+          disabled={isPending}
+        >
           토너먼트 시작하기
         </Button>
       </DialogContent>

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-header/ConfirmExitDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-header/ConfirmExitDialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Button from '@/components/button';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/dialog';
 
 import ConfirmExitBasket from '../../_assets/confirm-exit-basket.svg';
@@ -35,20 +36,12 @@ function ConfirmExitDialog({ open, onOpenChange, onConfirm }: ConfirmExitDialogP
         </div>
 
         <div className="flex w-full gap-2">
-          <button
-            type="button"
-            onClick={handleCancel}
-            className="flex h-13 flex-1 cursor-pointer items-center justify-center rounded-xl border border-border-neutral-muted bg-bg-layer-default body-1-semibold text-text-neutral-primary"
-          >
+          <Button variant="secondary" size="lg" onClick={handleCancel}>
             계속 담기
-          </button>
-          <button
-            type="button"
-            onClick={onConfirm}
-            className="flex h-13 flex-1 cursor-pointer items-center justify-center rounded-xl bg-bg-neutral-primary body-1-semibold text-text-neutral-inverse"
-          >
+          </Button>
+          <Button variant="primary" size="lg" onClick={onConfirm}>
             나가기
-          </button>
+          </Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/ByeWarningDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/ByeWarningDialog.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { AlertIconFill } from '@/assets/icons/fill';
+import Button from '@/components/button';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/dialog';
+
+type ByeWarningDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** "상품 더 담기" — 모달 닫기만 (사용자가 후보를 더 추가하러 돌아감) */
+  onAddMore: () => void;
+  /** "시작하기" — 부전승 포함된 채로 토너먼트 시작 진행 */
+  onConfirm: () => void;
+};
+
+/**
+ * 후보 개수가 2의 거듭제곱(2, 4, 8, 16, 32) 이 아닐 때 시작 직전에 노출되는 안내 모달.
+ * 일부 후보가 자동으로 다음 라운드에 올라가는 부전승이 발생함을 사용자에게 알린다.
+ */
+function ByeWarningDialog({ open, onOpenChange, onAddMore, onConfirm }: ByeWarningDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton={false} className="flex flex-col items-center gap-3 p-5">
+        <AlertIconFill className="size-10 text-icon-accent" aria-hidden />
+
+        <div className="flex flex-col items-center gap-2">
+          <DialogTitle className="text-center heading-1 text-text-neutral-primary">
+            부전승이 포함돼요
+          </DialogTitle>
+          <DialogDescription className="text-center body-1-medium text-text-neutral-tertiary">
+            상품 수가 2, 4, 8, 16, 32개가 아니면
+            <br />
+            일부 상품은 자동으로 다음 라운드에 올라가요.
+          </DialogDescription>
+        </div>
+
+        <div className="mt-1 flex w-full gap-2">
+          <Button variant="secondary" size="lg" onClick={onAddMore}>
+            상품 더 담기
+          </Button>
+          <Button variant="primary" size="lg" onClick={onConfirm}>
+            시작하기
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default ByeWarningDialog;

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/ConfirmStartDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/ConfirmStartDialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Button from '@/components/button';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/dialog';
 
 import ConfirmStartFace from '../../_assets/confirm-start-face.svg';
@@ -30,20 +31,12 @@ function ConfirmStartDialog({ open, onOpenChange, onConfirm }: ConfirmStartDialo
         </div>
 
         <div className="flex w-full gap-2">
-          <button
-            type="button"
-            onClick={handleCancel}
-            className="flex h-13 flex-1 cursor-pointer items-center justify-center rounded-xl border border-border-neutral-muted bg-bg-layer-default body-1-semibold text-text-neutral-primary"
-          >
+          <Button variant="secondary" size="lg" onClick={handleCancel}>
             돌아가기
-          </button>
-          <button
-            type="button"
-            onClick={onConfirm}
-            className="flex h-13 flex-1 cursor-pointer items-center justify-center rounded-xl bg-bg-neutral-primary body-1-semibold text-text-neutral-inverse"
-          >
+          </Button>
+          <Button variant="primary" size="lg" onClick={onConfirm}>
             바로 시작할래요
-          </button>
+          </Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/TournamentStartButton.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/TournamentStartButton.tsx
@@ -64,7 +64,10 @@ function TournamentStartButton({
     startTournament();
   };
 
-  const isDisabled = isWaitingForOwnerStart || (!isDepositClosed && (count < 2 || hasUnreadyItem));
+  // 마감(isDepositClosed) 된 참여자는 후보 수와 무관하게 시작 불가.
+  // 그 외에는 후보 2개 미만 / 아직 처리중인 아이템이 있으면 비활성.
+  const isDisabled =
+    isWaitingForOwnerStart || isDepositClosed || count < 2 || hasUnreadyItem;
 
   if (count === 0) return null;
 

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/TournamentStartButton.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/TournamentStartButton.tsx
@@ -92,8 +92,7 @@ function TournamentStartButton({
 
   // 마감(isDepositClosed) 된 참여자는 후보 수와 무관하게 시작 불가.
   // 그 외에는 후보 2개 미만 / 아직 처리중인 아이템이 있으면 비활성.
-  const isDisabled =
-    isWaitingForOwnerStart || isDepositClosed || count < 2 || hasUnreadyItem;
+  const isDisabled = isWaitingForOwnerStart || isDepositClosed || count < 2 || hasUnreadyItem;
 
   if (count === 0) return null;
 

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/TournamentStartButton.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/TournamentStartButton.tsx
@@ -5,9 +5,16 @@ import { useEffect, useState } from 'react';
 import Button from '@/components/button';
 
 import { usePostTournamentStart } from '../../_hooks/usePostTournamentStart';
+import ByeWarningDialog from './ByeWarningDialog';
 import ConfirmStartDialog from './ConfirmStartDialog';
 
 const PARTICIPANT_TOOLTIP_DURATION_MS = 3_000;
+
+/**
+ * count 가 2의 거듭제곱(2, 4, 8, 16, 32) 인지 검사.
+ * 아니면 부전승이 발생하므로 사용자에게 안내 모달을 띄운다.
+ */
+const isPowerOfTwo = (n: number) => n >= 2 && (n & (n - 1)) === 0;
 
 type TournamentStartButtonProps = {
   count: number;
@@ -29,6 +36,7 @@ function TournamentStartButton({
   isParticipant = false,
 }: TournamentStartButtonProps) {
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [isByeWarningOpen, setIsByeWarningOpen] = useState(false);
   const { postTournamentStartMutation, isPostTournamentStartPending } =
     usePostTournamentStart(tournamentId);
 
@@ -45,9 +53,12 @@ function TournamentStartButton({
 
   const startTournament = () => postTournamentStartMutation();
 
-  const handleClick = () => {
-    if (isWaitingForOwnerStart) return;
-    // 참여자는 본인 CLONE 만 만드는 거라 "담지 못한 친구" 안내가 필요 없음 — 바로 시작
+  /**
+   * 부전승 체크를 통과한 후의 분기:
+   * - 참여자(CLONE) 는 본인만 시작하니 바로 진행.
+   * - 주최자는 친구가 있으면 ConfirmStartDialog (담지 못한 친구 안내), 없으면 바로 시작.
+   */
+  const proceedAfterByeCheck = () => {
     if (isParticipant) {
       startTournament();
       return;
@@ -57,6 +68,21 @@ function TournamentStartButton({
       return;
     }
     startTournament();
+  };
+
+  const handleClick = () => {
+    if (isWaitingForOwnerStart) return;
+    // 후보 수가 2의 거듭제곱이 아니면 부전승 발생 — 먼저 안내 모달 노출.
+    if (!isPowerOfTwo(count)) {
+      setIsByeWarningOpen(true);
+      return;
+    }
+    proceedAfterByeCheck();
+  };
+
+  const handleByeWarningConfirm = () => {
+    setIsByeWarningOpen(false);
+    proceedAfterByeCheck();
   };
 
   const handleConfirm = () => {
@@ -99,6 +125,13 @@ function TournamentStartButton({
         open={isConfirmOpen}
         onOpenChange={setIsConfirmOpen}
         onConfirm={handleConfirm}
+      />
+
+      <ByeWarningDialog
+        open={isByeWarningOpen}
+        onOpenChange={setIsByeWarningOpen}
+        onAddMore={() => setIsByeWarningOpen(false)}
+        onConfirm={handleByeWarningConfirm}
       />
     </>
   );

--- a/apps/web/src/app/tournament/[id]/result/_components/ReceiptPaper.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ReceiptPaper.tsx
@@ -1,5 +1,4 @@
 import { Kode_Mono } from 'next/font/google';
-import Image from 'next/image';
 import { forwardRef } from 'react';
 
 import PikiReceiptLogo from '@/assets/images/piki-receipt-logo.svg';
@@ -138,19 +137,28 @@ type ProductCardProps = {
   highlight?: boolean;
 };
 
+/**
+ * 외부 쇼핑몰 이미지 URL 을 Next.js 의 이미지 proxy(`/_next/image`) 경유 URL 로 변환.
+ * 영수증 캡처 시 html-to-image 는 cross-origin 이미지를 캔버스에 그리지 못해 상품 사진만 빠진다.
+ * 동일 origin 으로 가져오면 캔버스 tainted 문제가 해소된다.
+ */
+const toSameOriginImageUrl = (originalUrl: string, width = 120) =>
+  `/_next/image?url=${encodeURIComponent(originalUrl)}&w=${width}&q=75`;
+
 function ProductCard({ product, highlight = false }: ProductCardProps) {
   return (
     <div className="flex items-center gap-3 px-5">
       <div className="relative size-15 shrink-0">
         <div className="size-full overflow-hidden rounded-md bg-gray-50">
           {product.imageUrl && (
-            <Image
-              src={product.imageUrl}
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={toSameOriginImageUrl(product.imageUrl)}
               alt={product.name}
               width={60}
               height={60}
               className="size-full object-cover"
-              unoptimized
+              crossOrigin="anonymous"
             />
           )}
         </div>

--- a/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
@@ -129,20 +129,15 @@ function ResultClient({ tournamentId }: ResultClientProps) {
 
         {/*
           친구 토너먼트 결과보기 카드 노출 + 라우팅.
-          - 그룹 결과 조회는 ROOT 토너먼트 id 로만 가능 (백엔드 정책)
-          - ROOT 사용자(주최자 / 친구 초대 멤버): 본인 id 가 ROOT 라 그대로 사용
-          - CLONE 사용자(플레이 링크 게스트): 응답의 sourceTournamentId 로 ROOT 지정
-          - 친구 유무는 클릭 시 group-result API 응답으로 판단한다 (캐시 의존 X)
+          - ROOT 사용자(주최자 / 친구 초대 멤버) 에게만 노출. 본인 id 가 그대로 group-result 대상이다.
+          - CLONE 사용자(플레이 링크 게스트) 는 ROOT 토너먼트의 친구 일원이 아니라 결과 카드가 의미 없으므로 숨긴다.
+          - 친구 유무는 클릭 시 group-result API 응답으로 판단한다 (캐시 의존 X).
         */}
-        <div className="mx-5">
-          <GroupResultEntryCard
-            tournamentId={
-              tournamentData.isRoot
-                ? tournamentId
-                : (tournamentData.sourceTournamentId ?? tournamentId)
-            }
-          />
-        </div>
+        {tournamentData.isRoot && (
+          <div className="mx-5">
+            <GroupResultEntryCard tournamentId={tournamentId} />
+          </div>
+        )}
       </div>
 
       {/* 하단 버튼 — 시안상 단일 CTA */}

--- a/apps/web/src/app/tournament/[id]/result/_utils/shareReceiptImage.ts
+++ b/apps/web/src/app/tournament/[id]/result/_utils/shareReceiptImage.ts
@@ -61,7 +61,10 @@ export const shareReceiptImage = async (element: HTMLElement): Promise<boolean> 
   const pixelRatio = typeof window !== 'undefined' ? Math.max(window.devicePixelRatio || 2, 2) : 2;
   const blob = await toBlob(element, {
     pixelRatio,
-    cacheBust: true,
+    // cacheBust:true 는 URL 에 query 를 붙여 새 요청을 만드는데, S3 가 CORS 헤더를 일관되게
+    // 안 주면 preflight 가 매번 일어나 차단 위험이 커진다. 브라우저 캐시를 활용해 CORS 검증을 줄인다.
+    cacheBust: false,
+    fetchRequestInit: { cache: 'force-cache', mode: 'cors' },
     backgroundColor: '#ffffff',
   });
   if (!blob) throw new Error('영수증 이미지 변환 실패');

--- a/apps/web/src/utils/formatDate.ts
+++ b/apps/web/src/utils/formatDate.ts
@@ -6,11 +6,11 @@ export const formatTimeKo = (dateString: string) =>
   });
 
 /**
- * 서버가 LocalDateTime (시간대 없는 시각) 을 응답에 `Z` 접미사를 붙여 내려보내는 경우가 있다.
- * `Z` 가 있으면 `new Date()` 가 UTC 로 해석해 9시간(KST 기준) 어긋난다.
- * Z 를 떼고 로컬 시각으로 파싱한다.
+ * 서버 응답의 ISO 8601 시각 문자열을 Date 로 파싱한다.
+ *
+ * 백엔드가 `Z`(UTC) 접미사 포함한 정상 ISO 형식으로 보내므로 `new Date()` 가 올바르게 로컬 시각으로 변환한다.
+ *
+ * NOTE: 과거 백엔드 변형 시 LocalDateTime 을 시간대 없이 Z 만 붙여 보내 9시간 어긋나던 시기가 있어
+ * Z 를 떼는 처리가 들어갔었으나, 현재는 정상 UTC 형식으로 통일됐다.
  */
-export const parseServerLocalDateTime = (raw: string) => {
-  const stripped = raw.endsWith('Z') ? raw.slice(0, -1) : raw;
-  return new Date(stripped);
-};
+export const parseServerLocalDateTime = (raw: string) => new Date(raw);

--- a/apps/web/src/utils/loginRedirect.ts
+++ b/apps/web/src/utils/loginRedirect.ts
@@ -1,5 +1,5 @@
-import { ROUTES } from '@/consts/route';
 import type { QueryActionValueT } from '@/consts/queryAction';
+import { ROUTES } from '@/consts/route';
 
 const LOGIN_REDIRECT_STORAGE_KEY = 'login_redirect';
 


### PR DESCRIPTION
## 작업 요약

- 토너먼트 시작 흐름에 안내 모달 3종 추가 (부전승 / 담기 시간 종료 / 주최자 시작 알림)
- 초대 마감 시각 picker 의 시간대 / 9시간 어긋남 / 만료 표시 / drag·remount 이슈 일괄 수정
- 영수증 이미지 캡처에서 상품 사진 누락 및 CORS 차단 회피
- 토큰 갱신·홈/보관함 헤더 등 기타 자잘한 QA 보정 누적분 머지

## 작업 세부 내용

### 토너먼트 시작 흐름
- `ByeWarningDialog` 신규 — 후보 수가 2의 거듭제곱이 아닐 때 시작 직전에 노출 (부전승 안내)
- `DepositClosedDialog` 신규 — 담기 시간 만료 시 주최자에게 자동 노출, 시작 유도
- `OwnerStartedDialog` 신규 — 주최자 시작 SSE(`TOURNAMENT_STARTED`) 신호를 받아 `ownerStarted: false→true` 변화 감지 시 참여자에게 자동 노출
- 시작 버튼 비활성 조건 정리 — 초대 마감 시 참여자는 후보 수와 무관하게 시작 불가
- 기존 `ConfirmStartDialog` / `ConfirmExitDialog` 의 raw `<button>` → 공통 `Button` 컴포넌트로 통일

### 초대 마감 시각 picker (변경 시트)
- 휠 picker 드래그 후 본인 위치가 유지되지 않고 한 칸으로 되돌아가는 버그 수정 (key 에서 `inviteExpiresAt` 의존 제거 → drag 중 react-query refetch 로 인한 remount 차단)
- ISO 8601 UTC (Z 접미사 포함) 형식으로 전송하도록 변경 — 서버 OffsetDateTime/Instant 호환
- 서버가 정상 ISO UTC 로 응답한 후로는 `parseServerLocalDateTime` 의 Z 제거 로직을 제거 (9시간 어긋남으로 "만료됨" 잘못 표시되던 문제 해결)

### 영수증 이미지 공유
- 상품 사진만 캡처에서 빠지던 문제 — `next/image` proxy URL (`/_next/image?url=...`) 로 same-origin 우회
- html-to-image 의 `cacheBust: false` + `fetchRequestInit: { cache: 'force-cache', mode: 'cors' }` 로 S3 / 외부 도메인 CORS 차단 완화

### 결과 페이지
- 플레이 체험 게스트(CLONE) 사용자에게는 결과 페이지의 "전체 결과 보기" 카드를 노출하지 않음

## 연관 이슈

closes #236


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 토너먼트 초대 마감 기간 설정 기능 추가 (기본 30분)
  * 담기 마감 시 자동 알림 다이얼로그 추가
  * 주최자가 토너먼트 시작 시 참여자 알림 다이얼로그 추가
  * 토너먼트 시작 전 부전승 경고 안내 추가

* **Bug Fixes**
  * 영수증 이미지 공유 시 이미지 로딩 최적화
  * 참여자 선택 휠 드래그 상호작용 개선
  * 그룹 결과 표시 조건 수정

* **Improvements**
  * 버튼 스타일 일관성 강화
  * 날짜/시간 형식 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->