### PR TITLE
feat: 위시 상품 삭제 토스트 추가 및 복구 필드명 수정

### DIFF
--- a/apps/web/src/app/archive/wish/[id]/_hooks/useDeleteWish.ts
+++ b/apps/web/src/app/archive/wish/[id]/_hooks/useDeleteWish.ts
@@ -16,7 +16,7 @@ export const useDeleteWish = (wishId: number) => {
     mutationFn: () => deleteWish(wishId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['wishlists'] });
-      queryClient.invalidateQueries({ queryKey: ['wish', wishId] });
+      toast.success('위시 상품이 삭제되었습니다.');
       router.replace(ROUTES.ARCHIVE());
     },
     onError: error => {

--- a/apps/web/src/app/archive/wish/[id]/_hooks/usePatchWish.ts
+++ b/apps/web/src/app/archive/wish/[id]/_hooks/usePatchWish.ts
@@ -17,7 +17,7 @@ export const usePatchWish = (wishId: number) => {
     mutationFn: (body: Omit<PatchWishRequestT, 'currency'>) => {
       const formData = new FormData();
       formData.append('name', body.name);
-      formData.append('price', String(body.currentPrice));
+      formData.append('currentPrice', String(body.currentPrice));
       formData.append('currency', 'KRW');
       formData.append('image', body.image);
       return patchWish(wishId, formData);


### PR DESCRIPTION
## 작업 요약

- 위시 상품 삭제 토스트 알림 추가 및 복구 요청 필드명 오타, 불필요한 invalidation 수정


## 작업 세부 내용
#### 위시 상품 삭제 토스트 알림 추가
- 삭제 성공 시 토스트 메시지 노출
- 문구: `위시 상품이 삭제되었습니다.`

#### 위시 복구 요청 필드명 오타 수정
- PATCH 요청 시 formData 필드명 오타 수정
```
price → currentPrice
```

#### 불필요한 invalidation 제거
- 위시 삭제 성공 시 단건 조회 invalidation 제거


## 연관 이슈

closes #262 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **기능 개선**
  * 위시 상품 삭제 시 성공 확인 메시지가 표시됩니다.
  * 위시 상품 정보 업데이트 시 가격 데이터 처리 로직이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->