### PR TITLE
fix: SSE 의 refresh 가 별도 경로로 호출되어 race 발생하던 문제 수정

### DIFF
--- a/apps/web/src/apis/client.ts
+++ b/apps/web/src/apis/client.ts
@@ -1,32 +1,14 @@
 import type { AxiosError } from 'axios';
 import axios from 'axios';
 
-import { ENDPOINTS } from '@/consts/api';
 import { QUERY_ACTION } from '@/consts/queryAction';
 import { ROUTES } from '@/consts/route';
 import { CLIENT_TYPE } from '@/consts/webBridge';
 import type { ApiErrorResponseT } from '@/types/api';
-import { getCookie, setCookie } from '@/utils/cookie';
+import { getCookie } from '@/utils/cookie';
 import { getLoginPath } from '@/utils/loginRedirect';
+import { refreshClientToken } from '@/utils/refreshClientToken';
 import { isWebview } from '@/utils/webBridge';
-
-/** refresh 진행 중 여부 */
-let isRefreshing = false;
-
-/** refresh 완료를 기다리는 요청 큐 */
-let failedQueue: Array<{
-  resolve: () => void;
-  reject: (reason?: unknown) => void;
-}> = [];
-
-/** 큐에 쌓인 요청들을 일괄 처리 */
-const processQueue = (error: unknown) => {
-  failedQueue.forEach(pendingRequest => {
-    if (error) pendingRequest.reject(error);
-    else pendingRequest.resolve();
-  });
-  failedQueue = [];
-};
 
 export const clientApi = axios.create({
   withCredentials: true,
@@ -50,47 +32,13 @@ clientApi.interceptors.response.use(
     const hasRetried = originalRequest?.headers.get('x-retry-attempted') === 'true';
 
     if (error.response?.status === 401 && originalRequest && !hasRetried) {
-      /** refresh 진행 중이면 큐에 대기 */
-      if (isRefreshing) {
-        return new Promise<void>((resolve, reject) => {
-          failedQueue.push({ resolve, reject });
-        })
-          .then(() => clientApi(originalRequest))
-          .catch(err => Promise.reject(err));
-      }
-
       originalRequest.headers.set('x-retry-attempted', 'true');
-      isRefreshing = true;
 
       try {
-        /**
-         * 토큰 갱신 — body 와 Content-Type 을 모두 제거해야 한다.
-         * 빈 객체 {} + Content-Type:json 으로 보내면 백엔드가 "body 우선" 으로 검증해
-         * refreshToken 필드 누락 → 400 거부. 헤더 자체를 빼면 쿠키만 보고 처리한다.
-         */
-        const { data } = await axios.post(ENDPOINTS.AUTH_TOKEN_REFRESH, void 0, {
-          withCredentials: true,
-          // Content-Type 헤더가 있으면 백엔드가 body 우선 검증해 refreshToken 필드 누락으로 400 거부.
-          // serverApi 의 postTokenRefreshServer 와 동일하게 false 로 헤더 자체를 제거.
-          headers: {
-            'Content-Type': false as unknown as string,
-            'X-Client-Type': isWebview() ? CLIENT_TYPE.APP : CLIENT_TYPE.WEB,
-          },
-        });
-        /** 웹뷰인 경우 토큰 쿠키에 저장 */
-        const { access_token: newAccessToken, refresh_token: newRefreshToken } = data.data;
-        if (isWebview() && newAccessToken && newRefreshToken) {
-          setCookie('access_token', newAccessToken, { hours: 1 });
-          setCookie('refresh_token', newRefreshToken, { days: 14 });
-        }
-
-        /** 큐에 대기한 요청들을 일괄 처리 */
-        processQueue(null);
+        // 단일 진입점 — 동시 호출이라도 백엔드는 1번만 때리고 모두 같은 결과 공유.
+        await refreshClientToken();
         return clientApi(originalRequest);
-
-        /** refresh 요청 실패 시 로그인 페이지로 리다이렉트 */
       } catch (refreshError) {
-        processQueue(refreshError);
         if (typeof window !== 'undefined') {
           const loginRedirectDisabled =
             window.location.pathname === ROUTES.LOGIN ||
@@ -104,10 +52,7 @@ clientApi.interceptors.response.use(
             );
           }
         }
-
         return Promise.reject(refreshError);
-      } finally {
-        isRefreshing = false;
       }
     }
 

--- a/apps/web/src/hooks/useNotificationSSE.ts
+++ b/apps/web/src/hooks/useNotificationSSE.ts
@@ -7,8 +7,12 @@ import { toast } from 'sonner';
 import { ENDPOINTS } from '@/consts/api';
 import { ROUTES } from '@/consts/route';
 import { CLIENT_TYPE } from '@/consts/webBridge';
-import type { NotificationSsePayloadT, TournamentItemParsedSsePayloadT } from '@/types/notification';
-import { getCookie, setCookie } from '@/utils/cookie';
+import type {
+  NotificationSsePayloadT,
+  TournamentItemParsedSsePayloadT,
+} from '@/types/notification';
+import { getCookie } from '@/utils/cookie';
+import { refreshClientToken } from '@/utils/refreshClientToken';
 import { isWebview } from '@/utils/webBridge';
 
 const MAX_RETRY_DELAY_MS = 30_000;
@@ -78,32 +82,18 @@ export const useNotificationSSE = (enabled: boolean) => {
             return;
           }
           if (response.status === 401) {
-            // 토큰 만료 시 클라이언트사이드에서 refresh 후 재연결
+            // 토큰 만료 시 공유 refresh 함수를 통해 갱신 후 재연결.
+            // 단일 진입점 — page request / API 호출과 같은 dedupe 큐를 공유한다.
+            // (직접 fetch 로 호출하면 동시 다발 race 로 백엔드가 401/500 거부 → 사용자 로그아웃)
             try {
-              const refreshRes = await fetch(ENDPOINTS.AUTH_TOKEN_REFRESH, {
-                method: 'POST',
-                credentials: 'include',
-              });
-              if (!refreshRes.ok) {
-                cancelled = true;
-                throw new Error('unauthorized');
-              }
-              if (isWebview()) {
-                const body = await refreshRes.json();
-                const { access_token: newAccessToken, refresh_token: newRefreshToken } =
-                  body.data;
-                if (newAccessToken && newRefreshToken) {
-                  setCookie('access_token', newAccessToken, { hours: 1 });
-                  setCookie('refresh_token', newRefreshToken, { days: 14 });
-                }
-              }
-              // refresh 성공 → onerror backoff로 재연결
+              await refreshClientToken();
+              // refresh 성공 → onerror backoff 로 재연결
               throw new Error('token-refreshed');
             } catch (err) {
-              if (err instanceof Error && err.message === 'unauthorized') {
-                cancelled = true;
-              }
-              throw err;
+              if (err instanceof Error && err.message === 'token-refreshed') throw err;
+              // refresh 실패 (만료 등) → 연결 중단
+              cancelled = true;
+              throw new Error('unauthorized');
             }
           }
           throw new Error(`SSE open failed: ${response.status}`);

--- a/apps/web/src/utils/refreshClientToken.ts
+++ b/apps/web/src/utils/refreshClientToken.ts
@@ -1,0 +1,67 @@
+import axios from 'axios';
+
+import { ENDPOINTS } from '@/consts/api';
+import { CLIENT_TYPE } from '@/consts/webBridge';
+
+import { setCookie } from './cookie';
+import { isWebview } from './webBridge';
+
+/**
+ * 클라이언트 측 토큰 갱신 — 모든 클라 코드(axios interceptor / SSE / 그 외)는
+ * 직접 `/auth/token/refresh` 를 호출하지 말고 이 함수만 사용한다.
+ *
+ * 왜 단일 진입점?
+ *  - 백엔드의 refresh_token rotation 정책: 호출 즉시 이전 refresh_token 무효화
+ *  - 여러 경로에서 거의 동시에 refresh 를 호출하면 첫 번째만 성공, 나머지는 401/500 받음
+ *  - 같은 process 안에서는 진행 중인 refresh 가 있으면 그 Promise 를 공유해
+ *    백엔드를 한 번만 때리도록 dedupe 한다.
+ *
+ * 동작 보장:
+ *  - 동시 N개 호출 → 백엔드 호출 1번, 모두 같은 결과 (성공/실패) 공유
+ *  - 호출 완료 후 inflight 비워서 다음 라운드는 새 호출
+ *  - 웹뷰: 응답 body 의 토큰을 쿠키에도 저장 (네이티브와 동기화)
+ *  - 일반 브라우저: 백엔드의 Set-Cookie 헤더가 자동으로 적용됨
+ *
+ * Content-Type 헤더 제거 이유:
+ *  - body 없는 POST 에 Content-Type: application/json 이 붙으면 백엔드가
+ *    "body 우선 검증" 하다가 refreshToken 필드 누락으로 400 거부.
+ *  - axios 의 false 트릭으로 헤더 자체를 빼면 백엔드가 쿠키만 보고 처리.
+ */
+
+type RefreshResponseT = {
+  data: {
+    access_token: string | null;
+    refresh_token: string | null;
+  };
+};
+
+let inflightRefresh: Promise<void> | null = null;
+
+const performRefresh = async (): Promise<void> => {
+  const { data } = await axios.post<RefreshResponseT>(ENDPOINTS.AUTH_TOKEN_REFRESH, void 0, {
+    withCredentials: true,
+    headers: {
+      'Content-Type': false as unknown as string,
+      'X-Client-Type': isWebview() ? CLIENT_TYPE.APP : CLIENT_TYPE.WEB,
+    },
+  });
+
+  // 웹뷰는 백엔드 Set-Cookie 가 그대로 안 박히는 케이스가 있어 응답 body 의 토큰을 직접 저장.
+  if (isWebview()) {
+    const { access_token: newAccessToken, refresh_token: newRefreshToken } = data.data;
+    if (newAccessToken && newRefreshToken) {
+      setCookie('access_token', newAccessToken, { hours: 1 });
+      setCookie('refresh_token', newRefreshToken, { days: 14 });
+    }
+  }
+};
+
+export const refreshClientToken = (): Promise<void> => {
+  if (inflightRefresh) return inflightRefresh;
+
+  inflightRefresh = performRefresh().finally(() => {
+    inflightRefresh = null;
+  });
+
+  return inflightRefresh;
+};


### PR DESCRIPTION
## 작업 내용

SSE 가 자체적으로 `/auth/token/refresh` 를 직접 호출하면서 axios interceptor 와 dedupe 되지 않아, 토큰 갱신이 동시 다발로 발생해 백엔드가 401/500 으로 거부하던 문제를 수정.

### 원인
- `useNotificationSSE` 가 `fetch(ENDPOINTS.AUTH_TOKEN_REFRESH, ...)` 로 직접 호출
- axios interceptor 의 `isRefreshing` 큐와 분리 → 동시 다발 race
- `X-Client-Type` 헤더 누락, Content-Type 분기도 누락

### 해결
- `utils/refreshClientToken.ts` 신규 — Promise 기반 dedupe 가 들어간 클라 측 공유 함수
- `apis/client.ts` 와 `hooks/useNotificationSSE.ts` 둘 다 이 함수만 호출하도록 통합
- 헤더 처리 (Content-Type 제거 / `X-Client-Type` / 웹뷰 토큰 setCookie) 일원화

### 효과
- 클라 측 모든 refresh 가 한 경로로 통일 → 동시 N개 호출이라도 백엔드는 1번만 호출
- SSE 의 500 / 401 fallout 해소

## 검증

- [x] `pnpm check-types` · `pnpm lint` 통과
- [x] dev 환경에서 SSE 재연결 시 refresh 1번만 호출 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 토큰 갱신 메커니즘을 개선하여 인증 처리의 일관성과 안정성을 높였습니다.
  * 동시 요청 시 불필요한 중복 갱신을 방지하는 최적화를 적용했습니다.
  * 세션 만료 시 토큰 재갱신 흐름을 단순화하고 안정화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->