### PR TITLE
fix: 로그인 후 일정 시간 지나면 자동 로그아웃되던 문제 수정

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -16,21 +16,55 @@ const handleGuestLogin = async () => {
   return nextResponse;
 };
 
+/**
+ * 같은 process 안에서 동일 refresh_token 으로 동시 호출되는 refresh 요청을 dedupe.
+ *
+ * 백엔드가 refresh_token rotation 정책(이전 토큰 즉시 무효) 을 쓰기 때문에,
+ * 페이지 진입 시 RSC payload + page request 등 동시 다발 요청이 각자 refresh 를 호출하면
+ * 첫 번째만 성공하고 두 번째부터 401 거부되어 사용자가 로그인 페이지로 튕긴다.
+ *
+ * key: refresh_token 값 그대로 사용 (다른 사용자는 다른 토큰)
+ * value: 진행 중인 refresh 응답 Promise — 결과를 공유한다.
+ *
+ * 주의:
+ *  - Edge runtime / serverless 환경에서는 process 가 짧게 살거나 인스턴스가 여러 개라
+ *    완벽한 dedupe 은 불가. 그래도 대부분의 동시 요청은 동일 process 에서 발생하므로 효과적.
+ *  - rotation 으로 새 토큰이 발급되면 다음 호출은 새 key 라 자동으로 새 entry 생성.
+ *  - finally 에서 entry 를 제거해 메모리 누수 방지.
+ */
+const inflightRefreshByToken = new Map<
+  string,
+  Promise<Awaited<ReturnType<typeof postTokenRefreshServer>>>
+>();
+
+const refreshTokenDedupe = (refreshToken: string, cookieHeader: string) => {
+  const existing = inflightRefreshByToken.get(refreshToken);
+  if (existing) return existing;
+
+  const promise = postTokenRefreshServer(cookieHeader).finally(() => {
+    inflightRefreshByToken.delete(refreshToken);
+  });
+  inflightRefreshByToken.set(refreshToken, promise);
+  return promise;
+};
+
 const handleTokenRefresh = async (request: NextRequest) => {
   const { pathname, search } = request.nextUrl;
 
   const cookieMap = new Map(
     request.cookies.getAll().map(cookie => [cookie.name, cookie.value] as const)
   );
+  const cookieHeader = [...cookieMap.entries()]
+    .map(([name, value]) => `${name}=${value}`)
+    .join('; ');
+  const refreshTokenValue = cookieMap.get('refresh_token') ?? '';
 
   try {
     /**
      * 토큰 갱신 요청
-     * - 쿠키 옵션 제거 후 key, value만 추출하여 페이지로 전달
+     * - 동일 refresh_token 에 대한 동시 호출은 한 번만 백엔드를 때리고 결과를 공유 (rotation 대응)
      */
-    const response = await postTokenRefreshServer(
-      [...cookieMap.entries()].map(([name, value]) => `${name}=${value}`).join('; ')
-    );
+    const response = await refreshTokenDedupe(refreshTokenValue, cookieHeader);
 
     /**
      * 페이지 요청에서는 쿠키 옵션을 필요로 하지 않음
@@ -63,7 +97,28 @@ const handleTokenRefresh = async (request: NextRequest) => {
     setCookieHeaders.forEach(cookie => nextResponse.headers.append('set-cookie', cookie));
 
     return nextResponse;
-  } catch {
+  } catch (error) {
+    /**
+     * dedupe 가 잡지 못한 race condition 의 마지막 안전망:
+     * - 다른 process 가 같은 refresh_token 으로 먼저 성공했을 수도 있다
+     * - 잠깐 기다린 뒤 들어온 요청의 새로운 쿠키(브라우저가 미들웨어를 다시 태우며 보낸 것) 가
+     *   이미 다음 라운드의 새 access_token 이면 그걸로 통과시킨다
+     *
+     * 실제 fix 는 백엔드의 rotation grace period; 이건 임시 우회.
+     */
+    const isUnauthorized =
+      error && typeof error === 'object' && 'response' in error
+        ? (error as { response?: { status?: number } }).response?.status === 401
+        : false;
+
+    if (isUnauthorized) {
+      await new Promise(resolve => setTimeout(resolve, 200));
+      const freshAccess = request.cookies.get('access_token');
+      if (freshAccess && isTokenValid(freshAccess.value)) {
+        return NextResponse.next();
+      }
+    }
+
     return NextResponse.redirect(new URL(getLoginPath(`${pathname}${search}`), request.url));
   }
 };


### PR DESCRIPTION
## 작업 내용

소셜 로그인 후 일정 시간이 지나면 사용자가 의도치 않게 로그인 페이지로 튕기는 문제를 해결했습니다.

### 원인 — refresh_token rotation race

페이지 진입/새로고침 시 RSC payload + page request 등 **동시 다발 요청** 이 발생하는데, 각 요청이 proxy 를 거치며 만료된 access_token 을 발견하면 **각자 독립적으로** `/auth/token/refresh` 를 호출합니다.

백엔드는 보안 정책상 refresh_token rotation 을 사용하므로:
1. 첫 번째 요청 → refresh 성공 (새 토큰 발급 + 이전 refresh_token 즉시 무효화)
2. 거의 동시에 들어온 두 번째 요청 → 이미 무효화된 이전 refresh_token 으로 호출 → **401 거부**
3. proxy 의 catch 가 401 을 잡아 `/login` 으로 redirect → 사용자 입장에서는 갑자기 로그아웃

재현 시 백엔드 응답: `{ status: 401, detail: '로그인 정보가 만료됐어요. 다시 로그인해 주세요.' }`

### 해결 — 2단계 방어

**1차: module-level dedupe (`refreshTokenDedupe`)**

동일 process 안에서 같은 `refresh_token` 으로 동시에 들어온 refresh 호출을 1번의 백엔드 요청으로 묶어 결과를 공유합니다.

- key 는 refresh_token 값 자체 — 사용자별로 자연히 분리되고, rotation 으로 새 토큰이 발급되면 다음 호출은 새 entry 가 됨
- `finally` 로 응답 완료 후 entry 제거 (메모리 누수 방지)

**2차: 401 안전망 (cross-process / edge fork 대응)**

Next.js Edge runtime / serverless 환경에서는 process 가 짧게 살거나 인스턴스가 여러 개라 dedupe 만으로는 완벽하지 않습니다. catch 에서 401 일 때:

1. 200ms 대기
2. `request.cookies.get('access_token')` 재확인 — 다른 처리 흐름이 이미 새 토큰을 박았으면 그걸로 통과
3. 그래도 무효면 진짜 만료로 보고 `/login` redirect

## 검증 (재현 → fix 확인)

`utils/auth.ts` 의 `isTokenValid` 에 임시 만료 buffer 를 박아 15분 토큰을 즉시 만료된 것처럼 시뮬레이션하고 proxy 의 refresh 흐름을 강제 발동.

**Before**

[proxy] handleTokenRefresh START   ← 1번째
[proxy] handleTokenRefresh START   ← 2번째 (동시)
[proxy] handleTokenRefresh SUCCESS
[proxy] handleTokenRefresh FAILED { httpStatus: 401, detail: '로그인 정보가 만료됐어요.' }
GET /login?redirect=%2Fhome 200   ← 사용자가 본 증상


**After**
[proxy] handleTokenRefresh START   ← 1번만!
[proxy] handleTokenRefresh SUCCESS
GET /home 200   ← 정상


연달아 새로고침해도 두 라운드 모두 깨끗하게 갱신 성공. 검증용 디버그 코드는 최종 PR 에서 모두 제거.

## 후속 — 권장되는 진짜 fix

이 PR 은 **클라이언트 측 임시 우회**입니다. 정석적인 fix 는 백엔드의 rotation 정책 완화:

- refresh_token rotation 시 짧은 grace period (5~10초) 동안 이전 토큰도 유효
- 또는 동일 토큰의 동시 요청은 idempotent 하게 같은 새 토큰을 반환

백엔드와 후속 협의 권장.

## 체크리스트

- [x] `pnpm check-types` · `pnpm lint` 통과
- [x] dev 환경에서 만료 시뮬레이션으로 race 재현 → fix 적용 후 깨끗하게 해소

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 토큰 갱신 프로세스의 안정성 및 성능 개선
  * 동시 토큰 갱신 요청에 대한 중복 처리로 서버 부하 감소
  * 인증 실패 상황에서 자동 복구 메커니즘 추가
  * 401 오류 처리 로직 개선으로 세션 유지 강화
  * 향상된 토큰 유효성 검증으로 보안 및 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->