### PR TITLE
style: 하단 바텀 내비 그라디언트 레이어 추가

### DIFF
--- a/apps/web/src/components/bottom-tab-bar/index.tsx
+++ b/apps/web/src/components/bottom-tab-bar/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 
 import { usePathname, useRouter } from 'next/navigation';
 import { createPortal } from 'react-dom';
@@ -17,15 +17,15 @@ const TABS = [
 function BottomTabBar() {
   const router = useRouter();
   const pathname = usePathname();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+  const isClient = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false
+  );
 
   return (
     <>
-      {mounted && createPortal(
+      {isClient && createPortal(
         <div
           className="fixed bottom-0 left-1/2 z-10 h-[240px] w-full max-w-120 -translate-x-1/2 pointer-events-none"
           style={{

--- a/apps/web/src/components/bottom-tab-bar/index.tsx
+++ b/apps/web/src/components/bottom-tab-bar/index.tsx
@@ -1,6 +1,9 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+
 import { usePathname, useRouter } from 'next/navigation';
+import { createPortal } from 'react-dom';
 
 import HeartIconFill from '@/assets/icons/fill/heart.svg';
 import HomeIconFill from '@/assets/icons/fill/home.svg';
@@ -14,9 +17,24 @@ const TABS = [
 function BottomTabBar() {
   const router = useRouter();
   const pathname = usePathname();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   return (
-    <div className="inline-flex items-center rounded-[100px] bg-white p-1 shadow-[0_0_8px_0_rgba(0,0,0,0.04)]">
+    <>
+      {mounted && createPortal(
+        <div
+          className="fixed bottom-0 left-1/2 z-10 h-[240px] w-full max-w-120 -translate-x-1/2 pointer-events-none"
+          style={{
+            background: 'linear-gradient(180deg, rgba(0, 0, 0, 0.00) 0%, rgba(0, 0, 0, 0.20) 100%)',
+          }}
+        />,
+        document.body
+      )}
+      <div className="inline-flex items-center rounded-[100px] bg-white p-1 shadow-[0_0_8px_0_rgba(0,0,0,0.04)]">
       {TABS.map(({ label, icon: Icon, href }) => {
         const isActive =
           label === '보관'
@@ -42,6 +60,7 @@ function BottomTabBar() {
         );
       })}
     </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## 작업 요약

- 바텀 내비 하단 그라디언트 레이어 추가

## 작업 세부 내용

- `BottomTabBar` 컴포넌트에 `createPortal`로 그라디언트 레이어 추가
- 포털로 `document.body`에 마운트해 부모 transform 영향 없이 뷰포트 기준 고정
- `max-w-120` 적용으로 앱 레이아웃 영역 내에만 표시
- SSR 환경 대응을 위해 `mounted` 상태로 클라이언트 마운트 후 렌더링

## 스크린샷
<img width="485" height="837" alt="스크린샷 2026-06-18 오후 5 55 04" src="https://github.com/user-attachments/assets/360c8a99-2acf-41c4-999c-ba70efa812a4" />


## 연관 이슈

closes #246
