### PR TITLE
refactor: 토너먼트 시작 409 시 match 페이지로 복구 이동

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/_hooks/usePostTournamentStart.ts
+++ b/apps/web/src/app/tournament/[id]/create/_hooks/usePostTournamentStart.ts
@@ -1,8 +1,11 @@
 import { useMutation } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
 import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 
 import { ANALYTICS_EVENT } from '@/consts/analytics';
 import { ROUTES } from '@/consts/route';
+import type { ApiErrorResponseT } from '@/types/api';
 import { logAnalyticsEvent } from '@/utils/analytics';
 
 import { postTournamentStart } from '../_apis/postTournamentStart';
@@ -22,6 +25,20 @@ export const usePostTournamentStart = (tournamentId: number) => {
           source_tournament_id: tournamentId,
         });
         router.push(ROUTES.TOURNAMENT_LOADING(nextTournamentId));
+      },
+      onError: error => {
+        if (!isAxiosError<ApiErrorResponseT>(error) || !error.response) return;
+
+        const { status, data } = error.response;
+
+        if (status === 409) {
+          router.push(ROUTES.TOURNAMENT_MATCH(tournamentId));
+          return;
+        }
+
+        if (status < 500) {
+          toast.error(data.detail ?? '요청을 처리하지 못했어요.');
+        }
       },
     });
 

--- a/apps/web/src/app/tournament/[id]/create/_hooks/usePostTournamentStart.ts
+++ b/apps/web/src/app/tournament/[id]/create/_hooks/usePostTournamentStart.ts
@@ -7,6 +7,7 @@ import { ANALYTICS_EVENT } from '@/consts/analytics';
 import { ROUTES } from '@/consts/route';
 import type { ApiErrorResponseT } from '@/types/api';
 import { logAnalyticsEvent } from '@/utils/analytics';
+import { getApiErrorMessage } from '@/utils/getApiErrorMessage';
 
 import { postTournamentStart } from '../_apis/postTournamentStart';
 
@@ -29,7 +30,7 @@ export const usePostTournamentStart = (tournamentId: number) => {
       onError: error => {
         if (!isAxiosError<ApiErrorResponseT>(error) || !error.response) return;
 
-        const { status, data } = error.response;
+        const { status } = error.response;
 
         if (status === 409) {
           router.push(ROUTES.TOURNAMENT_MATCH(tournamentId));
@@ -37,7 +38,7 @@ export const usePostTournamentStart = (tournamentId: number) => {
         }
 
         if (status < 500) {
-          toast.error(data.detail ?? '요청을 처리하지 못했어요.');
+          toast.error(getApiErrorMessage(error));
         }
       },
     });


### PR DESCRIPTION
## 작업 요약

- 토너먼트 시작 409 시 match 페이지로 복구 이동

## 작업 세부 내용

status code 대응 전수조사에서 확인된 잔여 항목 처리입니다. 
조사 항목 중 대부분(빈 `onError` 제거, 502 포함 5xx 일괄 처리, generic 토스트)은 #311 에서 이미 해결되었고, 남은 작업인 **시작 버튼의 409 맞춤 복구 UX** 작업을 진행했습니다.

- `useDeleteTournament` — 주석 처리된 빈 `onError`는 #311에서 이미 제거됨. 409 포함 4xx는 전역 fallback이 서버 `detail` 토스트로 처리하므로 변경 없음
- `usePostCreateTournament` — `onError` 없음 → 전역 generic 토스트가 커버. 맞춤 UX 불필요로 close



#### `usePostTournamentStart`에 `onError` 추가

- **409 (이미 시작됨)**: 다른 탭/참여자 요청이 먼저 start를 선점한 경우, 에러 토스트 대신 `router.push(TOURNAMENT_MATCH)`로 이동합니다. match 페이지 서버 컴포넌트가 최신 상태를 조회해 상태별 복구(COMPLETED → 결과 페이지 redirect, IN_PROGRESS → 매치 진행)를 이미 담당하고 있어 해당 로직을 재활용합니다.
- **409 외 4xx**: 개별 `onError`를 정의하면 전역 4xx fallback이 스킵되므로, 기존 패턴(`usePostTournamentItemLink`)대로 서버 `detail` 토스트를 훅 내에서 재현했습니다.
- **5xx·네트워크**: 전역 MutationCache가 항상 처리하므로 훅에서는 건드리지 않았습니다 

## 연관 이슈

closes #301 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 토너먼트 시작 요청 실패 시 오류 타입과 응답 상태를 먼저 확인한 뒤, 상황에 맞게 예외 처리를 개선했습니다.
  * 이미 시작된 토너먼트(409)인 경우 해당 매치 화면으로 자동 이동합니다.
  * 서버 오류(특정 상태 범위)에서는 보다 구체적인 안내 메시지를 토스트로 표시합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->