### PR TITLE
feat: GA4 funnel 이벤트 보강 + iOS Analytics 빌드 fix

### DIFF
--- a/apps/app/app.json
+++ b/apps/app/app.json
@@ -128,12 +128,13 @@
       "expo-secure-store",
       "@react-native-firebase/app",
       "@react-native-firebase/messaging",
+      "@react-native-firebase/analytics",
       [
         "expo-build-properties",
         {
           "ios": {
             "useFrameworks": "static",
-            "forceStaticLinking": ["RNFBApp", "RNFBMessaging"]
+            "forceStaticLinking": ["RNFBApp", "RNFBMessaging", "RNFBAnalytics"]
           },
           "android": {
             "extraMavenRepos": ["https://devrepo.kakao.com/nexus/content/groups/public/"]

--- a/apps/web/src/app/home/_components/AddWishHomeDialog.tsx
+++ b/apps/web/src/app/home/_components/AddWishHomeDialog.tsx
@@ -3,13 +3,20 @@
 import { HeartIconFill } from '@/assets/icons';
 import { Dialog, DialogTrigger } from '@/components/dialog';
 import GetItemDialogContent from '@/components/get-item-dialog';
+import { ANALYTICS_EVENT } from '@/consts/analytics';
+import { logAnalyticsEvent } from '@/utils/analytics';
 
 function AddWishHomeDialog() {
+  const handleAddWishClick = () => {
+    logAnalyticsEvent(ANALYTICS_EVENT.WISH_ADD_START);
+  };
+
   return (
     <Dialog>
       <DialogTrigger asChild>
         <button
           type="button"
+          onClick={handleAddWishClick}
           className="flex flex-1 cursor-pointer flex-col items-center gap-2 rounded-[12px] bg-bg-layer-default p-5"
         >
           <HeartIconFill className="size-8 text-red-400" />

--- a/apps/web/src/app/home/_components/InviteTournamentButton.tsx
+++ b/apps/web/src/app/home/_components/InviteTournamentButton.tsx
@@ -3,13 +3,18 @@
 import { useState } from 'react';
 
 import { LoginIconOutline } from '@/assets/icons';
+import { ANALYTICS_EVENT } from '@/consts/analytics';
+import { logAnalyticsEvent } from '@/utils/analytics';
 
 import InviteCodeDialog from './invite-code-dialog/InviteCodeDialog';
 
 function InviteTournamentButton() {
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleOpen = () => setIsOpen(true);
+  const handleOpen = () => {
+    logAnalyticsEvent(ANALYTICS_EVENT.SOCIAL_INVITE_CLICK);
+    setIsOpen(true);
+  };
 
   return (
     <>

--- a/apps/web/src/app/play/[id]/_components/PlayClient.tsx
+++ b/apps/web/src/app/play/[id]/_components/PlayClient.tsx
@@ -9,7 +9,9 @@ import { postGuestLogin } from '@/app/login/_apis/postGuestLogin';
 import { getTournament } from '@/app/tournament/[id]/_common/_apis/getTournament';
 import Button from '@/components/button';
 import Spinner from '@/components/spinner';
+import { ANALYTICS_EVENT } from '@/consts/analytics';
 import { ROUTES } from '@/consts/route';
+import { logAnalyticsEvent } from '@/utils/analytics';
 
 import { postFromPlayLink } from '../_apis/postFromPlayLink';
 
@@ -28,6 +30,9 @@ function PlayClient({ sourceTournamentId }: PlayClientProps) {
     // StrictMode/dev double-invoke 방지
     if (hasRunRef.current) return;
     hasRunRef.current = true;
+
+    // 게스트가 공유받은 링크로 진입한 시점 — 외부 유입률 측정용.
+    logAnalyticsEvent(ANALYTICS_EVENT.GUEST_VISIT, { source_tournament_id: sourceTournamentId });
 
     // CLONE 의 status 에 따라 적절한 화면으로 라우팅한다.
     // - PENDING: 아직 본인 매치를 시작 안 한 상태 → create (바구니 미리보기 + 시작 버튼)

--- a/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
@@ -43,14 +43,14 @@ function ResultClient({ tournamentId }: ResultClientProps) {
     router.replace(ROUTES.TOURNAMENT_MATCH(tournamentId));
   }, [tournamentData.status, router, tournamentId]);
 
-  // COMPLETED 진입 시 GA4 funnel 완료 이벤트.
+  // 결과 화면 진입 시 GA4 result_view 이벤트 — 결과 조회율 측정용.
   // 같은 인스턴스가 다른 tournamentId 로 재사용되더라도 ID 별로 정확히 1회만 로깅한다.
   const loggedCompleteForRef = useRef<number | null>(null);
   useEffect(() => {
     if (tournamentData.status !== 'COMPLETED') return;
     if (loggedCompleteForRef.current === tournamentId) return;
     loggedCompleteForRef.current = tournamentId;
-    logAnalyticsEvent(ANALYTICS_EVENT.TOURNAMENT_COMPLETE, { tournament_id: tournamentId });
+    logAnalyticsEvent(ANALYTICS_EVENT.RESULT_VIEW, { tournament_id: tournamentId });
   }, [tournamentData.status, tournamentId]);
 
   const handleShareReceiptImage = useCallback(async () => {

--- a/apps/web/src/app/tournament/[id]/result/_components/plate-share-dialog/PlateShareDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/plate-share-dialog/PlateShareDialog.tsx
@@ -53,7 +53,7 @@ function PlateShareDialog({
     });
 
     if (result === 'shared' || result === 'copied') {
-      logAnalyticsEvent(ANALYTICS_EVENT.PLAY_LINK_SHARE, {
+      logAnalyticsEvent(ANALYTICS_EVENT.RESULT_SHARE_CLICK, {
         tournament_id: tournamentId,
         method: result,
       });

--- a/apps/web/src/consts/analytics.ts
+++ b/apps/web/src/consts/analytics.ts
@@ -3,20 +3,33 @@
  *
  * 네이밍 규칙: snake_case, 40자 이내.
  * 파라미터: PII 금지(이메일/닉네임/실명), ID 만 보낸다.
+ *
+ * funnel 페어 정책:
+ *  - `*_start`  사용자가 액션을 시작한 시점 (클릭 등) — 도달률 측정
+ *  - `*_complete` API 성공 / 최종 도달 — 완료율 측정
  */
 export const ANALYTICS_EVENT = {
-  /** 핵심 funnel */
+  /** 가입 / 인증 */
   SIGN_UP_COMPLETE: 'sign_up_complete',
-  WISH_ADD: 'wish_add',
+
+  /** 위시 등록 funnel */
+  WISH_ADD_START: 'wish_add_start',
+  WISH_ADD_COMPLETE: 'wish_add_complete',
+
+  /** 토너먼트 funnel */
   TOURNAMENT_CREATE: 'tournament_create',
   TOURNAMENT_START: 'tournament_start',
-  TOURNAMENT_COMPLETE: 'tournament_complete',
+  RESULT_VIEW: 'result_view',
+  RESULT_SHARE_CLICK: 'result_share_click',
+  RECEIPT_SHARE: 'receipt_share',
 
-  /** 사용자 행동 */
+  /** 친구 초대 funnel */
+  SOCIAL_INVITE_CLICK: 'social_invite_click',
   FRIEND_INVITE_SEND: 'friend_invite_send',
   FRIEND_JOIN: 'friend_join',
-  RECEIPT_SHARE: 'receipt_share',
-  PLAY_LINK_SHARE: 'play_link_share',
+  GUEST_VISIT: 'guest_visit',
+
+  /** 설정 */
   INVITE_EXPIRY_CHANGE: 'invite_expiry_change',
 } as const;
 

--- a/apps/web/src/hooks/usePostWishLink.ts
+++ b/apps/web/src/hooks/usePostWishLink.ts
@@ -21,7 +21,7 @@ export const usePostWishLink = () => {
   } = useMutation({
     mutationFn: (url: string) => postWishLink(url),
     onSuccess: () => {
-      logAnalyticsEvent(ANALYTICS_EVENT.WISH_ADD, { source: 'link' });
+      logAnalyticsEvent(ANALYTICS_EVENT.WISH_ADD_COMPLETE, { source: 'link' });
       queryClient.invalidateQueries({ queryKey: ['wishlists'] });
       if (pathname !== ROUTES.ARCHIVE_BASE) router.push(ROUTES.ARCHIVE('wish'));
     },

--- a/apps/web/src/hooks/usePostWishOCR.ts
+++ b/apps/web/src/hooks/usePostWishOCR.ts
@@ -21,7 +21,7 @@ export const usePostWishOCR = () => {
   } = useMutation({
     mutationFn: (formData: FormData) => postWishOCR(formData),
     onSuccess: () => {
-      logAnalyticsEvent(ANALYTICS_EVENT.WISH_ADD, { source: 'ocr' });
+      logAnalyticsEvent(ANALYTICS_EVENT.WISH_ADD_COMPLETE, { source: 'ocr' });
       queryClient.invalidateQueries({ queryKey: ['wishlists'] });
       router.push(ROUTES.ARCHIVE('wish'));
     },


### PR DESCRIPTION
## 작업 내용

#258 에서 통합된 Firebase Analytics 기반 위에 funnel 분석용 이벤트를 보강하고, iOS 빌드 실패 원인을 해결했습니다.

### 1. iOS 빌드 fix — `app.json`
- `@react-native-firebase/analytics` 플러그인 누락 → 추가
- `forceStaticLinking` 에 `RNFBAnalytics` 추가
- 결과: `RCTBridgeModule must be imported from RNFBApp.RNFBAppModule` 빌드 에러 해결

### 2. 신규 funnel 이벤트 3개
| 이벤트명 | 트리거 | 측정 목표 |
|---|---|---|
| `wish_add_start` | 홈 "위시 담기" 버튼 클릭 | 위시 등록 시작률 |
| `social_invite_click` | 홈 "초대 토너먼트 입장" 클릭 | 친구 초대 입장 시도율 |
| `guest_visit` | 게스트가 플레이 링크로 진입 | 외부 유입률 |

`wish_add_start` ↔ `wish_add_complete` funnel 페어로 위시 등록 도달률/완료율 분리 측정 가능.

### 3. 시안 기준 이벤트명 정리
| Before | After | 사유 |
|---|---|---|
| `WISH_ADD` | `WISH_ADD_COMPLETE` | start/complete 페어링 일관성 |
| `TOURNAMENT_COMPLETE` | `RESULT_VIEW` | 시안 명세 + 의미 명확 |
| `PLAY_LINK_SHARE` | `RESULT_SHARE_CLICK` | 시안 명세 |

## 검증

- [x] 시뮬레이터 빌드 성공 — DebugView 에서 `wish_add_start` → `wish_add_complete` funnel 페어링 동작 확인
- [x] `pnpm check-types` · `pnpm lint` 통과
- [x] 이중 집계 방지 정책 유지 (webview UA 분기, PII 미전송)

## 연관 이슈

closes #259


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 사용자 행동 분석 확대: 위시 추가, 토너먼트 공유, 사용자 초대 등 주요 상호작용에 대한 추적 강화
  * 게스트 사용자의 공유 링크 방문 기록 추적
  * 모바일 앱 분석 기능 통합으로 더욱 정확한 사용 통계 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->