### PR TITLE
style: 토너먼트 준비 페이지 상태 라벨 주최자·참여자 디자인 통일

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -166,7 +166,6 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
         <TournamentItemBasketStatus
           isProcessing={hasPendingItem}
           count={pending?.items.length ?? 0}
-          isDepositClosed={isDepositClosed}
         />
       </div>
 

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket-status/TournamentItemBasketStatus.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket-status/TournamentItemBasketStatus.tsx
@@ -3,14 +3,9 @@ import { cn } from '@/utils/cn';
 type TournamentItemBasketStatusProps = {
   isProcessing: boolean;
   count: number;
-  isDepositClosed?: boolean;
 };
 
-function TournamentItemBasketStatus({
-  isProcessing,
-  count,
-  isDepositClosed = false,
-}: TournamentItemBasketStatusProps) {
+function TournamentItemBasketStatus({ isProcessing, count }: TournamentItemBasketStatusProps) {
   const label = (() => {
     if (isProcessing) return '담는 중...';
     if (count === 0) return '후보를 장바구니에 담아보세요';
@@ -18,16 +13,15 @@ function TournamentItemBasketStatus({
     return `${count}/32`;
   })();
 
-  const isBlue = !isDepositClosed && count < 2;
+  const isBlue = count < 2;
 
   return (
     <div className="flex items-center justify-center">
       <span
         className={cn(
           'inline-flex h-10 items-center rounded-3xl border px-3 body-2-regular',
-          isDepositClosed && 'border-transparent bg-transparent text-text-accent',
           isBlue && 'border-blue-100 bg-blue-50 text-text-accent',
-          !isDepositClosed && !isBlue && 'border-gray-100 bg-gray-75 text-gray-600'
+          !isBlue && 'border-gray-100 bg-gray-75 text-gray-600'
         )}
       >
         {label}


### PR DESCRIPTION
## 작업 요약
- 주최자·참여자 간 상태 라벨 디자인 불일치 수정 — `isDepositClosed` 조건 제거 후 count 기반으로 스타일 통일


## 작업 세부 내용

### 변경 전
`isDepositClosed` 상태일 때 투명 배경 적용으로 주최자·참여자 간 디자인 불일치 발생
```tsx
border-transparent bg-transparent // isDepositClosed 시 적용
```

### 변경 후
`isDepositClosed` 조건 제거, count 기반으로만 스타일 분기

| 조건 | 스타일 |
|------|--------|
| `count < 2` | `border-blue-100 bg-blue-50` (파란 배경) |
| `count ≥ 2` | `border-gray-100 bg-gray-75` (회색 배경) |

- `TournamentItemBasketStatus`에서 `isDepositClosed` prop 제거

## 연관 이슈

closes #248 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* 토너먼트 바스켓 상태 표시 로직이 간소화되었습니다. 바스켓 상태 인디케이터가 이제 더욱 일관되고 명확하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->