### PR TITLE
PR 봇 재싱크: 머지 스레드 잠금 해제 + 종합 백필

### DIFF
--- a/.github/workflows/discord-pr-bot.yml
+++ b/.github/workflows/discord-pr-bot.yml
@@ -537,7 +537,8 @@ jobs:
               -H "Authorization: Bot $DISCORD_BOT_TOKEN"
           fi
 
-          # 스레드: 이름 앞에 결과 프리픽스 + archive + lock. 이름은 100자 제한이라 90자로 자른다.
+          # 스레드: 이름 앞에 결과 프리픽스 + archive(닫힘). lock 은 하지 않아 머지 후에도 글을 쓸 수 있게 둔다.
+          # (archived 만이라 글을 쓰면 다시 열린다.) 이름은 100자 제한이라 90자로 자른다.
           if [ -n "$THREAD_ID" ]; then
             if [ "$MERGED" = "true" ]; then PREFIX="✅"; else PREFIX="🗑️"; fi
             NEW_NAME=$(printf '%s PR #%s %s' "$PREFIX" "${{ steps.pr.outputs.pr_number }}" "$PR_TITLE" | cut -c1-90)
@@ -545,13 +546,16 @@ jobs:
               "$DISCORD_API/channels/$THREAD_ID" \
               -H "Authorization: Bot $DISCORD_BOT_TOKEN" \
               -H "Content-Type: application/json; charset=utf-8" \
-              --data "$(jq -n --arg name "$NEW_NAME" '{name:$name, archived:true, locked:true}')")
+              --data "$(jq -n --arg name "$NEW_NAME" '{name:$name, archived:true, locked:false}')")
             [ "$CODE" = "200" ] && echo "스레드 정리됨: $NEW_NAME" || echo "::warning::스레드 정리 실패 (HTTP $CODE)"
           fi
 
-  backfill-thread-members:
-    # 기존 열린 PR 들의 스레드에 팀원(DISCORD_USER_MAP)을 일괄 추가하는 수동 백필. Actions 에서 Run workflow 로 실행.
-    # 공개 스레드는 멤버만 사이드바에 뜨므로, 이 봇 변경 이전에 만들어진 스레드를 팀 전원 사이드바에 노출시킨다.
+  backfill-threads:
+    # 기존 PR 스레드를 현재 정책으로 일괄 통일하는 수동 백필. Actions → Run workflow.
+    #  - 열린 PR:        unarchive + 팀원(DISCORD_USER_MAP) 전원 스레드 멤버 추가(사이드바 노출)
+    #  - 머지된 PR:      이름에 ✅ 프리픽스 + archived(닫힘). lock 은 안 함(글 쓰기 가능)
+    #  - 머지 없이 닫힘: 이름에 🗑️ 프리픽스 + archived
+    # 과거 find_meta 버그(#674 이전)로 close 정리가 스킵돼 안 닫힌 스레드까지 소급 정리한다. 멱등(재실행 안전).
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
@@ -562,23 +566,43 @@ jobs:
       DISCORD_USER_MAP: ${{ secrets.DISCORD_USER_MAP }}
       DISCORD_API: https://discord.com/api/v10
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
     steps:
-      - name: Add team members to all open PR threads
+      - name: Backfill existing PR threads (members + close state)
         shell: bash
         run: |
           [ -n "$DISCORD_USER_MAP" ] || DISCORD_USER_MAP='{}'
-          PRS=$(gh api "repos/${{ github.repository }}/pulls?state=open&per_page=100" --jq '.[].number')
-          for pr in $PRS; do
-            # 각 PR 의 메타 주석에서 thread_id 추출 (find_meta 와 같은 JSON 마커 매칭).
+          # 최근 100개 PR(열림+닫힘). 스레드 메타가 있는 PR 만 처리한다.
+          PRS=$(gh api "repos/$REPO/pulls?state=all&per_page=100&sort=updated&direction=desc")
+          echo "$PRS" | jq -c '.[] | {num:.number, title:.title, state:.state, merged:(.merged_at != null)}' | while read -r pr; do
+            NUM=$(echo "$pr" | jq -r '.num')
+            TITLE=$(echo "$pr" | jq -r '.title')
+            STATE=$(echo "$pr" | jq -r '.state')
+            MERGED=$(echo "$pr" | jq -r '.merged')
+            # 메타 주석에서 thread_id (find_meta 와 같은 JSON 마커 매칭)
             COMMENTS=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/$pr/comments")
+              "https://api.github.com/repos/$REPO/issues/$NUM/comments")
             META=$(echo "$COMMENTS" | jq -r '.[]? | objects | select((.body // "") | test("discord-pr-bot:\\s*\\{")) | .body' | tail -n 1)
             THREAD_ID=$(echo "$META" | grep -oP 'discord-pr-bot:\s*\K\{[^}]*\}' | jq -r '.thread_id // empty' 2>/dev/null || true)
-            if [ -z "$THREAD_ID" ]; then echo "PR #$pr: 스레드 메타 없음, 건너뜀"; continue; fi
-            echo "$DISCORD_USER_MAP" | jq -r '.[]?' | while read -r uid; do
-              [ -z "$uid" ] && continue
-              curl -s -o /dev/null -X PUT "$DISCORD_API/channels/$THREAD_ID/thread-members/$uid" \
-                -H "Authorization: Bot $DISCORD_BOT_TOKEN"
-            done
-            echo "PR #$pr (thread $THREAD_ID): 팀원 추가 완료"
+            if [ -z "$THREAD_ID" ]; then echo "PR #$NUM: 스레드 메타 없음, skip"; continue; fi
+            if [ "$STATE" = "open" ]; then
+              # 열린 PR: 열림 유지 + 팀원 전원 추가
+              curl -s -o /dev/null -X PATCH "$DISCORD_API/channels/$THREAD_ID" \
+                -H "Authorization: Bot $DISCORD_BOT_TOKEN" -H "Content-Type: application/json; charset=utf-8" \
+                --data '{"archived":false}'
+              echo "$DISCORD_USER_MAP" | jq -r '.[]?' | while read -r uid; do
+                [ -z "$uid" ] && continue
+                curl -s -o /dev/null -X PUT "$DISCORD_API/channels/$THREAD_ID/thread-members/$uid" \
+                  -H "Authorization: Bot $DISCORD_BOT_TOKEN"
+              done
+              echo "PR #$NUM (open): 팀원 추가 + 열림"
+            else
+              # 닫힘: 결과 프리픽스 + archived(닫힘), lock 안 함
+              if [ "$MERGED" = "true" ]; then PREFIX="✅"; else PREFIX="🗑️"; fi
+              NEW_NAME=$(printf '%s PR #%s %s' "$PREFIX" "$NUM" "$TITLE" | cut -c1-90)
+              CODE=$(curl -s -o /dev/null -w '%{http_code}' -X PATCH "$DISCORD_API/channels/$THREAD_ID" \
+                -H "Authorization: Bot $DISCORD_BOT_TOKEN" -H "Content-Type: application/json; charset=utf-8" \
+                --data "$(jq -n --arg name "$NEW_NAME" '{name:$name, archived:true, locked:false}')")
+              echo "PR #$NUM ($PREFIX 닫힘): HTTP $CODE"
+            fi
           done


### PR DESCRIPTION
## 작업 요약

- 머지 스레드 잠금 해제(archived 만) — 머지 후에도 스레드에 글을 쓸 수 있게
- 백필 잡을 종합형으로 교체 — 열린 PR 팀원 추가, 머지 PR ✅+닫힘, 미머지 🗑️+닫힘 (서버 #703 반영)

## Situation

- 서버(be-pr) 봇이 #703(PIKI-Server)에서 **머지 스레드 잠금 해제**와 **기존 스레드 종합 백필**을 추가하며 클라(fe-pr) 봇과 갈라졌다.
- 클라 봇은 아직 머지 스레드를 `locked` 로 잠가 **머지 후 글을 못 쓰고**, 백필은 열린 스레드 팀원 추가만 해 머지 스레드 소급 정리가 없다.

## Task

- 두 봇 동작을 다시 일치시킨다: 잠금 해제 + 종합 백필.

## Action

- **머지 스레드 잠금 해제**: close 정리에서 `locked` 를 빼고 `archived` 만 둔다. 목록에선 닫히되 글을 쓰면 다시 열린다.
- **종합 백필** (`backfill-threads` 로 교체): `workflow_dispatch` 수동 실행 시 기존 스레드를 상태별로 통일한다.

| PR 상태 | 백필 처리 |
|---|---|
| 열림 | unarchive + 팀원 전원 추가 |
| 머지됨 | ✅ + archived (닫힘, 잠금 안 함) |
| 머지 없이 닫힘 | 🗑️ + archived |

- 과거 `find_meta` 버그로 안 닫힌 스레드까지 소급 정리한다. 멱등이라 재실행 안전.

## Result

- 클라 봇이 서버 봇과 동작 일치. 머지 후에도 스레드에 글을 쓸 수 있다.
- 머지 후 Actions → Discord PR Bot → Run workflow(dev)로 백필을 돌리면 기존 fe-pr 스레드가 일괄 정리된다(머지 ✅+닫힘, 열린 것 팀원 추가).

---
## 연관 이슈

- close #314

