### PR TITLE
fix: 장바구니 가득 찬 상태에서 아이템 삭제 시 장바구니 사라지는 버그 수정

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
@@ -58,11 +58,11 @@ function TournamentItemBasketCarousel({
 
   /** 초기 이미지 위치 틀어짐 방지 */
   useLayoutEffect(() => {
-    if (!carouselApi) return;
+    if (!carouselApi || !isCarouselEnabled) return;
 
     carouselApi.reInit();
     carouselApi.scrollTo(carouselApi.selectedScrollSnap(), true);
-  }, [carouselApi, activeBasketCount]);
+  }, [carouselApi, activeBasketCount, isCarouselEnabled]);
 
   useEffect(() => {
     if (!carouselApi) return;
@@ -90,7 +90,9 @@ function TournamentItemBasketCarousel({
   const gap = isCarouselEnabled ? 16 : 0;
   let basketMaxHeight: number | undefined;
   if (containerHeight) {
-    basketMaxHeight = containerHeight - (indicatorHeight ?? 0) - gap;
+    basketMaxHeight = isCarouselEnabled
+      ? containerHeight - (indicatorHeight ?? 0) - gap
+      : containerHeight;
   }
 
   if (!isCarouselEnabled) {


### PR DESCRIPTION
## 작업 요약

- 8개 가득 찬 장바구니에서 FAILED 아이템 삭제 시 장바구니가 사라지는 버그 수정


## 작업 세부 내용
### 원인

캐러셀 → 비캐러셀 전환 시 stale `indicatorHeight` 값이 매 `ResizeObserver` 사이클마다 누적 차감되는 수렴 루프 발생.

**수렴 루프 흐름**
```
캐러셀 → 비캐러셀 전환
  → indicatorHeight stale 값 잔존 (리셋 안 됨)
  → basketMaxHeight = containerHeight - indicatorHeight(stale) 계산
  → ResizeObserver가 containerHeight를 바구니 높이로 갱신
  → 다음 사이클에 다시 차감
  → 반복 → 0으로 수렴 → 바구니 소멸 x
```

### 수정

**1. 비캐러셀 모드 분기 처리**

비캐러셀 모드에서는 `indicatorHeight`를 차감하지 않도록 분기 추가.

**2. `flex-1` 추가**

`containerHeight`를 바구니 크기가 아닌 부모 flex 공간 기준으로 측정하도록 변경
→ 순환 의존 제거

```
화면 확대 → 컨테이너가 먼저 늘어남 (flex-1)
         → ResizeObserver 발동
         → maxWidth 재계산
         → 바구니 크기 복구 
```

## 함께 수정된 동작
- 화면 축소 → 확대 시 장바구니 크기가 올바르게 반응하지 않던 문제 함께 해소


## 연관 이슈
closes #250 
