### PR TITLE
feat: 앱 아이콘 뱃지 동기화 및 알림 실시간 갱신 구현

### DIFF
--- a/apps/app/app.json
+++ b/apps/app/app.json
@@ -135,7 +135,8 @@
         {
           "ios": {
             "useFrameworks": "static",
-            "forceStaticLinking": ["RNFBApp", "RNFBMessaging", "RNFBAnalytics"]
+            "forceStaticLinking": ["RNFBApp", "RNFBMessaging", "RNFBAnalytics"],
+            "deploymentTarget": "16.4"
           },
           "android": {
             "extraMavenRepos": ["https://devrepo.kakao.com/nexus/content/groups/public/"]

--- a/apps/app/app.json
+++ b/apps/app/app.json
@@ -125,6 +125,7 @@
           ]
         }
       ],
+      "expo-notifications",
       "expo-secure-store",
       "@react-native-firebase/app",
       "@react-native-firebase/messaging",

--- a/apps/app/app/index.tsx
+++ b/apps/app/app/index.tsx
@@ -18,7 +18,11 @@ import { useWebDeepLink } from '@/hooks/useWebDeepLink';
 import { useWebviewCookieSync } from '@/hooks/useWebviewCookieSync';
 import { logAnalyticsEvent, logAppOpenEvent } from '@/utils/analytics';
 import { handleOpenImagePicker } from '@/utils/handleImage';
-import { handleRequestPushPermission, syncPushStatusToWeb } from '@/utils/pushNotification';
+import {
+  handleRequestPushPermission,
+  setAppBadgeCount,
+  syncPushStatusToWeb,
+} from '@/utils/pushNotification';
 import { TokenStorage } from '@/utils/tokenStorage';
 import { WebBridge } from '@/utils/webBridge';
 
@@ -110,6 +114,10 @@ function Page() {
 
         case WEBBRIDGE_MESSAGE_TYPE.WEB_REQ_LOG_ANALYTICS_EVENT:
           await logAnalyticsEvent(message.payload.name, message.payload.params);
+          return;
+
+        case WEBBRIDGE_MESSAGE_TYPE.WEB_REQ_SET_BADGE:
+          await setAppBadgeCount(message.payload.count);
           return;
 
         default:

--- a/apps/app/index.js
+++ b/apps/app/index.js
@@ -1,7 +1,13 @@
 import { getMessaging, setBackgroundMessageHandler } from '@react-native-firebase/messaging';
 import 'expo-router/entry';
 
+import { setAppBadgeCount } from '@/utils/pushNotification';
+
 /** 백그라운드 FCM 메시지 핸들러 */
 setBackgroundMessageHandler(getMessaging(), async remoteMessage => {
   console.warn('[FCM] Background message:', remoteMessage.messageId ?? 'unknown');
+  const unreadCount = remoteMessage.data?.unreadCount;
+  if (unreadCount !== undefined) {
+    await setAppBadgeCount(Number(unreadCount));
+  }
 });

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -35,6 +35,7 @@
     "expo-image": "~3.0.11",
     "expo-image-picker": "^17.0.11",
     "expo-linking": "~8.0.11",
+    "expo-notifications": "^56.0.18",
     "expo-router": "~6.0.23",
     "expo-secure-store": "~15.0.8",
     "expo-share-extension": "^5.0.6",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -35,7 +35,7 @@
     "expo-image": "~3.0.11",
     "expo-image-picker": "^17.0.11",
     "expo-linking": "~8.0.11",
-    "expo-notifications": "^56.0.18",
+    "expo-notifications": "^0.32.17",
     "expo-router": "~6.0.23",
     "expo-secure-store": "~15.0.8",
     "expo-share-extension": "^5.0.6",

--- a/apps/app/utils/pushNotification.ts
+++ b/apps/app/utils/pushNotification.ts
@@ -13,6 +13,7 @@ import {
   requestPermission,
 } from '@react-native-firebase/messaging';
 import * as Application from 'expo-application';
+import * as Notifications from 'expo-notifications';
 import { Linking, PermissionsAndroid, Platform } from 'react-native';
 
 import { WebBridge } from '@/utils/webBridge';
@@ -105,6 +106,11 @@ export const handleRequestPushPermission = async () => {
   await syncPushStatusToWeb();
 };
 
+/** OS 레벨 앱 아이콘 뱃지 수 설정 */
+export const setAppBadgeCount = async (count: number) => {
+  await Notifications.setBadgeCountAsync(count);
+};
+
 /** 앱 시작 시 FCM 권한 요청·토큰 로그 및 메시지 리스너 등록 */
 export const initializePushNotification = async () => {
   const isEnabled = await checkPushPermission();
@@ -118,6 +124,10 @@ export const initializePushNotification = async () => {
 export const setupMessagingListeners = () => {
   const unsubscribeOnMessage = onMessage(messaging, async remoteMessage => {
     console.log('[FCM] Foreground message:', remoteMessage.messageId);
+    const unreadCount = remoteMessage.data?.unreadCount;
+    if (unreadCount !== undefined) {
+      await setAppBadgeCount(Number(unreadCount));
+    }
     // 💡 나중에 Notifee가 들어오면 바로 여기에 Notifee.displayNotification() 코드를 넣으면 됩니다!
   });
 

--- a/apps/app/utils/pushNotification.ts
+++ b/apps/app/utils/pushNotification.ts
@@ -20,6 +20,18 @@ import { WebBridge } from '@/utils/webBridge';
 
 const messaging = getMessaging();
 
+// expo-notifications가 UNUserNotificationCenter delegate를 점유할 때,
+// 포그라운드에서 APNs aps.badge 업데이트가 무시되는 것을 방지
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: false,
+    shouldShowBanner: false,
+    shouldShowList: false,
+    shouldPlaySound: false,
+    shouldSetBadge: true,
+  }),
+});
+
 /** 푸시 알림 권한 체크 */
 export const checkPushPermission = async (): Promise<boolean> => {
   if (Platform.OS === 'android') {

--- a/apps/web/src/app/notification/_hooks/useGetNotifications.ts
+++ b/apps/web/src/app/notification/_hooks/useGetNotifications.ts
@@ -1,4 +1,8 @@
+import { WEBBRIDGE_MESSAGE_TYPE } from '@piki/core';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+import { isWebview, WebBridge } from '@/utils/webBridge';
 
 import { getNotifications } from '../_apis/getNotifications';
 
@@ -18,6 +22,14 @@ export const useGetNotifications = () => {
 
   const notifications = notificationsData?.pages.flatMap(page => page.items) ?? [];
   const unreadCount = notificationsData?.pages[0]?.unreadCount ?? 0;
+
+  useEffect(() => {
+    if (!isWebview()) return;
+    WebBridge.postMessage({
+      type: WEBBRIDGE_MESSAGE_TYPE.WEB_REQ_SET_BADGE,
+      payload: { count: unreadCount },
+    });
+  }, [unreadCount]);
 
   return {
     notificationsData: notifications,

--- a/apps/web/src/app/notification/_hooks/usePostNotificationsRead.ts
+++ b/apps/web/src/app/notification/_hooks/usePostNotificationsRead.ts
@@ -1,4 +1,7 @@
+import { WEBBRIDGE_MESSAGE_TYPE } from '@piki/core';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { isWebview, WebBridge } from '@/utils/webBridge';
 
 import { postNotificationsRead } from '../_apis/postNotificationsRead';
 
@@ -8,8 +11,14 @@ export const usePostNotificationsRead = () => {
   const { mutate: postNotificationsReadMutation, isPending: isPostNotificationsReadPending } =
     useMutation({
       mutationFn: postNotificationsRead,
-      onSuccess: () => {
+      onSuccess: data => {
         queryClient.invalidateQueries({ queryKey: ['notifications'] });
+        if (isWebview() && data) {
+          WebBridge.postMessage({
+            type: WEBBRIDGE_MESSAGE_TYPE.WEB_REQ_SET_BADGE,
+            payload: { count: data.unreadCount },
+          });
+        }
       },
     });
 

--- a/apps/web/src/hooks/useNotificationSSE.ts
+++ b/apps/web/src/hooks/useNotificationSSE.ts
@@ -1,19 +1,30 @@
 import { fetchEventSource } from '@microsoft/fetch-event-source';
+import { WEBBRIDGE_MESSAGE_TYPE } from '@piki/core';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 
+import { getNotifications } from '@/app/notification/_apis/getNotifications';
 import { ENDPOINTS } from '@/consts/api';
 import { ROUTES } from '@/consts/route';
 import { CLIENT_TYPE } from '@/consts/webBridge';
-import type {
-  NotificationSsePayloadT,
-  TournamentItemParsedSsePayloadT,
-} from '@/types/notification';
+import type { NotificationSsePayloadT, SilentSyncSsePayloadT } from '@/types/notification';
 import { getCookie } from '@/utils/cookie';
 import { refreshClientToken } from '@/utils/refreshClientToken';
-import { isWebview } from '@/utils/webBridge';
+import { WebBridge, isWebview } from '@/utils/webBridge';
+
+const syncBadgeWithServer = () => {
+  if (!isWebview()) return;
+  getNotifications({ size: 1 })
+    .then(result => {
+      WebBridge.postMessage({
+        type: WEBBRIDGE_MESSAGE_TYPE.WEB_REQ_SET_BADGE,
+        payload: { count: result.unreadCount },
+      });
+    })
+    .catch(() => {});
+};
 
 const MAX_RETRY_DELAY_MS = 30_000;
 
@@ -100,10 +111,23 @@ export const useNotificationSSE = (enabled: boolean) => {
         },
 
         onmessage: event => {
-          if (event.event === 'tournament-item-parsed') {
+          if (event.event === 'silent-sync') {
             try {
-              const payload = JSON.parse(event.data) as TournamentItemParsedSsePayloadT;
-              queryClient.invalidateQueries({ queryKey: ['tournament', payload.tournamentId] });
+              const payload = JSON.parse(event.data) as SilentSyncSsePayloadT;
+              switch (payload.type) {
+                case 'TOURNAMENT_ITEM_PARSED':
+                  queryClient.invalidateQueries({ queryKey: ['tournament', payload.tournamentId] });
+                  break;
+                case 'UNREAD_COUNT_CHANGED':
+                  void queryClient.refetchQueries({ queryKey: ['notifications'], type: 'all' });
+                  if (isWebview()) {
+                    WebBridge.postMessage({
+                      type: WEBBRIDGE_MESSAGE_TYPE.WEB_REQ_SET_BADGE,
+                      payload: { count: payload.unreadCount },
+                    });
+                  }
+                  break;
+              }
             } catch {
               // malformed JSON — 무시
             }
@@ -113,6 +137,8 @@ export const useNotificationSSE = (enabled: boolean) => {
           if (event.event === 'notification') {
             try {
               const payload = JSON.parse(event.data) as NotificationSsePayloadT;
+              void queryClient.refetchQueries({ queryKey: ['notifications'], type: 'all' });
+              syncBadgeWithServer();
               const deepLink = resolveDeepLink(payload);
               const action = deepLink
                 ? { label: '바로가기', onClick: () => router.push(deepLink) }

--- a/apps/web/src/types/notification.ts
+++ b/apps/web/src/types/notification.ts
@@ -3,16 +3,26 @@ export type NotificationTypeT =
   | 'TOURNAMENT_ITEM_ADDED'
   | 'TOURNAMENT_ITEM_DELETED'
   | 'TOURNAMENT_STARTED'
+  | 'TOURNAMENT_PLAYED_FROM_LINK'
+  | 'TOURNAMENT_COMPLETED'
+  | 'TOURNAMENT_RESULT_READY'
   | 'ITEM_PARSING_COMPLETED'
-  | 'ITEM_PARSING_FAILED';
+  | 'ITEM_PARSING_FAILED'
+  | 'ANNOUNCEMENT';
 
 export type NotificationKindT = 'WISH' | 'TOURNAMENT';
 
-export type TournamentItemParsedSsePayloadT = {
-  tournamentId: number;
-  tournamentItemId: number;
-  status: 'READY' | 'FAILED';
-};
+export type SilentSyncSsePayloadT =
+  | {
+      type: 'TOURNAMENT_ITEM_PARSED';
+      tournamentId: number;
+      tournamentItemId: number;
+      status: 'READY' | 'FAILED';
+    }
+  | {
+      type: 'UNREAD_COUNT_CHANGED';
+      unreadCount: number;
+    };
 
 export type NotificationSsePayloadT = {
   id: number;

--- a/packages/core/src/consts/webBridge.ts
+++ b/packages/core/src/consts/webBridge.ts
@@ -38,6 +38,9 @@ export const WEBBRIDGE_MESSAGE_TYPE = {
 
   /** 토큰 갱신 — 웹에서 토큰 갱신 후 앱 SecureStore 동기화 */
   WEB_REQ_TOKEN_REFRESHED: 'WEB_REQ_TOKEN_REFRESHED',
+
+  /** 뱃지 관련 — 웹이 읽음 처리 후 앱 아이콘 뱃지 수를 동기화 */
+  WEB_REQ_SET_BADGE: 'WEB_REQ_SET_BADGE',
 } as const;
 
 export const PUSH_NOTIFICATION_TYPE = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,7 @@ export type {
   WebReqOpenNotificationSettingsMessageT,
   WebReqPushPermissionMessageT,
   WebReqPushPermissionStatusMessageT,
+  WebReqSetBadgeMessageT,
 } from './types/pushNotification';
 export type { WebBridgeMessageT, WebReqReadyMessageT } from './types/webBridge';
 

--- a/packages/core/src/types/pushNotification.ts
+++ b/packages/core/src/types/pushNotification.ts
@@ -36,6 +36,12 @@ export type FcmTokenPayloadT = {
   deviceId: string | null;
 };
 
+/** 웹 → 앱: 앱 아이콘 뱃지 수 설정 */
+export type WebReqSetBadgeMessageT = {
+  type: typeof WEBBRIDGE_MESSAGE_TYPE.WEB_REQ_SET_BADGE;
+  payload: { count: number };
+};
+
 /** 앱 → 웹: 푸시 알림 탭 딥링크 */
 export type AppReqDeepLinkMessageT = {
   type: typeof WEBBRIDGE_MESSAGE_TYPE.APP_REQ_DEEP_LINK;

--- a/packages/core/src/types/webBridge.ts
+++ b/packages/core/src/types/webBridge.ts
@@ -20,6 +20,7 @@ import type {
   WebReqOpenNotificationSettingsMessageT,
   WebReqPushPermissionMessageT,
   WebReqPushPermissionStatusMessageT,
+  WebReqSetBadgeMessageT,
 } from './pushNotification';
 import type { AppResShareIntentMessageT } from './shareIntent';
 
@@ -41,7 +42,8 @@ export type WebBridgeMessageT =
   | AppReqDeepLinkMessageT
   | WebReqLogoutMessageT
   | WebReqLogAnalyticsEventMessageT
-  | WebReqTokenRefreshedMessageT;
+  | WebReqTokenRefreshedMessageT
+  | WebReqSetBadgeMessageT;
 
 /** 웹이 페이지 hydrate 완료 후 RN에게 메시지 수신 준비됨을 알리는 메시지 */
 export type WebReqReadyMessageT = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       expo-linking:
         specifier: ~8.0.11
         version: 8.0.12(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-notifications:
+        specifier: ^56.0.18
+        version: 56.0.18(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2)
       expo-router:
         specifier: ~6.0.23
         version: 6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.12)(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -1158,9 +1161,16 @@ packages:
   '@expo/env@2.0.11':
     resolution: {integrity: sha512-xV+ps6YCW7XIPVUwFVCRN2nox09dnRwy8uIjwHWTODu0zFw4kp4omnVkl0OOjuu2XOe7tdgAHxikrkJt9xB/7Q==}
 
+  '@expo/env@2.3.0':
+    resolution: {integrity: sha512-9HnnIbzwTTdbwSjNLXTk0fPm9ZwMJ7c1/31tsni8HZ8Q62KzYCyspahH+V365vg5J6lr001DzNwBxVWSaYCQLg==}
+    engines: {node: '>=20.12.0'}
+
   '@expo/fingerprint@0.15.4':
     resolution: {integrity: sha512-eYlxcrGdR2/j2M6pEDXo9zU9KXXF1vhP+V+Tl+lyY+bU8lnzrN6c637mz6Ye3em2ANy8hhUR03Raf8VsT9Ogng==}
     hasBin: true
+
+  '@expo/image-utils@0.10.1':
+    resolution: {integrity: sha512-YDeefvmYdihS7Wp3ESDUVnOgOSWmj2Cczm9lVNDdm4MqQLdAKm/LPYg83HtFQPfefRlAxyHrQR/O9kIXN9C1Wg==}
 
   '@expo/image-utils@0.8.13':
     resolution: {integrity: sha512-1I//yBQeTY6p0u1ihqGNDAr35EbSG8uFEupFrIF0jd++h9EWH33521yZJU1yE+mwGlzCb61g3ehu78siMhXBlA==}
@@ -1219,6 +1229,14 @@ packages:
       typescript:
         optional: true
 
+  '@expo/require-utils@56.1.3':
+    resolution: {integrity: sha512-KyLeOn/zzQSvuPpV5YhB/FPKnpQytno4luN918bGdPDssLBoS3N/0UbC3W0rJAn9kSFu+XpfR81eABRVsSdfgQ==}
+    peerDependencies:
+      typescript: ^5.0.0 || ^5.0.0-0 || ^6.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@expo/schema-utils@0.1.8':
     resolution: {integrity: sha512-9I6ZqvnAvKKDiO+ZF8BpQQFYWXOJvTAL5L/227RUbWG1OVZDInFifzCBiqAZ3b67NRfeAgpgvbA7rejsqhY62A==}
 
@@ -1227,6 +1245,10 @@ packages:
 
   '@expo/spawn-async@1.7.2':
     resolution: {integrity: sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==}
+    engines: {node: '>=12'}
+
+  '@expo/spawn-async@1.8.0':
+    resolution: {integrity: sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==}
     engines: {node: '>=12'}
 
   '@expo/sudo-prompt@9.3.2':
@@ -3504,6 +3526,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  badgin@1.2.3:
+    resolution: {integrity: sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -4312,6 +4337,11 @@ packages:
       expo: '*'
       react-native: '*'
 
+  expo-application@56.0.3:
+    resolution: {integrity: sha512-DdGGPlMuM6cSTeKhbvh6OeLr2O/+EI5BHKYrD+Do8sJPYgLwzGrgESELfyjJCpEhFzT+TgKIdmLmWXhNUQnHiw==}
+    peerDependencies:
+      expo: '*'
+
   expo-application@7.0.8:
     resolution: {integrity: sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==}
     peerDependencies:
@@ -4331,6 +4361,12 @@ packages:
 
   expo-constants@18.0.13:
     resolution: {integrity: sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
+
+  expo-constants@56.0.18:
+    resolution: {integrity: sha512-8AMtbDGl/WVPnWlmbpGmvcdnNCy9E4PFnwdVwj600vljkMDPSxcAcjw8GVXEPk3PpZ+ngTqsrkltWyj0UKYAxw==}
     peerDependencies:
       expo: '*'
       react-native: '*'
@@ -4421,6 +4457,13 @@ packages:
   expo-modules-core@3.0.29:
     resolution: {integrity: sha512-LzipcjGqk8gvkrOUf7O2mejNWugPkf3lmd9GkqL9WuNyeN2fRwU0Dn77e3ZUKI3k6sI+DNwjkq4Nu9fNN9WS7Q==}
     peerDependencies:
+      react: 19.1.0
+      react-native: '*'
+
+  expo-notifications@56.0.18:
+    resolution: {integrity: sha512-HHnrwyCLC5srFojcHYS2KskbNroy9o2fwPKdyhjrdjjrBu4sNRKm4LepcuZjDy98cZKEm89WIPW8O45vut8Rgw==}
+    peerDependencies:
+      expo: '*'
       react: 19.1.0
       react-native: '*'
 
@@ -8479,6 +8522,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/env@2.3.0':
+    dependencies:
+      chalk: 4.1.2
+      debug: 4.4.3
+      getenv: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/fingerprint@0.15.4':
     dependencies:
       '@expo/spawn-async': 1.7.2
@@ -8494,6 +8545,19 @@ snapshots:
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
+
+  '@expo/image-utils@0.10.1(typescript@5.9.2)':
+    dependencies:
+      '@expo/require-utils': 56.1.3(typescript@5.9.2)
+      '@expo/spawn-async': 1.8.0
+      chalk: 4.1.2
+      getenv: 2.0.0
+      jimp-compact: 0.16.1
+      parse-png: 2.1.0
+      semver: 7.7.3
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   '@expo/image-utils@0.8.13(typescript@5.9.2)':
     dependencies:
@@ -8633,11 +8697,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/require-utils@56.1.3(typescript@5.9.2)':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/schema-utils@0.1.8': {}
 
   '@expo/sdk-runtime-versions@1.0.0': {}
 
   '@expo/spawn-async@1.7.2':
+    dependencies:
+      cross-spawn: 7.0.6
+
+  '@expo/spawn-async@1.8.0':
     dependencies:
       cross-spawn: 7.0.6
 
@@ -11182,6 +11260,8 @@ snapshots:
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
 
+  badgin@1.2.3: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -12112,6 +12192,10 @@ snapshots:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.14.0)(react-native-webview@13.16.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
+  expo-application@56.0.3(expo@54.0.33):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.14.0)(react-native-webview@13.16.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2)
+
   expo-application@7.0.8(expo@54.0.33):
     dependencies:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.14.0)(react-native-webview@13.16.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2)
@@ -12137,6 +12221,14 @@ snapshots:
     dependencies:
       '@expo/config': 12.0.13
       '@expo/env': 2.0.11
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.14.0)(react-native-webview@13.16.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-constants@56.0.18(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)):
+    dependencies:
+      '@expo/env': 2.3.0
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.14.0)(react-native-webview@13.16.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
@@ -12242,6 +12334,20 @@ snapshots:
       invariant: 2.2.4
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+
+  expo-notifications@56.0.18(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2):
+    dependencies:
+      '@expo/image-utils': 0.10.1(typescript@5.9.2)
+      abort-controller: 3.0.0
+      badgin: 1.2.3
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.14.0)(react-native-webview@13.16.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2)
+      expo-application: 56.0.3(expo@54.0.33)
+      expo-constants: 56.0.18(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   expo-router@6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.12)(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: ~8.0.11
         version: 8.0.12(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-notifications:
-        specifier: ^56.0.18
-        version: 56.0.18(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2)
+        specifier: ^0.32.17
+        version: 0.32.17(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2)
       expo-router:
         specifier: ~6.0.23
         version: 6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.12)(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -1161,16 +1161,9 @@ packages:
   '@expo/env@2.0.11':
     resolution: {integrity: sha512-xV+ps6YCW7XIPVUwFVCRN2nox09dnRwy8uIjwHWTODu0zFw4kp4omnVkl0OOjuu2XOe7tdgAHxikrkJt9xB/7Q==}
 
-  '@expo/env@2.3.0':
-    resolution: {integrity: sha512-9HnnIbzwTTdbwSjNLXTk0fPm9ZwMJ7c1/31tsni8HZ8Q62KzYCyspahH+V365vg5J6lr001DzNwBxVWSaYCQLg==}
-    engines: {node: '>=20.12.0'}
-
   '@expo/fingerprint@0.15.4':
     resolution: {integrity: sha512-eYlxcrGdR2/j2M6pEDXo9zU9KXXF1vhP+V+Tl+lyY+bU8lnzrN6c637mz6Ye3em2ANy8hhUR03Raf8VsT9Ogng==}
     hasBin: true
-
-  '@expo/image-utils@0.10.1':
-    resolution: {integrity: sha512-YDeefvmYdihS7Wp3ESDUVnOgOSWmj2Cczm9lVNDdm4MqQLdAKm/LPYg83HtFQPfefRlAxyHrQR/O9kIXN9C1Wg==}
 
   '@expo/image-utils@0.8.13':
     resolution: {integrity: sha512-1I//yBQeTY6p0u1ihqGNDAr35EbSG8uFEupFrIF0jd++h9EWH33521yZJU1yE+mwGlzCb61g3ehu78siMhXBlA==}
@@ -1225,14 +1218,6 @@ packages:
     resolution: {integrity: sha512-JAANvXqV7MOysWeVWgaiDzikoyDjJWOV/ulOW60Zb3kXJfrx2oZOtGtDXDFKD1mXuahQgoM5QOjuZhF7gFRNjA==}
     peerDependencies:
       typescript: ^5.0.0 || ^5.0.0-0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@expo/require-utils@56.1.3':
-    resolution: {integrity: sha512-KyLeOn/zzQSvuPpV5YhB/FPKnpQytno4luN918bGdPDssLBoS3N/0UbC3W0rJAn9kSFu+XpfR81eABRVsSdfgQ==}
-    peerDependencies:
-      typescript: ^5.0.0 || ^5.0.0-0 || ^6.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1523,6 +1508,9 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@ide/backoff@1.0.0':
+    resolution: {integrity: sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==}
 
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -3425,6 +3413,9 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  assert@2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -4337,11 +4328,6 @@ packages:
       expo: '*'
       react-native: '*'
 
-  expo-application@56.0.3:
-    resolution: {integrity: sha512-DdGGPlMuM6cSTeKhbvh6OeLr2O/+EI5BHKYrD+Do8sJPYgLwzGrgESELfyjJCpEhFzT+TgKIdmLmWXhNUQnHiw==}
-    peerDependencies:
-      expo: '*'
-
   expo-application@7.0.8:
     resolution: {integrity: sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==}
     peerDependencies:
@@ -4361,12 +4347,6 @@ packages:
 
   expo-constants@18.0.13:
     resolution: {integrity: sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==}
-    peerDependencies:
-      expo: '*'
-      react-native: '*'
-
-  expo-constants@56.0.18:
-    resolution: {integrity: sha512-8AMtbDGl/WVPnWlmbpGmvcdnNCy9E4PFnwdVwj600vljkMDPSxcAcjw8GVXEPk3PpZ+ngTqsrkltWyj0UKYAxw==}
     peerDependencies:
       expo: '*'
       react-native: '*'
@@ -4460,8 +4440,8 @@ packages:
       react: 19.1.0
       react-native: '*'
 
-  expo-notifications@56.0.18:
-    resolution: {integrity: sha512-HHnrwyCLC5srFojcHYS2KskbNroy9o2fwPKdyhjrdjjrBu4sNRKm4LepcuZjDy98cZKEm89WIPW8O45vut8Rgw==}
+  expo-notifications@0.32.17:
+    resolution: {integrity: sha512-lwwzn7tImuzTzn9PAglZlS2VfZEvsfFGJTK9Eb8I4cqkGh2DI23YJFJH+WPEIu4QhDvk5JeBjklenJ8IZbmA4A==}
     peerDependencies:
       expo: '*'
       react: 19.1.0
@@ -5025,6 +5005,10 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -5111,6 +5095,10 @@ packages:
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-nan@1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
     engines: {node: '>= 0.4'}
 
   is-negative-zero@2.0.3:
@@ -5856,6 +5844,10 @@ packages:
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
     engines: {node: '>= 0.4'}
 
   object-keys@1.1.1:
@@ -7125,6 +7117,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -8522,14 +8517,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/env@2.3.0':
-    dependencies:
-      chalk: 4.1.2
-      debug: 4.4.3
-      getenv: 2.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@expo/fingerprint@0.15.4':
     dependencies:
       '@expo/spawn-async': 1.7.2
@@ -8546,23 +8533,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/image-utils@0.10.1(typescript@5.9.2)':
-    dependencies:
-      '@expo/require-utils': 56.1.3(typescript@5.9.2)
-      '@expo/spawn-async': 1.8.0
-      chalk: 4.1.2
-      getenv: 2.0.0
-      jimp-compact: 0.16.1
-      parse-png: 2.1.0
-      semver: 7.7.3
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@expo/image-utils@0.8.13(typescript@5.9.2)':
     dependencies:
       '@expo/require-utils': 55.0.4(typescript@5.9.2)
-      '@expo/spawn-async': 1.7.2
+      '@expo/spawn-async': 1.8.0
       chalk: 4.1.2
       getenv: 2.0.0
       jimp-compact: 0.16.1
@@ -8688,16 +8662,6 @@ snapshots:
       - typescript
 
   '@expo/require-utils@55.0.4(typescript@5.9.2)':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-    optionalDependencies:
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@expo/require-utils@56.1.3(typescript@5.9.2)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
@@ -9098,6 +9062,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@ide/backoff@1.0.0': {}
 
   '@img/colour@1.0.0':
     optional: true
@@ -11097,6 +11063,14 @@ snapshots:
 
   asap@2.0.6: {}
 
+  assert@2.1.0:
+    dependencies:
+      call-bind: 1.0.8
+      is-nan: 1.3.2
+      object-is: 1.1.6
+      object.assign: 4.1.7
+      util: 0.12.5
+
   ast-types-flow@0.0.8: {}
 
   ast-types@0.16.1:
@@ -12192,10 +12166,6 @@ snapshots:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.14.0)(react-native-webview@13.16.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
-  expo-application@56.0.3(expo@54.0.33):
-    dependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.14.0)(react-native-webview@13.16.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2)
-
   expo-application@7.0.8(expo@54.0.33):
     dependencies:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.14.0)(react-native-webview@13.16.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2)
@@ -12221,14 +12191,6 @@ snapshots:
     dependencies:
       '@expo/config': 12.0.13
       '@expo/env': 2.0.11
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.14.0)(react-native-webview@13.16.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2)
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  expo-constants@56.0.18(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)):
-    dependencies:
-      '@expo/env': 2.3.0
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.14.0)(react-native-webview@13.16.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
@@ -12335,14 +12297,16 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
-  expo-notifications@56.0.18(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2):
+  expo-notifications@0.32.17(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2):
     dependencies:
-      '@expo/image-utils': 0.10.1(typescript@5.9.2)
+      '@expo/image-utils': 0.8.13(typescript@5.9.2)
+      '@ide/backoff': 1.0.0
       abort-controller: 3.0.0
+      assert: 2.1.0
       badgin: 1.2.3
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.14.0)(react-native-webview@13.16.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.2)
-      expo-application: 56.0.3(expo@54.0.33)
-      expo-constants: 56.0.18(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
+      expo-application: 7.0.8(expo@54.0.33)
+      expo-constants: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
@@ -12997,6 +12961,11 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
@@ -13077,6 +13046,11 @@ snapshots:
   is-interactive@2.0.0: {}
 
   is-map@2.0.3: {}
+
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
 
   is-negative-zero@2.0.3: {}
 
@@ -14006,6 +13980,11 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
+
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 
@@ -15489,6 +15468,14 @@ snapshots:
       react: 19.1.0
 
   util-deprecate@1.0.2: {}
+
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.0
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.19
 
   utils-merge@1.0.1: {}
 


### PR DESCRIPTION
## 작업 요약
- 알림 읽음 처리 후 앱 뱃지가 줄어들지 않던 문제 수정 — WebBridge 즉각 반영 및 Silent Push 전 기기 동기화
- 새 알림 도착 시 뱃지 증가 및 알림 목록 실시간 갱신 (SSE 기반)
- 앱 WebView에서 SSE가 동작하지 않던 버그 수정

## 배경
서버는 읽음 처리 API 응답에 갱신된 `unreadCount`를 내려주고 silent push도 발송하고 있었으나, FE에서 OS 레벨 뱃지 업데이트를 하지 않아 뱃지 숫자가 줄어들지 않는 문제가 있었음

백엔드에서 SSE 이벤트 `tournament-item-parsed` → `silent-sync` (type 분기) 변경 및`UNREAD_COUNT_CHANGED` silent-sync 이벤트가 추가됨에 따라 클라이언트 대응

## 동작 흐름

### 뱃지 DOWN (읽음 처리)

**즉각 반영**
```
알림 클릭
  → read API 호출
  → unreadCount 응답
  → WebBridge(WEB_REQ_SET_BADGE)
  → 앱 뱃지 즉시 업데이트
```

**전 기기 동기화 (SSE)**
```
서버 UNREAD_COUNT_CHANGED silent-sync
  → refetchQueries
  → WebBridge(WEB_REQ_SET_BADGE)
  → 앱 뱃지 동기화
```

**전 기기 동기화 (FCM)**
```
서버 badge_sync silent push
  → onMessage / 백그라운드 핸들러
  → data.unreadCount로 뱃지 업데이트
```

### 뱃지 UP (새 알림 도착)
```
SSE notification 이벤트
  → syncBadgeWithServer()
  → WebBridge(WEB_REQ_SET_BADGE)
  → 뱃지 증가

FCM notification push
  → APNs aps.badge
  → OS 네이티브 뱃지 업데이트
```

### 알림 목록 실시간 갱신
```
SSE notification 이벤트
  → refetchQueries(['notifications'])
  → 목록 즉시 갱신
```

---

## 작업 내용

### WebBridge 메시지 타입 추가 (`packages/core`)
- `WEB_REQ_SET_BADGE` 메시지 타입 추가
- `WebReqSetBadgeMessageT` 타입 정의 및 `WebBridgeMessageT` 유니온에 추가

---

### 웹 → 앱 뱃지 동기화 (`apps/web`)
- `usePostNotificationsRead` onSuccess에서 `unreadCount`를 `WEB_REQ_SET_BADGE`로 WebBridge 전송 (단건/전체 읽음 동일)
- `useGetNotifications`에서 `unreadCount` 변경 시 WebBridge로 뱃지 동기화 (알림 페이지 진입 시 즉시 반영)
- SSE `silent-sync` 이벤트 처리: `TOURNAMENT_ITEM_PARSED` / `UNREAD_COUNT_CHANGED` type 분기
- SSE `notification` 이벤트 수신 시 알림 목록 즉시 갱신 + 뱃지 증가
- `SilentSyncSsePayloadT` 타입 추가, `NotificationTypeT`에 누락 타입 추가

**앱 SSE 버그 수정**

Next.js rewrite 경유 시 SSE 버퍼링 문제로 앱 WebView에서 이벤트 미수신되던 문제 수정.
→ Route Handler(`/api/notifications/subscribe`) 경유로 통일, `X-Client-Type` 헤더 forwarding 추가

---

### 앱 뱃지 설정 (`apps/app`)
- `setAppBadgeCount(count)` 함수 추가 (`expo-notifications.setBadgeCountAsync` 활용)
- `WEB_REQ_SET_BADGE` 메시지 수신 시 OS 레벨 뱃지 즉시 업데이트
- `setNotificationHandler` 추가 — 포그라운드에서 APNs `aps.badge` 처리 허용 (`expo-notifications` delegate 충돌 해결)
- silent push 포그라운드 수신 시(`onMessage`) `data.unreadCount`로 뱃지 동기화
- 백그라운드 FCM 핸들러에서 `data.unreadCount`로 뱃지 동기화

---

### 빌드 환경 (`apps/app`)
- `expo-notifications@^0.32.17` 설치 (SDK 54 호환 버전)
- iOS 최소 버전 15.1 → 16.4 상향 (expo-notifications podspec 요구사항)
- `app.json`에 expo-notifications 플러그인 추가
- iOS Podfile Firebase + `useFrameworks: static` 조합 빌드 에러 수정
  - `$RNFirebaseAsStaticFramework = true` 추가
  - `RNFBAnalytics CLANG_ENABLE_MODULES = NO` 설정
  
## 관련 이슈
closes #279 
closes #287 