### PR TITLE
feat: 담기 마감 동작 개선 (협업 의도 판정 + 이어서 담기)

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -15,6 +15,7 @@ import { useGetTournament } from '../../_common/_hooks/useGetTournament';
 import { useCountdown } from '../_hooks/useCountdown';
 import { usePostTournamentStart } from '../_hooks/usePostTournamentStart';
 import { useScrollToLast } from '../_hooks/useScrollToLast';
+import { hasSentInvite } from '../_utils/inviteSentSession';
 import DepositClosedDialog from './deposit-closed-dialog/DepositClosedDialog';
 import MemberJoinConfirmDialog from './member-join-confirm-dialog/MemberJoinConfirmDialog';
 import OwnerStartedDialog from './owner-started-dialog/OwnerStartedDialog';
@@ -52,10 +53,6 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
   const ownerStarted = pending?.ownerStarted ?? false;
   const depositDeadline = pending?.inviteExpiresAt ?? '';
   const { isExpired } = useCountdown(depositDeadline);
-  // 담기 마감 = 초대 코드 만료 시점 (둘은 동일 정책으로 운영).
-  // 단, 주최자는 만료 영향 없이 본인 토너먼트에 후보를 담을 수 있다.
-  // ownerStarted 면 어차피 시작 흐름으로 넘어가야 하므로 마감 처리하지 않는다.
-  const isDepositClosed = !tournamentData.isOwner && !ownerStarted && isExpired;
   const participants = (pending?.participants ?? []).map(p => ({
     user: {
       id: p.userId,
@@ -65,6 +62,17 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
     itemCount: p.itemCount,
   }));
   const hasFriends = participants.length > 1;
+  // 협업 의도가 표명된 토너먼트만 담기 마감 정책을 적용한다.
+  // - 친구가 합류했거나 (디바이스 변경에 무관)
+  // - "초대 링크 보내기" 를 한 번이라도 눌렀거나 (혼자라도 초대 의도 있음, localStorage)
+  // 어느 쪽도 아니면 혼자 천천히 담는 시나리오라 타이머/마감 모달이 의미 없다.
+  const isCollaborative = hasFriends || hasSentInvite(tournamentId);
+  // 담기 마감 = 초대 코드 만료 시점 (둘은 동일 정책으로 운영).
+  // 단, 주최자는 만료 영향 없이 본인 토너먼트에 후보를 담을 수 있다.
+  // ownerStarted 면 어차피 시작 흐름으로 넘어가야 하므로 마감 처리하지 않는다.
+  // 협업 의도가 없는 토너먼트는 만료 자체를 무시한다.
+  const isDepositClosed =
+    !tournamentData.isOwner && !ownerStarted && isExpired && isCollaborative;
 
   const participantImageMap = new Map(
     (pending?.participants ?? []).map(p => [p.userId, p.profileImage])
@@ -86,10 +94,15 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
 
   // 담기 마감 직후 주최자에게 노출되는 자동 안내 모달.
   // 만료 시점에 자동 오픈, 사용자가 닫으면 다시 띄우지 않는다.
+  // 협업 의도가 없는 토너먼트(혼자 + 초대 미발송)는 띄우지 않는다.
   const [isDepositClosedDialogOpen, setIsDepositClosedDialogOpen] = useState(false);
   const [hasDismissedDepositClosed, setHasDismissedDepositClosed] = useState(false);
   const shouldShowDepositClosedDialog =
-    tournamentData.isOwner && !ownerStarted && isExpired && !hasDismissedDepositClosed;
+    tournamentData.isOwner &&
+    !ownerStarted &&
+    isExpired &&
+    isCollaborative &&
+    !hasDismissedDepositClosed;
   if (shouldShowDepositClosedDialog && !isDepositClosedDialogOpen) {
     setIsDepositClosedDialogOpen(true);
   }
@@ -146,7 +159,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
             participants={participants}
             inviteCode={pending?.inviteCode ?? ''}
             inviteExpiresAt={pending?.inviteExpiresAt ?? ''}
-            {...(!ownerStarted && !isDepositClosed && { depositDeadline })}
+            {...(isCollaborative && !ownerStarted && !isDepositClosed && { depositDeadline })}
           />
         </div>
       </div>

--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -187,6 +187,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
         open={isDepositClosedDialogOpen}
         onOpenChange={handleDepositClosedOpenChange}
         onStart={handleStartFromDepositClosed}
+        onContinue={() => handleDepositClosedOpenChange(false)}
         itemCount={itemCount}
         isPending={isPostTournamentStartPending}
       />

--- a/apps/web/src/app/tournament/[id]/create/_components/deposit-closed-dialog/DepositClosedDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/deposit-closed-dialog/DepositClosedDialog.tsx
@@ -9,6 +9,8 @@ type DepositClosedDialogProps = {
   onOpenChange: (open: boolean) => void;
   /** "토너먼트 시작하기" — 시작 흐름 진입 */
   onStart: () => void;
+  /** "이어서 담기" — 모달 닫기만 (사용자가 후보를 더 추가하러 돌아감) */
+  onContinue: () => void;
   /** 담긴 후보 수 — "N강" 표시에 그대로 사용 */
   itemCount: number;
   /** 시작 mutation 진행 중 여부 — 빠른 연타로 인한 중복 호출을 막기 위해 버튼을 비활성한다. */
@@ -17,12 +19,14 @@ type DepositClosedDialogProps = {
 
 /**
  * 담기 마감 시각이 지난 직후 주최자에게 노출되는 자동 안내 모달.
- * 시스템이 자동으로 담기를 종료했음을 알리고 토너먼트 시작을 유도한다.
+ * 시스템이 자동으로 담기를 종료했음을 알리고 토너먼트 시작을 유도하되,
+ * 후보를 더 담고 싶은 경우 "이어서 담기" 로 모달을 닫고 화면에 머무를 수 있다.
  */
 function DepositClosedDialog({
   open,
   onOpenChange,
   onStart,
+  onContinue,
   itemCount,
   isPending = false,
 }: DepositClosedDialogProps) {
@@ -40,15 +44,14 @@ function DepositClosedDialog({
           </DialogDescription>
         </div>
 
-        <Button
-          variant="primary"
-          size="lg"
-          className="w-full"
-          onClick={onStart}
-          disabled={isPending}
-        >
-          토너먼트 시작하기
-        </Button>
+        <div className="flex w-full gap-2">
+          <Button variant="secondary" size="lg" onClick={onContinue} disabled={isPending}>
+            이어서 담기
+          </Button>
+          <Button variant="primary" size="lg" onClick={onStart} disabled={isPending}>
+            토너먼트 시작하기
+          </Button>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
@@ -12,6 +12,7 @@ import { parseServerLocalDateTime } from '@/utils/formatDate';
 import { share } from '@/utils/share';
 
 import { usePatchInviteExpiry } from '../../_hooks/usePatchInviteExpiry';
+import { markInviteSent } from '../../_utils/inviteSentSession';
 import InviteExpiresPicker from './InviteExpiresPicker';
 
 type InviteFriendsDialogProps = {
@@ -100,6 +101,8 @@ function InviteFriendsDialog({
     });
 
     if (result === 'shared' || result === 'copied') {
+      // 협업 의도 표명 — 이 시점 이후부터 담기 마감 카운트다운/모달이 의미를 가진다.
+      markInviteSent(tournamentId);
       logAnalyticsEvent(ANALYTICS_EVENT.FRIEND_INVITE_SEND, {
         tournament_id: tournamentId,
         method: result,

--- a/apps/web/src/app/tournament/[id]/create/_utils/inviteSentSession.ts
+++ b/apps/web/src/app/tournament/[id]/create/_utils/inviteSentSession.ts
@@ -1,0 +1,30 @@
+/**
+ * 주최자가 "초대 링크 보내기" 를 한 번이라도 눌렀는지 토너먼트 단위로 저장한다.
+ *
+ * 담기 마감 카운트다운 / 마감 모달은 협업 의도가 표명된 토너먼트에만 적용한다.
+ * - 한 번도 안 보냈고 참여자도 본인뿐이면 혼자 천천히 담는 시나리오라 타이머 의미 없음
+ * - 친구가 합류했다면 (`participants.length > 1`) localStorage 없이도 타이머 ON
+ *
+ * SSR 환경에서는 `window` 가 없으므로 안전 가드.
+ */
+const STORAGE_KEY_PREFIX = 'piki:inviteSent:';
+
+const getStorageKey = (tournamentId: number) => `${STORAGE_KEY_PREFIX}${tournamentId}`;
+
+export const hasSentInvite = (tournamentId: number): boolean => {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(getStorageKey(tournamentId)) === '1';
+  } catch {
+    return false;
+  }
+};
+
+export const markInviteSent = (tournamentId: number): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(getStorageKey(tournamentId), '1');
+  } catch {
+    /* private mode 등 — 무시 */
+  }
+};


### PR DESCRIPTION
## 작업 내용

담기 마감(초대 코드 만료) 정책이 협업할 의사 없이 혼자 후보를 담는 사용자에게도 적용되어, 30분 후 자동으로 마감 모달이 떠 흐름을 끊던 문제를 개선했습니다.

### 1. 협업 의도 판정 도입

협업 의도가 표명된 토너먼트에만 담기 마감 정책을 적용합니다. 두 가지 신호 중 어느 하나라도 만족하면 `isCollaborative=true`:

| 신호 | 출처 | 디바이스 영속성 |
|---|---|---|
| `participants.length > 1` | 서버 응답 | ✅ 디바이스 변경 무관 |
| "초대 링크 보내기" 클릭 이력 | localStorage `piki:inviteSent:{tournamentId}` | ⚠️ 디바이스 단위 |

OR 합성으로 두 신호 중 어느 한쪽이라도 협업 의사가 표명된 경우를 안전하게 포착합니다.

**적용 위치**:
- `isDepositClosed` (비주최자 측 잠금 조건)
- `shouldShowDepositClosedDialog` (주최자 측 마감 모달 노출)
- `ParticipantPanel` 의 `depositDeadline` prop 전달 (카운트다운 UI)

### 2. "초대 링크 보내기" 클릭 시점에 flag 저장

`InviteFriendsDialog` 의 `handleSendInviteLink` 가 공유 성공(`shared`/`copied`) 시 `markInviteSent(tournamentId)` 호출. 분석 이벤트 발사 시점과 동일 라인에 배치.

### 3. 담기 마감 모달에 '이어서 담기' 버튼 추가

마감 모달이 떴을 때 사용자가 후보를 더 담고 싶으면 모달만 닫고 화면에 머무를 수 있도록 좌측 버튼 추가.
- 좌: secondary `이어서 담기` → 모달 닫기 (`hasDismissedDepositClosed=true` 로 자동 재오픈 방지)
- 우: primary `토너먼트 시작하기` → 기존 동작 그대로

주최자는 만료 후에도 본인 토너먼트에 후보를 계속 담을 수 있어 (`isDepositClosed = !isOwner && ...`) UX 가 자연스럽게 이어집니다.

## 검증

- [x] 혼자 + 초대 안 보냄 → 30분 지나도 카운트다운/모달 노출 X
- [x] 혼자 + 초대 링크 보내기 클릭 → 그 시점 이후 카운트다운/모달 ON
- [x] 친구 join 됨 → localStorage 없이도 카운트다운/모달 ON (디바이스 변경 안전)
- [x] 마감 모달 "이어서 담기" 클릭 → 모달 닫힘 + 재오픈 안 됨
- [x] `pnpm check-types` · `pnpm lint` 통과

## 관련 파일

- `apps/web/src/app/tournament/[id]/create/_utils/inviteSentSession.ts` (신규)
- `apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx`
- `apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx`
- `apps/web/src/app/tournament/[id]/create/_components/deposit-closed-dialog/DepositClosedDialog.tsx`

## 연관 이슈

closes #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 담기 마감 대화상자에 "이어서 담기" 버튼 추가로 토너먼트 진행 중 계속 참가자를 모집할 수 있습니다.

* **Bug Fixes**
  * 담기 마감 알림이 협업 토너먼트(2명 이상 참가자 또는 초대 링크 공유)에서만 표시되도록 개선되었습니다.
  * 초대 링크 공유 여부가 정확하게 추적되도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->