### PR TITLE
fix: 웹 토큰 갱신 시 앱 SecureStore 미업데이트 버그 수정

### DIFF
--- a/apps/app/app/index.tsx
+++ b/apps/app/app/index.tsx
@@ -47,15 +47,23 @@ function Page() {
   // proxy.ts(서버)에서 토큰 갱신 시 WebBridge 호출 불가 → AppState로 커버
   useEffect(() => {
     const WEB_URL = process.env.EXPO_PUBLIC_WEB_URL ?? 'http://localhost:3000';
-    const subscription = AppState.addEventListener('change', async nextState => {
-      if (nextState !== 'active') return;
+
+    const syncCookies = async () => {
       const cookies = await CookieManager.get(WEB_URL, Platform.OS === 'ios');
       const accessToken = cookies['access_token']?.value;
       const refreshToken = cookies['refresh_token']?.value;
       if (accessToken && refreshToken) {
         await TokenStorage.setTokens(accessToken, refreshToken);
       }
+    };
+
+    syncCookies();
+
+    const subscription = AppState.addEventListener('change', async nextState => {
+      if (nextState !== 'active') return;
+      syncCookies();
     });
+
     return () => subscription.remove();
   }, []);
 

--- a/apps/app/app/index.tsx
+++ b/apps/app/app/index.tsx
@@ -3,8 +3,9 @@ import {
   WEB_REQ_READY_PAYLOAD_TYPE,
   type WebBridgeMessageT,
 } from '@piki/core';
+import CookieManager from '@react-native-cookies/cookies';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { KeyboardAvoidingView, Linking, Platform } from 'react-native';
+import { AppState, KeyboardAvoidingView, Linking, Platform } from 'react-native';
 import type { WebView } from 'react-native-webview';
 import Webview from 'react-native-webview';
 
@@ -40,6 +41,22 @@ function Page() {
   // 앱 진입 시 GA4(Firebase Analytics) 세션 시작.
   useEffect(() => {
     void logAppOpenEvent();
+  }, []);
+
+  // 포그라운드 복귀 시 WKHTTPCookieStore → SecureStore 동기화
+  // proxy.ts(서버)에서 토큰 갱신 시 WebBridge 호출 불가 → AppState로 커버
+  useEffect(() => {
+    const WEB_URL = process.env.EXPO_PUBLIC_WEB_URL ?? 'http://localhost:3000';
+    const subscription = AppState.addEventListener('change', async nextState => {
+      if (nextState !== 'active') return;
+      const cookies = await CookieManager.get(WEB_URL, Platform.OS === 'ios');
+      const accessToken = cookies['access_token']?.value;
+      const refreshToken = cookies['refresh_token']?.value;
+      if (accessToken && refreshToken) {
+        await TokenStorage.setTokens(accessToken, refreshToken);
+      }
+    });
+    return () => subscription.remove();
   }, []);
 
   const { sendShareIntent } = useShareIntent({

--- a/apps/app/app/index.tsx
+++ b/apps/app/app/index.tsx
@@ -79,6 +79,10 @@ function Page() {
           await TokenStorage.clearTokens();
           return;
 
+        case WEBBRIDGE_MESSAGE_TYPE.WEB_REQ_TOKEN_REFRESHED:
+          await TokenStorage.setTokens(message.payload.accessToken, message.payload.refreshToken);
+          return;
+
         case WEBBRIDGE_MESSAGE_TYPE.WEB_REQ_LOG_ANALYTICS_EVENT:
           await logAnalyticsEvent(message.payload.name, message.payload.params);
           return;

--- a/apps/web/src/utils/refreshClientToken.ts
+++ b/apps/web/src/utils/refreshClientToken.ts
@@ -1,10 +1,11 @@
+import { WEBBRIDGE_MESSAGE_TYPE } from '@piki/core';
 import axios from 'axios';
 
 import { ENDPOINTS } from '@/consts/api';
 import { CLIENT_TYPE } from '@/consts/webBridge';
 
 import { setCookie } from './cookie';
-import { isWebview } from './webBridge';
+import { WebBridge, isWebview } from './webBridge';
 
 /**
  * 클라이언트 측 토큰 갱신 — 모든 클라 코드(axios interceptor / SSE / 그 외)는
@@ -52,6 +53,10 @@ const performRefresh = async (): Promise<void> => {
     if (newAccessToken && newRefreshToken) {
       setCookie('access_token', newAccessToken, { hours: 1 });
       setCookie('refresh_token', newRefreshToken, { days: 14 });
+      WebBridge.postMessage({
+        type: WEBBRIDGE_MESSAGE_TYPE.WEB_REQ_TOKEN_REFRESHED,
+        payload: { accessToken: newAccessToken, refreshToken: newRefreshToken },
+      });
     }
   }
 };

--- a/packages/core/src/consts/webBridge.ts
+++ b/packages/core/src/consts/webBridge.ts
@@ -35,6 +35,9 @@ export const WEBBRIDGE_MESSAGE_TYPE = {
 
   /** 분석 관련 — 웹뷰에서 발생한 사용자 행동을 네이티브 Firebase Analytics 로 전달 */
   WEB_REQ_LOG_ANALYTICS_EVENT: 'WEB_REQ_LOG_ANALYTICS_EVENT',
+
+  /** 토큰 갱신 — 웹에서 토큰 갱신 후 앱 SecureStore 동기화 */
+  WEB_REQ_TOKEN_REFRESHED: 'WEB_REQ_TOKEN_REFRESHED',
 } as const;
 
 export const PUSH_NOTIFICATION_TYPE = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,7 +33,9 @@ export type {
   SocialLoginSuccessMessageT,
   SocialLoginSuccessPayloadT,
   SocialProviderT,
+  TokenRefreshedPayloadT,
   WebReqLogoutMessageT,
+  WebReqTokenRefreshedMessageT,
 } from './types/login';
 export type { ShareIntentFileT, ShareIntentMetaT, ShareIntentPayloadT } from './types/shareIntent';
 export type {

--- a/packages/core/src/types/login.ts
+++ b/packages/core/src/types/login.ts
@@ -33,3 +33,13 @@ export type SocialLoginErrorMessageT = {
 export type SocialLoginErrorPayloadT = {
   detail: string;
 };
+
+/** 웹 → 앱 토큰 갱신 알림 */
+export type WebReqTokenRefreshedMessageT = {
+  type: typeof WEBBRIDGE_MESSAGE_TYPE.WEB_REQ_TOKEN_REFRESHED;
+  payload: TokenRefreshedPayloadT;
+};
+export type TokenRefreshedPayloadT = {
+  accessToken: string;
+  refreshToken: string;
+};

--- a/packages/core/src/types/webBridge.ts
+++ b/packages/core/src/types/webBridge.ts
@@ -11,6 +11,7 @@ import type {
   SocialLoginErrorMessageT,
   SocialLoginSuccessMessageT,
   WebReqLogoutMessageT,
+  WebReqTokenRefreshedMessageT,
 } from './login';
 import type {
   AppReqDeepLinkMessageT,
@@ -39,7 +40,8 @@ export type WebBridgeMessageT =
   | AppResFcmTokenMessageT
   | AppReqDeepLinkMessageT
   | WebReqLogoutMessageT
-  | WebReqLogAnalyticsEventMessageT;
+  | WebReqLogAnalyticsEventMessageT
+  | WebReqTokenRefreshedMessageT;
 
 /** 웹이 페이지 hydrate 완료 후 RN에게 메시지 수신 준비됨을 알리는 메시지 */
 export type WebReqReadyMessageT = {


### PR DESCRIPTION
## 작업 요약

- 웹 토큰 갱신 시 앱 SecureStore가 업데이트되지 않는 문제를 수정합니다

## 작업 세부 내용

- `@piki/core`에 `WEB_REQ_TOKEN_REFRESHED` WebBridge 메시지 타입 추가
- `refreshClientToken.ts`에서 WebView 환경 토큰 갱신 성공 시 새 토큰을 앱으로 전달
- 앱 `index.tsx`에서 메시지 수신 후 `TokenStorage.setTokens()` 호출하여 SecureStore 동기화

**기존 문제**
웹 middleware(proxy.ts)에서 토큰 갱신 성공 시 WebView 쿠키만 업데이트되고
앱 SecureStore는 예전 토큰 보유 → 앱 재시작 시 만료된 토큰 재주입 → 리프레시 실패 → 로그인 튕김


## 연관 이슈

closes #276


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 웹에서 토큰이 갱신되면 최신 액세스/리프레시 토큰을 앱으로 즉시 동기화합니다.
  * 앱이 포그라운드로 돌아올 때 웹 쿠키에 토큰이 존재하면 앱 저장소에 자동으로 반영합니다.  
* **타입/호환성**
  * 토큰 갱신 브리지 메시지 타입이 추가되어 관련 이벤트 처리를 지원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->