### PR TITLE
fix: 장바구니 리사이즈 후 다시 커지지 않는 버그 수정

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
@@ -97,7 +97,7 @@ function TournamentItemBasketCarousel({
     return (
       <div
         ref={containerRef}
-        className="flex min-h-0 w-full flex-col items-center justify-start px-5"
+        className="flex min-h-0 w-full flex-1 flex-col items-center justify-start px-5"
       >
         <TournamentItemBasket
           basketIndex={0}


### PR DESCRIPTION
## 작업 요약
- 화면 축소 후 다시 확대 시 장바구니 크기가 복구되지 않는 버그 수정


## 작업 세부 내용

### 원인

단일 바구니(비-캐러셀) 컨테이너 div에 `flex-1`이 없어, 컨테이너 높이가 바구니 크기에 종속되는 구조였음.

**화면 축소 시** (정상)
```
화면 축소 → 바구니 축소 → 컨테이너 축소 → ResizeObserver 감지 
```

**화면 확대 시** (버그)
```
화면 확대 → 바구니는 이전 maxWidth 유지
         → 컨테이너도 그대로
         → ResizeObserver 미발동
         → 바구니 미복구 x
```

### 수정

컨테이너에 `flex-1` 추가 → 부모 flex 공간을 먼저 채우도록 변경

```
화면 확대 → 컨테이너가 먼저 늘어남
         → ResizeObserver 발동
         → maxWidth 재계산
         → 바구니 크기 복구 
```
## 연관 이슈

closes #249
