### PR TITLE
fix: 영수증 화면 상품 사진 미표시 및 긴 상품명 넘침 수정

### DIFF
--- a/apps/web/src/app/tournament/[id]/result/_components/ReceiptPaper.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ReceiptPaper.tsx
@@ -172,7 +172,9 @@ function ProductCard({ product, highlight = false }: ProductCardProps) {
         )}
       </div>
       <div className="flex min-w-0 flex-1 flex-col">
-        <p className="body-2-regular break-keep text-text-neutral-primary">{product.name}</p>
+        <p className="body-2-regular break-keep wrap-break-word text-text-neutral-primary">
+          {product.name}
+        </p>
         <p className="body-2-semibold text-text-neutral-primary">{formatPrice(product.price)}</p>
       </div>
       <span className="sr-only">{product.rank}위</span>

--- a/apps/web/src/app/tournament/[id]/result/_components/ReceiptPaper.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ReceiptPaper.tsx
@@ -141,8 +141,11 @@ type ProductCardProps = {
  * 외부 쇼핑몰 이미지 URL 을 Next.js 의 이미지 proxy(`/_next/image`) 경유 URL 로 변환.
  * 영수증 캡처 시 html-to-image 는 cross-origin 이미지를 캔버스에 그리지 못해 상품 사진만 빠진다.
  * 동일 origin 으로 가져오면 캔버스 tainted 문제가 해소된다.
+ *
+ * `w` 값은 next.config 의 `imageSizes` 에 포함된 값만 허용된다 (기본: 16/32/48/64/96/128/256/384).
+ * 영수증 썸네일은 60x60 표시라 그 두 배인 128 이 적정.
  */
-const toSameOriginImageUrl = (originalUrl: string, width = 120) =>
+const toSameOriginImageUrl = (originalUrl: string, width = 128) =>
   `/_next/image?url=${encodeURIComponent(originalUrl)}&w=${width}&q=75`;
 
 function ProductCard({ product, highlight = false }: ProductCardProps) {
@@ -158,7 +161,6 @@ function ProductCard({ product, highlight = false }: ProductCardProps) {
               width={60}
               height={60}
               className="size-full object-cover"
-              crossOrigin="anonymous"
             />
           )}
         </div>


### PR DESCRIPTION
## 작업 내용

토너먼트 결과 화면의 영수증 컴포넌트에서 발견된 두 가지 표시 오류를 수정했습니다.

### 1. 상품 사진이 표시되지 않던 문제 (`ReceiptPaper.tsx`)

- 영수증 캡처 시 cross-origin 이미지가 캔버스에 그려지지 않는 문제를 우회하려고 외부 쇼핑몰 이미지를 `/_next/image` proxy 로 통과시키고 있었는데, 호출 시 `w=120` 값이 Next.js 의 허용 width 화이트리스트(`imageSizes`: 16/32/48/64/96/128/256/384)에 포함되지 않아 **400 Bad Request** 를 받아 broken image 가 떴습니다.
- 영수증 썸네일 표시 크기(60x60)의 2배인 `w=128` 로 변경.
- same-origin 이라 더 이상 필요 없는 `crossOrigin="anonymous"` 도 제거(붙어 있으면 응답에 CORS 헤더 없는 경우 거부됨).

### 2. 긴 상품명이 컨테이너 밖으로 넘치던 문제

- 기존 `break-keep` 은 한국어 단어 보존 측면에서 적합하지만, 공백 없는 긴 영문/숫자 토큰(예: `(FANATICS)_2026FIFA_WORLDCUP_KR`)이 들어오면 줄바꿈이 안 돼 카드 밖으로 넘쳤습니다.
- `wrap-break-word` (overflow-wrap: break-word) 추가 — 자연스러운 단어 단위 줄바꿈을 우선 시도하고 불가피하면 글자 단위로 강제 줄바꿈.

## 검증

- [x] DevTools Network 에서 `/_next/image?w=128` → 200 OK + jpeg 응답 확인
- [x] 영수증 영역에 두 상품 모두 썸네일 정상 렌더링
- [x] 한국어/영문 혼합 긴 상품명 모두 컨테이너 안에서 줄바꿈 동작
- [x] `pnpm check-types` · `pnpm lint` 통과

## 연관 이슈

closes #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 상품명 텍스트 줄바꿈 동작을 개선했습니다.

* **버그 수정**
  * 상품 이미지 로딩 관련 설정을 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->