### PR TITLE
refactor: 토너먼트 아이템 수정 5xx 처리 전역 위임

### DIFF
--- a/apps/web/src/app/tournament/[id]/item/[itemId]/_hooks/usePatchTournamentItem.ts
+++ b/apps/web/src/app/tournament/[id]/item/[itemId]/_hooks/usePatchTournamentItem.ts
@@ -45,14 +45,10 @@ export const usePatchTournamentItem = (tournamentId: number, tournamentItemId: n
          * 404: 토너먼트 or 토너먼트 아이템 존재하지 않음
          * 409: PENDING 상태 아닌 토너먼트
          */
-        if (status < 500) toast.error(clientErrorMessage);
-
         if (status === 403 || status === 404 || status === 409) {
+          toast.error(clientErrorMessage);
           router.replace(ROUTES.TOURNAMENT_CREATE(tournamentId));
-          return;
         }
-
-        throw error;
       },
     });
 


### PR DESCRIPTION
## 작업 요약

- 토너먼트 아이템 수정 5xx 처리 전역 위임

### 배경

여러 mutation 훅이 `status === 500`으로만 분기해 **502(Bad Gateway)가 어느 분기에도 안 걸리는** 문제가 있었습니다. #299 전역 `MutationCache` 도입 이후, 각 훅에 502를 추가하는 대신 **5xx 분기를 삭제하고 전역에 위임**하는 방식으로 정리합니다.

### 대응 항목

| 파일 | 상태 | 내용 |
| --- | --- | --- |
| `hooks/usePostWishOCR.ts` | ✅ (#299 선행 반영) | 5xx 분기 없음, 400/403만 유지 |
| `app/archive/wish/[id]/_hooks/usePatchWish.ts` | ✅ (#299 선행 반영) | `status === 500` 브랜치 없음 |
| `hooks/usePostTournamentOCR.ts` | ✅ (#299 선행 반영) | `status === 500` 브랜치 없음 |
| `app/tournament/[id]/item/[itemId]/_hooks/usePatchTournamentItem.ts` | ✅ (본 PR) | `status < 500` 와일드카드 토스트 및 `throw error` 제거 → 4xx(403/404/409)만 개별 처리 |

### 본 PR 변경 상세 (`usePatchTournamentItem`)

- `onError`에서 5xx/`throw error` 제거 → 502 포함 5xx는 전역 `queryClient.ts` `MutationCache`가 단독 처리
- 4xx는 도달 가능한 **403/404/409**만 맞춤 UX 유지 (토스트 + 생성 페이지 이동)

## 연관 이슈

closes #302


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 대회 항목 수정 중 권한 없음, 항목 없음, 충돌 오류가 발생할 때 안내 토스트가 표시되고 대회 생성 화면으로 이동합니다.
  - 기타 오류가 불필요하게 재전파되지 않도록 오류 처리 동작을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->