### PR TITLE
chore: proxy.ts refresh 401 임시 안전망 제거 (백엔드 rotation grace 적용)

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -97,28 +97,7 @@ const handleTokenRefresh = async (request: NextRequest) => {
     setCookieHeaders.forEach(cookie => nextResponse.headers.append('set-cookie', cookie));
 
     return nextResponse;
-  } catch (error) {
-    /**
-     * dedupe 가 잡지 못한 race condition 의 마지막 안전망:
-     * - 다른 process 가 같은 refresh_token 으로 먼저 성공했을 수도 있다
-     * - 잠깐 기다린 뒤 들어온 요청의 새로운 쿠키(브라우저가 미들웨어를 다시 태우며 보낸 것) 가
-     *   이미 다음 라운드의 새 access_token 이면 그걸로 통과시킨다
-     *
-     * 실제 fix 는 백엔드의 rotation grace period; 이건 임시 우회.
-     */
-    const isUnauthorized =
-      error && typeof error === 'object' && 'response' in error
-        ? (error as { response?: { status?: number } }).response?.status === 401
-        : false;
-
-    if (isUnauthorized) {
-      await new Promise(resolve => setTimeout(resolve, 200));
-      const freshAccess = request.cookies.get('access_token');
-      if (freshAccess && isTokenValid(freshAccess.value)) {
-        return NextResponse.next();
-      }
-    }
-
+  } catch {
     return NextResponse.redirect(new URL(getLoginPath(`${pathname}${search}`), request.url));
   }
 };


### PR DESCRIPTION
## 작업 내용

#273 에서 도입한 refresh 401 임시 안전망 (200ms 대기 후 쿠키 재확인) 코드를 제거합니다. 백엔드에서 refresh_token rotation grace period 가 적용되어 더 이상 필요하지 않은 우회 로직입니다.

### 배경

#273 fix 당시, refresh_token rotation race 의 진짜 fix 는 백엔드의 grace period 였지만 즉시 적용이 어려운 상황이라 클라이언트 측에 두 단계 방어를 적용했습니다:

1. **module-level dedupe** — 같은 process 안에서 동일 refresh_token 동시 호출을 1번으로 묶음
2. **catch 블록의 200ms 대기 + 쿠키 재확인** — dedupe 가 못 잡은 cross-process race 의 마지막 안전망

이 중 2번 부분은 코드 주석에도 명시했듯 "실제 fix 는 백엔드의 rotation grace period; 이건 임시 우회" 였습니다. 이제 백엔드 정책이 적용되어 본 안전망을 제거할 수 있습니다.

### 변경 요약

`apps/web/src/proxy.ts` catch 블록을 원래 깔끔한 형태로 복귀:

`````ts
/* 변경 전 */
} catch (error) {
  /* dedupe 가 잡지 못한 race condition 의 마지막 안전망: ... */
  const isUnauthorized = /* ... */;
  if (isUnauthorized) {
    await new Promise(resolve => setTimeout(resolve, 200));
    const freshAccess = request.cookies.get('access_token');
    if (freshAccess && isTokenValid(freshAccess.value)) {
      return NextResponse.next();
    }
  }
  return NextResponse.redirect(new URL(getLoginPath(`${pathname}${search}`), request.url));
}
`````

`````ts
/* 변경 후 */
} catch {
  return NextResponse.redirect(new URL(getLoginPath(`${pathname}${search}`), request.url));
}
`````

- 22줄 감소, 1줄 추가
- 매직 넘버(`200`) 제거
- 임시 우회 주석 4줄 제거 → 의도가 명확한 코드

### 남기는 것

- **1차 방어 (module-level dedupe)** — `inflightRefreshByToken` Map + `refreshTokenDedupe()`
  → 정상적인 dedupe 패턴이라 백엔드 정책과 무관하게 유지하는 게 안전. 같은 process 안의 동시 호출은 클라에서 미리 합치는 게 백엔드 부하도 줄어듦.
- `isTokenValid` import 도 유지 — proxy 진입 시 access_token 검증에 계속 사용

## 검증

- [x] `pnpm check-types` · `pnpm lint` 통과 (warning 4개는 본 변경분과 무관)
- [x] dev 환경에서 access_token 만료 시뮬레이션 후 새로고침 시 정상 갱신
- [x] 동시 다발 page request 상황에서도 자동 로그아웃 미발생
- [ ] prod 환경에서 1~2주 모니터링 후 회귀 없음 확인

## 회귀 시 복구 방안

본 PR 의 변경은 단일 catch 블록의 22줄 제거 → 1줄 교체뿐이라, 만약 백엔드 grace period 가 충분치 않아 race 가 재발할 경우 본 PR 을 revert 하는 것만으로 즉시 복구 가능합니다.

## 관련 PR / 이슈

- closes #294
- #273 (fix: 로그인 후 일정 시간 지나면 자동 로그아웃되던 문제 수정) — 본 코드를 처음 도입한 PR
- (백엔드 grace period 적용 PR / 이슈 번호 추가 필요)