### PR TITLE
PR 봇 스레드를 팀 전원이 볼 수 있게 (스레드 멤버 자동 추가)

### DIFF
--- a/.github/workflows/discord-pr-bot.yml
+++ b/.github/workflows/discord-pr-bot.yml
@@ -144,8 +144,7 @@ jobs:
             echo "$issue_text"
           }
 
-          # PR 본문의 ## 작업 요약(FE 관례) 또는 ## Task(서버 STAR) 섹션 불릿을 "• ..." 요약으로(없으면 "요약 없음").
-          # 팀원 PR 은 작업 요약, STAR 로 쓴 PR 은 Task 를 쓰므로 둘 다 인식한다. 순수(인자만).
+          # PR 본문의 ## 작업 요약 섹션 불릿을 "• ..." 요약으로(없으면 "요약 없음"). 순수(인자만).
           build_summary() {
             local pr_body="$1"
             printf '%s\n' "$pr_body" | awk '
@@ -154,7 +153,7 @@ jobs:
                 if (in_task == 1) exit
                 r = $0
                 sub(/^##[[:space:]]+/, "", r)
-                ok = (match(r, /^작업 요약([^A-Za-z]|$)/) || match(r, /[[:space:]]작업 요약([^A-Za-z]|$)/) || match(r, /^[Tt][Aa][Ss][Kk]([^A-Za-z]|$)/) || match(r, /[[:space:]][Tt][Aa][Ss][Kk]([^A-Za-z]|$)/))
+                ok = (match(r, /^작업 요약([^A-Za-z]|$)/) || match(r, /[[:space:]]작업 요약([^A-Za-z]|$)/))
                 if (ok) { in_task=1; next }
                 next
               }

--- a/.github/workflows/discord-pr-bot.yml
+++ b/.github/workflows/discord-pr-bot.yml
@@ -135,7 +135,9 @@ jobs:
               state=$(echo "$res" | jq -r '.state // "unknown"')
               if [ "$state" = "open" ]; then emoji="🟢"; elif [ "$state" = "closed" ]; then emoji="⚫"; else emoji="❓"; fi
               link="https://github.com/$REPO/issues/$num"
-              line="$emoji [#$num]($link)"
+              # URL 을 <> 로 감싸 Discord 임베드 카드를 억제한다(클릭은 유지). 이슈 카드가 커서 부모 카드 본문을
+              # 밀어내므로, 연관 이슈는 링크만 남기고 카드는 PR(부모 타이틀 링크)만 뜨게 한다.
+              line="$emoji [#$num](<$link>)"
               if [ -z "$issue_text" ]; then issue_text="$line"; else issue_text=$(printf "%s\n%s" "$issue_text" "$line"); fi
             done <<< "$issues"
             [ -z "$issue_text" ] && issue_text="없음"

--- a/.github/workflows/discord-pr-bot.yml
+++ b/.github/workflows/discord-pr-bot.yml
@@ -144,7 +144,8 @@ jobs:
             echo "$issue_text"
           }
 
-          # PR 본문의 ## 작업 요약 섹션 불릿을 "• ..." 요약으로(없으면 "요약 없음"). 순수(인자만).
+          # PR 본문의 ## 작업 요약(FE 관례) 또는 ## Task(서버 STAR) 섹션 불릿을 "• ..." 요약으로(없으면 "요약 없음").
+          # 팀원 PR 은 작업 요약, STAR 로 쓴 PR 은 Task 를 쓰므로 둘 다 인식한다. 순수(인자만).
           build_summary() {
             local pr_body="$1"
             printf '%s\n' "$pr_body" | awk '
@@ -153,7 +154,7 @@ jobs:
                 if (in_task == 1) exit
                 r = $0
                 sub(/^##[[:space:]]+/, "", r)
-                ok = (match(r, /^작업 요약([^A-Za-z]|$)/) || match(r, /[[:space:]]작업 요약([^A-Za-z]|$)/))
+                ok = (match(r, /^작업 요약([^A-Za-z]|$)/) || match(r, /[[:space:]]작업 요약([^A-Za-z]|$)/) || match(r, /^[Tt][Aa][Ss][Kk]([^A-Za-z]|$)/) || match(r, /[[:space:]][Tt][Aa][Ss][Kk]([^A-Za-z]|$)/))
                 if (ok) { in_task=1; next }
                 next
               }

--- a/.github/workflows/discord-pr-bot.yml
+++ b/.github/workflows/discord-pr-bot.yml
@@ -1,6 +1,8 @@
 name: Discord PR Bot
 
 on:
+  # 기존 열린 PR 스레드에 팀원을 일괄 추가(백필)하는 수동 실행용. Actions → Run workflow.
+  workflow_dispatch:
   pull_request:
     types:
       - opened
@@ -21,6 +23,7 @@ concurrency:
 
 jobs:
   notify-discord:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     # metadata 코멘트는 PR(=issue #N)에 다는데, 대상이 PR 이라 생성엔 pull-requests write 가 필요하다
     # (issues:write 만으론 403 Resource not accessible). 연관 이슈(close #N) 상태 조회는 issues:read.
@@ -270,6 +273,14 @@ jobs:
           if [ -z "$THREAD_ID" ]; then
             echo "Discord thread create failed"; echo "$TRESP"; exit 1
           fi
+
+          # 팀 전원을 스레드 멤버로 추가 — 공개 스레드는 멤버만 사이드바에 뜨므로, DISCORD_USER_MAP 의 모든
+          # discord id 를 넣어 팀 전원 사이드바에 노출한다(멘션과 달리 조용히 목록에만 올림). 실패해도 무해.
+          echo "$DISCORD_USER_MAP" | jq -r '.[]?' | while read -r uid; do
+            [ -z "$uid" ] && continue
+            curl -s -o /dev/null -X PUT "$DISCORD_API/channels/$THREAD_ID/thread-members/$uid" \
+              -H "Authorization: Bot $DISCORD_BOT_TOKEN"
+          done
 
           echo "message_id=$MESSAGE_ID" >> "$GITHUB_OUTPUT"
           echo "thread_id=$THREAD_ID" >> "$GITHUB_OUTPUT"
@@ -535,3 +546,37 @@ jobs:
               --data "$(jq -n --arg name "$NEW_NAME" '{name:$name, archived:true, locked:true}')")
             [ "$CODE" = "200" ] && echo "스레드 정리됨: $NEW_NAME" || echo "::warning::스레드 정리 실패 (HTTP $CODE)"
           fi
+
+  backfill-thread-members:
+    # 기존 열린 PR 들의 스레드에 팀원(DISCORD_USER_MAP)을 일괄 추가하는 수동 백필. Actions 에서 Run workflow 로 실행.
+    # 공개 스레드는 멤버만 사이드바에 뜨므로, 이 봇 변경 이전에 만들어진 스레드를 팀 전원 사이드바에 노출시킨다.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      issues: read
+    env:
+      DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+      DISCORD_USER_MAP: ${{ secrets.DISCORD_USER_MAP }}
+      DISCORD_API: https://discord.com/api/v10
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Add team members to all open PR threads
+        shell: bash
+        run: |
+          [ -n "$DISCORD_USER_MAP" ] || DISCORD_USER_MAP='{}'
+          PRS=$(gh api "repos/${{ github.repository }}/pulls?state=open&per_page=100" --jq '.[].number')
+          for pr in $PRS; do
+            # 각 PR 의 메타 주석에서 thread_id 추출 (find_meta 와 같은 JSON 마커 매칭).
+            COMMENTS=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/$pr/comments")
+            META=$(echo "$COMMENTS" | jq -r '.[]? | objects | select((.body // "") | test("discord-pr-bot:\\s*\\{")) | .body' | tail -n 1)
+            THREAD_ID=$(echo "$META" | grep -oP 'discord-pr-bot:\s*\K\{[^}]*\}' | jq -r '.thread_id // empty' 2>/dev/null || true)
+            if [ -z "$THREAD_ID" ]; then echo "PR #$pr: 스레드 메타 없음, 건너뜀"; continue; fi
+            echo "$DISCORD_USER_MAP" | jq -r '.[]?' | while read -r uid; do
+              [ -z "$uid" ] && continue
+              curl -s -o /dev/null -X PUT "$DISCORD_API/channels/$THREAD_ID/thread-members/$uid" \
+                -H "Authorization: Bot $DISCORD_BOT_TOKEN"
+            done
+            echo "PR #$pr (thread $THREAD_ID): 팀원 추가 완료"
+          done


### PR DESCRIPTION
## 작업 요약

- 스레드 생성 직후 팀원 전원을 thread-members 로 추가해 모든 PR 스레드를 팀 전원 사이드바에 노출
- 이 변경 이전에 열린 스레드용 `backfill-thread-members` 수동 백필 잡 추가 (workflow_dispatch)
- 연관 이슈 링크의 Discord 임베드 카드 억제 (카드가 부모 카드 본문을 밀어내지 않게)

## Situation

- Discord 봇이 PR마다 여는 스레드는 공개 스레드지만, 부모 카드가 작성자만 `@멘션`해서 **작성자만 자기 PR 스레드가 사이드바에 뜬다.** 남의 PR 스레드는 사이드바에 안 떠(링크로만 접근) 팀이 리뷰 논의를 놓친다.

## Task

- 팀 전원이 모든 PR 스레드를 사이드바에서 보게 한다. 새로 열리는 스레드뿐 아니라 이미 열려 있는 스레드도 소급 적용한다.

## Action

- **스레드 멤버 자동 추가**: 스레드 생성 직후 `DISCORD_USER_MAP`의 팀원 전원을 thread-members 로 추가한다. 멘션과 달리 시끄러운 핑 없이 조용히 목록에만 올린다.
- **기존 스레드 백필**: `backfill-thread-members` 잡을 추가한다. `workflow_dispatch`로 수동 실행하면 열린 PR들의 메타 주석에서 `thread_id`를 읽어 팀원을 일괄 추가한다.
- **트리거 가드**: `workflow_dispatch` 추가에 맞춰 `notify-discord`를 `github.event_name == 'pull_request'`로 가드해, 수동 실행 시 알림 잡은 돌지 않게 한다.

## Result

- 새 PR: 생성 즉시 팀 전원 사이드바에 스레드가 뜬다.
- 기존 열린 PR: Actions 탭 → "Discord PR Bot" → Run workflow 로 한 번 실행하면 일괄 노출된다.
- 한계: 백필은 열린 PR 대상이다. 장기 미활동으로 archived 된 스레드는 멤버 추가만으로 사이드바에 복귀하지 않을 수 있다(열린 PR은 대개 활성이라 무해).
- 서버(be-pr) 봇도 같은 구조라 이후 동일 반영이 필요하다.

---
## 연관 이슈

- close #312


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 수동 실행 가능한 워크플로 지원이 추가되었습니다.
  * PR 알림 스레드에 팀원이 자동으로 추가되도록 개선되었습니다.
  * 기존 공개 PR 스레드에 팀원을 일괄 추가하는 백필 작업이 추가되었습니다.

* **Bug Fixes**
  * PR 이벤트가 아닐 때 알림 작업이 실행되지 않도록 제한되었습니다.
  * 스레드 정보가 없거나 찾을 수 없는 PR은 안전하게 건너뛰도록 처리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
## Updates

### 연관 이슈 링크 임베드 억제 (`4ffaef7`)
부모 카드의 연관 이슈 링크가 GitHub 임베드 카드로 크게 떠서 본문(작업 요약 등)을 아래로 밀어냈다. 이슈 URL 을 `<>` 로 감싸 임베드만 억제하고 클릭 링크는 유지한다. PR 타이틀 링크는 그대로 둬 PR 카드는 계속 뜬다.


