### PR TITLE
style: 토너먼트 담기 화면 레이아웃 및 UI 개선

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -74,7 +74,7 @@ async function RootLayout({
       <body className="h-full overflow-hidden">
         <Providers>
           {/** TEMP: max width 임시 값 */}
-          <div className="mx-auto hide-scrollbar h-full max-w-120 overflow-y-auto pb-[max(env(safe-area-inset-bottom),0px)] [scrollbar-gutter:stable]">
+          <div className="mx-auto hide-scrollbar h-full max-w-120 overflow-y-auto [scrollbar-gutter:stable]">
             {children}
           </div>
         </Providers>

--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -155,7 +155,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
         </div>
       </div>
 
-      <div className="mt-[5.9dvh] flex min-h-0 flex-1 flex-col gap-5">
+      <div className="mt-[3dvh] flex min-h-0 flex-1 flex-col">
         <TournamentItemBasketCarousel
           items={pending?.items}
           scrollToLast={scrollToLast}
@@ -169,7 +169,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
         />
       </div>
 
-      <div className="flex shrink-0 flex-col gap-3 px-5 pt-[max(6dvh)]">
+      <div className="flex shrink-0 flex-col gap-3 px-5 pt-[max(3dvh)]">
         <TournamentStartButton
           count={pending?.items.length ?? 0}
           tournamentId={tournamentId}

--- a/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantPanel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantPanel.tsx
@@ -117,7 +117,8 @@ function ParticipantPanel({
                 <span
                   key={index}
                   aria-hidden
-                  className="-ml-2 inline-flex size-6.75 items-center justify-center rounded-full border-[1.6px] border-white bg-gray-50 body-2-semibold text-text-neutral-tertiary"
+                  className="-ml-2 inline-flex size-6.75 items-center justify-center rounded-full border-[1.6px] border-white bg-gray-50 body-2-semibold text-text-neutral-tertiary relative"
+                  style={{ zIndex: index + 1 }}
                 >
                   ?
                 </span>

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-header/TournamentHeader.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-header/TournamentHeader.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 import { Header, HeaderIcon } from '@/components/header';
+import { ROUTES } from '@/consts/route';
 
 import ConfirmExitDialog from './ConfirmExitDialog';
 import TournamentGuidePopover from './TournamentGuidePopover';
@@ -22,7 +23,7 @@ function TournamentHeader({ name, hasFriends }: TournamentHeaderProps) {
       setIsExitConfirmOpen(true);
       return;
     }
-    router.back();
+    router.push(ROUTES.HOME);
   };
 
   const handleConfirmExit = () => {

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket-status/TournamentItemBasketStatus.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket-status/TournamentItemBasketStatus.tsx
@@ -16,7 +16,7 @@ function TournamentItemBasketStatus({ isProcessing, count }: TournamentItemBaske
   const isBlue = count < 2;
 
   return (
-    <div className="flex items-center justify-center">
+    <div className="flex items-center justify-center pt-3">
       <span
         className={cn(
           'inline-flex h-10 items-center rounded-3xl border px-3 body-2-regular',

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
 
 import { Carousel, type CarouselApi, CarouselContent, CarouselItem } from '@/components/carousel';
 import useContainerHeight from '@/hooks/useContainerHeight';
@@ -34,6 +35,14 @@ function TournamentItemBasketCarousel({
   const [currentIndex, setCurrentIndex] = useState(0);
 
   const activeBasketCount = useMemo(() => getActiveBasketCount(items.length), [items.length]);
+
+  const prevBasketCountRef = useRef(activeBasketCount);
+  useEffect(() => {
+    if (activeBasketCount > prevBasketCountRef.current) {
+      toast.info('카트가 꽉 찼어요! 새 카트를 만들었어요.');
+    }
+    prevBasketCountRef.current = activeBasketCount;
+  }, [activeBasketCount]);
 
   const prevItemCountRef = useRef(scrollToLast ? 0 : items.length);
 

--- a/apps/web/src/app/tournament/[id]/create/_consts/tournamentItemBasket.ts
+++ b/apps/web/src/app/tournament/[id]/create/_consts/tournamentItemBasket.ts
@@ -2,4 +2,4 @@ export const ITEMS_PER_BASKET = 8;
 export const BASKET_COUNT = 4;
 
 /** 매인 캐러셀 너비가 화면에서 차지하는 퍼센트 (인접 바구니는 100% - 이 값만큼 뺀 나머지 너비를 인접 바구니가 차지) */
-export const BASKET_CAROUSEL_SLIDE_SIZE_PERCENT = 85;
+export const BASKET_CAROUSEL_SLIDE_SIZE_PERCENT = 90;


### PR DESCRIPTION
## 작업 요약

- iOS safe-area 흰 라인 수정, 참여자 프로필 z-index 버그 수정, 뒤로가기 동작 변경 및 카트 만석 토스트 추가


## 작업 세부 내용

### 레이아웃 수정
- root layout wrapper의 `pb-[max(env(safe-area-inset-bottom),0px)]` 제거
  - iOS safe-area로 인한 화면 하단 흰색 라인 노출 문제 수정
- 캐러셀 영역 상단 여백 `5.9dvh → 3dvh`, 시작 버튼 상단 여백 `6dvh → 3dvh`로 조정
- `TournamentItemBasketStatus`를 carousel `flex-1` 컨테이너 밖으로 분리하여 불필요한 빈 영역 제거

---

### 참여자 프로필 z-index 수정
초대 슬롯 `?` 아이콘이 주최자 프로필 아래로 깔리던 문제 수정.
`relative` + `zIndex: index + 1` 적용으로 쌓임 순서 변경.

```
before: 초대2 → 초대1 → 주최자(앞) 
after:  주최자(뒤) → 초대1 → 초대2(앞)
```

---

### 뒤로가기 동작 수정
- 토너먼트 헤더 뒤로가기 클릭 시 `router.back()` → `ROUTES.HOME` 이동으로 변경

---

### 카트 만석 토스트 추가
- 장바구니가 꽉 차서 새 카트가 생성될 때 토스트 노출
- 문구: `카트가 꽉 찼어요! 새 카트를 만들었어요.`

---

### 캐러셀 슬라이드 크기 조정
- `BASKET_CAROUSEL_SLIDE_SIZE_PERCENT` 85% → 90%로 변경



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 카트 생성 시 사용자 알림 추가

* **버그 수정**
  * 토너먼트 나가기 시 올바른 페이지로 이동하도록 개선

* **스타일**
  * 토너먼트 생성 화면 레이아웃 및 간격 최적화
  * 하단 안전영역 패딩 조정
  * 캐러셀 슬라이드 크기 조정으로 가독성 개선
  * 참가자 패널 표시 순서 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->