### PR TITLE
fix: SSE 알림 구독 토큰 만료 시 재연결 처리

### DIFF
--- a/apps/web/src/hooks/useNotificationSSE.ts
+++ b/apps/web/src/hooks/useNotificationSSE.ts
@@ -8,7 +8,7 @@ import { ENDPOINTS } from '@/consts/api';
 import { ROUTES } from '@/consts/route';
 import { CLIENT_TYPE } from '@/consts/webBridge';
 import type { NotificationSsePayloadT } from '@/types/notification';
-import { getCookie } from '@/utils/cookie';
+import { getCookie, setCookie } from '@/utils/cookie';
 import { isWebview } from '@/utils/webBridge';
 
 const MAX_RETRY_DELAY_MS = 30_000;
@@ -80,13 +80,22 @@ export const useNotificationSSE = (enabled: boolean) => {
           if (response.status === 401) {
             // 토큰 만료 시 클라이언트사이드에서 refresh 후 재연결
             try {
-              const refreshRes = await fetch(
-                `${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/token/refresh`,
-                { method: 'POST', credentials: 'include' }
-              );
+              const refreshRes = await fetch(ENDPOINTS.AUTH_TOKEN_REFRESH, {
+                method: 'POST',
+                credentials: 'include',
+              });
               if (!refreshRes.ok) {
                 cancelled = true;
                 throw new Error('unauthorized');
+              }
+              if (isWebview()) {
+                const body = await refreshRes.json();
+                const { access_token: newAccessToken, refresh_token: newRefreshToken } =
+                  body.data;
+                if (newAccessToken && newRefreshToken) {
+                  setCookie('access_token', newAccessToken, { hours: 1 });
+                  setCookie('refresh_token', newRefreshToken, { days: 14 });
+                }
               }
               // refresh 성공 → onerror backoff로 재연결
               throw new Error('token-refreshed');

--- a/apps/web/src/hooks/useNotificationSSE.ts
+++ b/apps/web/src/hooks/useNotificationSSE.ts
@@ -77,10 +77,25 @@ export const useNotificationSSE = (enabled: boolean) => {
             retryDelayRef.current = 1_000;
             return;
           }
-          // 401이면 재연결하지 않음
           if (response.status === 401) {
-            cancelled = true;
-            throw new Error('unauthorized');
+            // 토큰 만료 시 클라이언트사이드에서 refresh 후 재연결
+            try {
+              const refreshRes = await fetch(
+                `${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/token/refresh`,
+                { method: 'POST', credentials: 'include' }
+              );
+              if (!refreshRes.ok) {
+                cancelled = true;
+                throw new Error('unauthorized');
+              }
+              // refresh 성공 → onerror backoff로 재연결
+              throw new Error('token-refreshed');
+            } catch (err) {
+              if (err instanceof Error && err.message === 'unauthorized') {
+                cancelled = true;
+              }
+              throw err;
+            }
           }
           throw new Error(`SSE open failed: ${response.status}`);
         },


### PR DESCRIPTION
## 작업 요약

- `access_token` 만료 후 SSE 재연결 시 로그인이 풀리는 버그 수정 — 401 수신 시 클라이언트사이드에서 직접 refresh 후 재연결하도록 변경

## 작업 세부 내용


### 문제 상황

`access_token` 만료 후 SSE 알림 구독(`/api/notifications/subscribe`)이 끊기고 재연결을 시도하면 로그인이 풀리는 현상 발생

```
GET /api/notifications/subscribe 401 in 18ms
⨯ unhandledRejection: Error: unauthorized at useNotificationSSE (useNotificationSSE.ts:83)
⨯ Error: failed to pipe response (application-code: 6.7min)
```

### 근본 원인

**1. 미들웨어가 `/api/*` 경로를 제외함**

페이지 요청은 미들웨어에서 토큰 갱신이 자동으로 이루어지지만 `/api/notifications/subscribe`는 미들웨어를 거치지 않아 만료된 토큰이 그대로 upstream에 전달됨

```ts
// proxy.ts
matcher: ['/((?!api|_next/static|...).*)']
```

---

**2. 훅이 401 수신 시 재연결을 완전히 포기함**

토큰 갱신 시도 없이 `cancelled = true`로 바로 종료

```ts
// before
if (response.status === 401) {
  cancelled = true; // 재연결 영구 차단
  throw new Error('unauthorized');
}
```

---

**3. 서버사이드 refresh가 로그인 풀림 부작용 유발**

Route Handler에서 `postTokenRefreshServer`를 호출하면 `refresh_token`이 소진됨
이때 다른 API 요청이 동시에 401을 받아 `client.ts` interceptor도 동일한 `refresh_token`으로 갱신을 시도하면 이미 폐기된 토큰으로 요청 → 갱신 실패 → 로그인 페이지로 강제 redirect

### 수정

401 수신 시 클라이언트사이드에서 직접 refresh 엔드포인트를 호출한 뒤 재연결하도록 변경

```ts
// after
if (response.status === 401) {
  try {
    const refreshRes = await fetch(
      `${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/token/refresh`,
      { method: 'POST', credentials: 'include' }
    );
    if (!refreshRes.ok) {
      cancelled = true;
      throw new Error('unauthorized');
    }
    // refresh 성공 → onerror backoff로 재연결
    throw new Error('token-refreshed');
  } catch (err) {
    if (err instanceof Error && err.message === 'unauthorized') {
      cancelled = true;
    }
    throw err;
  }
}
```

**포인트**
- `credentials: 'include'`로 호출 → 브라우저가 `Set-Cookie`를 직접 처리하여 새 토큰이 쿠키에 저장됨
- refresh 성공 시 `throw`로 `onerror` 핸들러로 흘려보내 기존 backoff 재연결 로직 재사용
- refresh 실패 시에만 `cancelled = true`로 재연결 포기
- refresh가 항상 클라이언트에서만 발생하므로 `client.ts` interceptor와 충돌 없음

### 변경 파일
- `src/hooks/useNotificationSSE.ts` — 401 수신 시 클라이언트사이드 refresh 후 재연결 로직 추가


## 연관 이슈
closes #253 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 알림 수신 서비스의 인증 오류 처리 개선. 인증 오류 발생 시 토큰 갱신을 자동으로 시도하고, 갱신 성공 시 서비스 연결을 자동으로 재설정합니다. 토큰 갱신이 실패한 경우에만 인증 오류로 처리되며, 기타 오류 재시도 메커니즘은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->