### PR TITLE
refactor: 링크 입력창 모바일 키보드를 일반 텍스트 키보드로 변경

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/_components/add-by-link-dialog/AddByLinkDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/add-by-link-dialog/AddByLinkDialog.tsx
@@ -64,7 +64,6 @@ function AddByLinkDialog({ open, onOpenChange, onSubmit }: AddByLinkDialogProps)
             aria-invalid={hasError}
             {...(hasError ? { helperText: '올바른 URL 형식으로 입력해주세요.' } : {})}
             autoFocus
-            inputMode="url"
           />
           <Button size="lg" variant="primary" disabled={isEmpty} onClick={handleSubmit}>
             후보 바구니에 담기

--- a/apps/web/src/components/get-item-dialog/ByLinkDialog.tsx
+++ b/apps/web/src/components/get-item-dialog/ByLinkDialog.tsx
@@ -93,7 +93,6 @@ function ByLinkDialog({ type, open, onOpenChange }: ByLinkProps) {
             aria-invalid={hasError}
             {...(hasError ? { helperText: 'https://로 시작하는 URL을 입력해주세요.' } : {})}
             autoFocus
-            inputMode="url"
           />
           <Button
             size="lg"


### PR DESCRIPTION
## 작업 요약

- 링크 담기 다이얼로그의 URL 입력 필드에서 `inputMode="url"` 을 제거해 모바일에서 일반 텍스트 키보드가 노출되도록 변경합니다

## 작업 세부 내용

### 배경

현재 링크 입력 `Input` 에 `inputMode="url"` 이 설정되어 있어 모바일(WebView 포함)에서 URL 전용 키보드가 노출됩니다. `.` `/` 입력에는 유리하지만 한글·특수문자 입력이 불편하고, 상품 설명 + URL 이 함께 복사된 텍스트를 붙여넣기 전후로 편집할 때 일반 키보드가 더 자연스럽습니다.

### 변경 내용

| 파일 | 변경 |
|---|---|
| `components/get-item-dialog/ByLinkDialog.tsx` | `inputMode="url"` 제거 (1줄) |
| `tournament/[id]/create/_components/add-by-link-dialog/AddByLinkDialog.tsx` | `inputMode="url"` 제거 (1줄) |

- `inputMode` 미지정 시 브라우저 기본 = 일반 텍스트 키보드. 명시적 `inputMode="text"` 는 기본값과 동일해 제거 방식을 선택했습니다
- `inputMode` 는 가상 키보드 힌트 속성이라 유효성 검사(`URL_PATTERN`)·붙여넣기·submit 등 기존 입력 동작에는 영향이 없습니다 (데스크탑도 영향 없음)
- 가격 입력의 `inputMode="numeric"` (ItemEditForm 2곳) 은 의도된 것이라 유지

### 참고

- 링크 입력은 타이핑보다 붙여넣기가 주 시나리오라 URL 키보드의 `.` `/` 빠른 입력 이점보다 일반 키보드의 편집 편의가 우선입니다. #317 (URL 자동 추출) 머지 시 붙여넣기 UX 가 강화되어 타이핑 필요성은 더 줄어듭니다

### 확인 필요 (실기기)

- [ ] iOS WebView / Android WebView / 모바일 Safari·Chrome 에서 일반 키보드 노출 확인

## 연관 이슈

closes #316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 링크 URL 입력창에서 입력 오류 시 검증 상태와 도움말 메시지가 더 안정적으로 표시되도록 유지했습니다.
  * 일부 링크 입력창에서 불필요한 입력 방식 설정을 제거해, 브라우저 기본 동작과의 호환성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->