### PR TITLE
fix: iOS 26 Safari 노치 영역이 흰색으로 보이는 문제 수정

### DIFF
--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -164,7 +164,7 @@
  */
 html,
 body {
-  background-color: var(--color-neutral-50);
+  background-color: var(--color-bg-layer-basement);
 }
 
 /**


### PR DESCRIPTION
fix: iOS 26 Safari 노치 영역이 본문과 다른 색으로 보이는 문제 수정


## 작업 내용

iOS 26 Safari 에서 페이지 본문(`#F4F4F6`)과 상단 노치 영역(`#FAFAFA`)의 색이 미세하게 달라 화면이 분리되어 보이던 시각적 결함을 수정했습니다.

### 원인

`apps/web/src/styles/globals.css` 의 `html, body` 배경색이 **Tailwind v4 의 기본 neutral 팔레트** 를 참조하고 있었습니다.

`````css
/* 변경 전 */
html,
body {
  background-color: var(--color-neutral-50);   /* Tailwind neutral-50 = #FAFAFA */
}
`````

- `--color-neutral-50` 은 Tailwind v4 가 자동 주입하는 토큰으로 값은 `#FAFAFA`
- piki 디자인 시스템의 기본 페이지 배경은 `--color-gray-50` = `#F4F4F6`
- 두 색이 미세하게 달라 (#FAFAFA 가 더 밝음) 본문은 회색, 노치는 거의 흰색으로 보이는 색 미스매치 발생

### 왜 iOS 26 부터만 보였나

iOS 26 Safari 부터는 `<meta name="theme-color">` 가 무시되고 **`<html>` / `<body>` 의 `background-color` 가 노치 / 홈 인디케이터 영역 색상의 결정 기준** 으로 동작합니다.

페이지 콘텐츠 영역은 내부 div 가 `bg-bg-layer-basement` 같은 클래스로 시안 색(`#F4F4F6`)을 직접 깔아서 정상 표시되지만, 노치 영역은 오직 body 배경에만 의존하기 때문에 미스매치된 `#FAFAFA` 가 그대로 드러났습니다.

### 변경

도메인 토큰으로 교체:

`````css
/* 변경 후 */
html,
body {
  background-color: var(--color-bg-layer-basement);
}
`````

- `--color-bg-layer-basement` 는 `var(--color-gray-50)` → `#F4F4F6` 으로 정의되어 페이지 본문 컨테이너와 정확히 같은 색이 적용됨
- 디자인 토큰을 참조하므로 시안의 기본 배경이 변경될 때 토큰 한 곳만 바꾸면 자동으로 따라가는 이점

## 검증

- [x] iOS 26 실기기 Safari 에서 노치 영역이 페이지 본문과 동일한 회색(`#F4F4F6`)으로 표시되는 것 확인
- [x] iOS 25 / Android Chrome / 데스크탑 등 다른 환경 회귀 없음
- [x] `pnpm check-types` · `pnpm lint` 통과

## 연관 이슈

closes #292
