### PR TITLE
fix: 내 토너먼트 페이지 게스트도 접근 가능하도록 변경

### DIFF
--- a/apps/web/src/app/archive/wish/layout.tsx
+++ b/apps/web/src/app/archive/wish/layout.tsx
@@ -6,16 +6,15 @@ import { redirect } from 'next/navigation';
 import { getMe } from '@/apis/getMe';
 import WishLoginRequired from '@/components/common/wish-login-required';
 import { QUERY_ACTION } from '@/consts/queryAction';
-import { ROUTES } from '@/consts/route';
 import type { ApiErrorResponseT } from '@/types/api';
 import { getLoginPath } from '@/utils/loginRedirect';
 import { getQueryClient } from '@/utils/queryClient';
 
-type ArchiveLayoutProps = {
+type WishArchiveLayoutProps = {
   children: React.ReactNode;
 };
 
-async function ArchiveLayout({ children }: ArchiveLayoutProps) {
+async function WishArchiveLayout({ children }: WishArchiveLayoutProps) {
   const headerStore = await headers();
   const redirectPath = headerStore.get('x-redirect-path');
   const queryClient = getQueryClient();
@@ -26,12 +25,8 @@ async function ArchiveLayout({ children }: ArchiveLayoutProps) {
       queryKey: ['me'],
       queryFn: getMe,
     });
-    if (user.identityType !== 'MEMBER') {
-      /** 위시 페이지는 로그인 유도 화면을 렌더 */
-      if (redirectPath?.startsWith(ROUTES.WISHLIST)) return <WishLoginRequired />;
-
-      redirect(getLoginPath(redirectPath));
-    }
+    /** 위시 페이지는 멤버가 아니면 로그인 유도 화면을 렌더 */
+    if (user.identityType !== 'MEMBER') return <WishLoginRequired />;
   } catch (error) {
     if (!isAxiosError<ApiErrorResponseT>(error)) throw error;
 
@@ -44,4 +39,4 @@ async function ArchiveLayout({ children }: ArchiveLayoutProps) {
   return <HydrationBoundary state={dehydrate(queryClient)}>{children}</HydrationBoundary>;
 }
 
-export default ArchiveLayout;
+export default WishArchiveLayout;

--- a/apps/web/src/app/archive/wish/layout.tsx
+++ b/apps/web/src/app/archive/wish/layout.tsx
@@ -7,6 +7,7 @@ import { getMe } from '@/apis/getMe';
 import WishLoginRequired from '@/components/common/wish-login-required';
 import { QUERY_ACTION } from '@/consts/queryAction';
 import type { ApiErrorResponseT } from '@/types/api';
+import type { UserT } from '@/types/user';
 import { getLoginPath } from '@/utils/loginRedirect';
 import { getQueryClient } from '@/utils/queryClient';
 
@@ -20,13 +21,12 @@ async function WishArchiveLayout({ children }: WishArchiveLayoutProps) {
   const queryClient = getQueryClient();
 
   /** MEMBER 권한 조회 - 멤버 권한 없으면 로그인 페이지로 리다이렉트 */
+  let user: UserT;
   try {
-    const user = await queryClient.fetchQuery({
+    user = await queryClient.fetchQuery({
       queryKey: ['me'],
       queryFn: getMe,
     });
-    /** 위시 페이지는 멤버가 아니면 로그인 유도 화면을 렌더 */
-    if (user.identityType !== 'MEMBER') return <WishLoginRequired />;
   } catch (error) {
     if (!isAxiosError<ApiErrorResponseT>(error)) throw error;
 
@@ -35,6 +35,9 @@ async function WishArchiveLayout({ children }: WishArchiveLayoutProps) {
 
     throw error;
   }
+
+  /** 위시 페이지는 멤버가 아니면 로그인 유도 화면을 렌더 */
+  if (user.identityType !== 'MEMBER') return <WishLoginRequired />;
 
   return <HydrationBoundary state={dehydrate(queryClient)}>{children}</HydrationBoundary>;
 }


### PR DESCRIPTION
## 작업 요약

- 내 토너먼트(`archive/tournament`) 페이지에 게스트가 접근할 수 있도록 권한 검사 위치를 옮겼습니다.

## 작업 세부 내용

- 기존에는 `archive/layout.tsx`에서 MEMBER 권한 검사를 하고 있어, 게스트가 `archive` 하위(토너먼트 포함) 전체에 접근하지 못했습니다.
- 토너먼트 페이지는 게스트·멤버 모두 접근 가능해야 하므로, 권한 검사를 `archive/wish/layout.tsx`로 이동했습니다. (`git mv` — rename으로 추적)
- 이제 MEMBER 권한 게이트는 위시(`archive/wish/*`) 서브트리에만 적용되고, 토너먼트는 게이트 없이 게스트·멤버 모두 접근 가능합니다.
- 권한 검사가 위시 서브트리 한정으로 좁혀지면서 `redirectPath?.startsWith(ROUTES.WISHLIST)` 분기가 항상 참이 되므로, 비멤버는 곧바로 `WishLoginRequired`를 렌더하도록 단순화했습니다. (도달 불가능해진 `redirect` 분기와 미사용 `ROUTES` import 제거)

## 연관 이슈

closes #335 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 회원 유형이 아닌 사용자가 위시 아카이브에 접근할 경우 로그인 필요 안내가 표시되도록 개선했습니다.
  - 위시 아카이브 접근 시 잘못된 리디렉션이 발생하던 동작을 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->