### PR TITLE
fix: SSE 재연결 시 활성 쿼리 재조회로 이벤트 유실 대응

### DIFF
--- a/apps/web/src/hooks/useNotificationSSE.ts
+++ b/apps/web/src/hooks/useNotificationSSE.ts
@@ -53,6 +53,7 @@ export const useNotificationSSE = (enabled: boolean) => {
   const queryClient = useQueryClient();
   const retryDelayRef = useRef(1_000);
   const abortRef = useRef<AbortController | null>(null);
+  const hasConnectedRef = useRef(false);
 
   useEffect(() => {
     if (!enabled) return;
@@ -90,6 +91,11 @@ export const useNotificationSSE = (enabled: boolean) => {
         onopen: async response => {
           if (response.ok) {
             retryDelayRef.current = 1_000;
+            if (hasConnectedRef.current) {
+              // 재연결 성공 — 끊긴 동안 놓쳤을 수 있는 변경사항을 화면 재조회로 복구
+              void queryClient.invalidateQueries();
+            }
+            hasConnectedRef.current = true;
             return;
           }
           if (response.status === 401) {


### PR DESCRIPTION
## 작업 요약

- SSE 연결이 끊겼다가 재연결에 성공하는 시점에 화면의 활성 쿼리를 전체 재조회하도록 수정
## 작업 세부 내용


서버가 30분마다 SSE 연결을 강제로 재연결시키는 구조라, 그 사이 발생한 `notification` / `silent-sync` 이벤트가 유실될 수 있음.
> 토너먼트 아이템 등록 화면에서 파싱 완료 이벤트를 놓치면 PENDING 로딩 카드가 낡은 채로 남는 문제.

이를 해결하기 위해 sse 재연결 시 활성 쿼리 재조회로 누락된 변경사항을 동기화하였습니다.

- `useNotificationSSE.ts`에 `hasConnectedRef` 추가 — 최초 연결과 재연결을 구분
- `onopen` 성공 시, 최초 연결이 아니면(`hasConnectedRef.current === true`)
  `queryClient.invalidateQueries()` 실행 후 플래그를 `true`로 유지
- 401 → 토큰 리프레시 재연결 경로도 동일한 `onopen`을 타므로 별도 분기 없이 커버됨
- 기존 60초 폴링 백스톱(`useSSEFallback`)은 재연결 자체가 지연/실패하는 경우의 최종 안전망으로 그대로 유지

```
[재연결 흐름]
SSE 연결 끊김 (30분 타임아웃 / 네트워크 / 401)
  → 재연결 성공 (onopen)
  → hasConnectedRef === true 확인 (재연결로 판별)
  → queryClient.invalidateQueries() — 활성 쿼리 전체 재조회
  → 끊긴 사이 낡은 화면 데이터 복구
```

## 연관 이슈

closes #362 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 알림 연결이 재연결된 후 연결이 끊긴 동안 누락된 업데이트를 자동으로 새로고침합니다.
  * 재연결 시 최신 알림 상태가 화면에 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->