### PR TITLE
style: 위시에서 가져오기 CTA 영역 그라데이션 디자인 반영

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
@@ -77,19 +77,28 @@ function ByWishContent({ tournamentId }: ByWishContentProps) {
         </div>
       </main>
 
-      <div className="fixed bottom-0 left-1/2 z-10 flex w-full max-w-120 -translate-x-1/2 gap-[10px] bg-white px-5 py-3">
-        <Button variant="secondary" size="lg" onClick={() => history.back()}>
-          뒤로
-        </Button>
-        <Button
-          variant="primary"
-          size="lg"
-          disabled={selectedIds.length === 0}
-          isLoading={isPostTournamentItemsByWishPending}
-          onClick={handleNext}
-        >
-          다음
-        </Button>
+      <div className="fixed bottom-0 left-1/2 z-10 w-full max-w-120 -translate-x-1/2">
+        <div
+          className="pointer-events-none w-full"
+          style={{
+            height: '66.878px',
+            background: 'linear-gradient(180deg, rgba(244, 244, 246, 0.00) 0%, #F4F4F6 100%)',
+          }}
+        />
+        <div className="flex gap-[10px] bg-[#F4F4F6] px-5 py-3">
+          <Button variant="secondary" size="lg" onClick={() => history.back()}>
+            뒤로
+          </Button>
+          <Button
+            variant="primary"
+            size="lg"
+            disabled={selectedIds.length === 0}
+            isLoading={isPostTournamentItemsByWishPending}
+            onClick={handleNext}
+          >
+            다음
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/tournament/[id]/loading/_components/TournamentBracketAnimation.tsx
+++ b/apps/web/src/app/tournament/[id]/loading/_components/TournamentBracketAnimation.tsx
@@ -147,7 +147,7 @@ function TournamentBracketAnimation() {
           >
             <div
               className="flex size-full items-center justify-center rounded-2xl border-2 border-white bg-gray-50 text-gray-300"
-              style={{ filter: 'drop-shadow(0 0 8px rgba(0,0,0,0.16))' }}
+              style={{ boxShadow: '0 0 8px rgba(0,0,0,0.16)' }}
             >
               <Icon width={iw} height={ih} aria-hidden />
             </div>


### PR DESCRIPTION
## 작업 요약

- 위시에서 가져오기 CTA 영역 그라데이션 및 배경색 디자인 반영
- 토너먼트 로딩 브라켓 아이콘 그림자 스타일 수정

## 작업 세부 내용

- CTA 버튼 영역 상단 그라데이션 오버레이 추가 (height: 66.878px, linear-gradient 투명 → #F4F4F6)
- CTA 버튼 영역 배경색 white → #F4F4F6 변경
- 토너먼트 로딩 브라켓 아이콘 `filter: drop-shadow` → `box-shadow`로 변경 (border-radius 적용 개선)

## 스크린샷
<img width="480" height="837" alt="스크린샷 2026-06-18 오후 5 22 39" src="https://github.com/user-attachments/assets/950d0af8-c237-4e0c-afa7-40e50a1ce327" />


## 연관 이슈

closes #244


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 토너먼트 생성 화면의 하단 버튼 영역 레이아웃을 개선했습니다.
  * 토너먼트 브래킷 애니메이션의 시각 효과를 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->