### PR TITLE
fix: 앱 로그인 풀림 현상 해결

### DIFF
--- a/apps/app/app/index.tsx
+++ b/apps/app/app/index.tsx
@@ -3,14 +3,14 @@ import {
   WEB_REQ_READY_PAYLOAD_TYPE,
   type WebBridgeMessageT,
 } from '@piki/core';
-import CookieManager from '@react-native-cookies/cookies';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { AppState, Linking, Platform, View } from 'react-native';
+import { Linking, View } from 'react-native';
 import type { WebView } from 'react-native-webview';
 import Webview from 'react-native-webview';
 import type {
   WebViewErrorEvent,
   WebViewHttpErrorEvent,
+  WebViewNavigationEvent,
 } from 'react-native-webview/lib/WebViewTypes';
 
 import SplashOverlay from '@/components/SplashOverlay';
@@ -35,11 +35,15 @@ import { WebBridge } from '@/utils/webBridge';
 function Page() {
   const webviewRef = useRef<WebView | null>(null);
   const [webviewUri, setWebviewUri] = useState(process.env.EXPO_PUBLIC_WEB_URL);
+  /** 워밍업 페이지 로드 완료 여부 */
+  const [isWarmupLoaded, setIsWarmupLoaded] = useState(false);
+  /** 실제 페이지 로드 완료 여부 */
   const [isWebViewLoaded, setIsWebViewLoaded] = useState(false);
+  /** 이동 대기 중인 딥링크 경로 */
   const [pendingWarmStartPath, setPendingWarmStartPath] = useState<string | null>(null);
 
   const { handleLogin } = useSocialLogin();
-  const { isSynced } = useWebviewCookieSync();
+  const { isSynced } = useWebviewCookieSync(isWarmupLoaded);
 
   const handleWebviewUriChange = useCallback((uri: string) => setWebviewUri(uri), []);
 
@@ -65,7 +69,7 @@ function Page() {
   }, []);
 
   useEffect(() => {
-    if (!isSynced || !isWebViewLoaded || pendingWarmStartPath === null || !webviewRef.current)
+    if (!isSynced || !isWebViewLoaded || !webviewRef.current || pendingWarmStartPath === null)
       return;
 
     WebBridge.postMessage({
@@ -78,33 +82,6 @@ function Page() {
   // 앱 진입 시 GA4(Firebase Analytics) 세션 시작.
   useEffect(() => {
     void logAppOpenEvent();
-  }, []);
-
-  /**
-   * WKHTTPCookieStore → SecureStore 동기화
-   *
-   * - 포그라운드 복귀, 백그라운드 진입 시
-   * - proxy.ts(서버)에서 토큰 갱신 시 WebBridge 호출 불가 → AppState로 커버
-   * - (mount 시점 동기화는 useWebviewCookieSync가 담당 — 여기서 중복 실행하면 부팅 refresh와 레이스)
-   */
-  useEffect(() => {
-    const WEB_URL = process.env.EXPO_PUBLIC_WEB_URL ?? 'http://localhost:3000';
-
-    const syncCookies = async () => {
-      const cookies = await CookieManager.get(WEB_URL, Platform.OS === 'ios');
-      const accessToken = cookies['access_token']?.value;
-      const refreshToken = cookies['refresh_token']?.value;
-      if (accessToken && refreshToken) {
-        await TokenStorage.setTokens(accessToken, refreshToken);
-      }
-    };
-
-    const subscription = AppState.addEventListener('change', async nextState => {
-      if (nextState !== 'active' && nextState !== 'background') return;
-      syncCookies();
-    });
-
-    return () => subscription.remove();
   }, []);
 
   const { sendShareIntent } = useShareIntent({
@@ -167,10 +144,18 @@ function Page() {
   const { isSplashOverlayVisible, onWebViewLoadEnd, onWebViewLoadError } =
     useSplashScreenController();
 
-  const handleWebViewLoadEnd = useCallback(() => {
-    onWebViewLoadEnd();
-    setIsWebViewLoaded(true);
-  }, [onWebViewLoadEnd]);
+  const handleWebViewLoadEnd = useCallback(
+    (event: WebViewNavigationEvent | WebViewErrorEvent) => {
+      if (event.nativeEvent.url === 'about:blank') {
+        setIsWarmupLoaded(true);
+        return;
+      }
+
+      onWebViewLoadEnd();
+      setIsWebViewLoaded(true);
+    },
+    [onWebViewLoadEnd]
+  );
 
   /** WebView 로드 실패(네이티브 측) 수집 + 기존 스플래시 처리 유지 */
   const handleWebViewError = useCallback(
@@ -198,23 +183,21 @@ function Page() {
 
   return (
     <View style={{ flex: 1 }}>
-      {isSynced && (
-        <Webview
-          ref={webviewRef}
-          style={{ flex: 1 }}
-          applicationNameForUserAgent={USER_AGENT}
-          source={{ uri: webviewUri }}
-          onMessage={onMessage}
-          onLoadEnd={handleWebViewLoadEnd}
-          onError={handleWebViewError}
-          onHttpError={handleWebViewHttpError}
-          allowsBackForwardNavigationGestures
-          cacheEnabled
-          webviewDebuggingEnabled={__DEV__}
-          startInLoadingState
-        />
-      )}
-      {/* 웹뷰 준비 전까지 네이티브 스플래시를 고해상도로 이어받는 오버레이 */}
+      <Webview
+        ref={webviewRef}
+        style={{ flex: 1 }}
+        applicationNameForUserAgent={USER_AGENT}
+        source={isSynced ? { uri: webviewUri } : { html: '' }}
+        onMessage={onMessage}
+        onLoadEnd={handleWebViewLoadEnd}
+        onError={handleWebViewError}
+        onHttpError={handleWebViewHttpError}
+        allowsBackForwardNavigationGestures
+        cacheEnabled
+        sharedCookiesEnabled
+        webviewDebuggingEnabled={__DEV__}
+        startInLoadingState
+      />
       {isSplashOverlayVisible && <SplashOverlay />}
     </View>
   );

--- a/apps/app/app/index.tsx
+++ b/apps/app/app/index.tsx
@@ -80,8 +80,13 @@ function Page() {
     void logAppOpenEvent();
   }, []);
 
-  // 포그라운드 복귀 시 WKHTTPCookieStore → SecureStore 동기화
-  // proxy.ts(서버)에서 토큰 갱신 시 WebBridge 호출 불가 → AppState로 커버
+  /**
+   * WKHTTPCookieStore → SecureStore 동기화
+   *
+   * - 포그라운드 복귀, 백그라운드 진입 시
+   * - proxy.ts(서버)에서 토큰 갱신 시 WebBridge 호출 불가 → AppState로 커버
+   * - (mount 시점 동기화는 useWebviewCookieSync가 담당 — 여기서 중복 실행하면 부팅 refresh와 레이스)
+   */
   useEffect(() => {
     const WEB_URL = process.env.EXPO_PUBLIC_WEB_URL ?? 'http://localhost:3000';
 
@@ -94,10 +99,8 @@ function Page() {
       }
     };
 
-    syncCookies();
-
     const subscription = AppState.addEventListener('change', async nextState => {
-      if (nextState !== 'active') return;
+      if (nextState !== 'active' && nextState !== 'background') return;
       syncCookies();
     });
 

--- a/apps/app/hooks/useWebviewCookieSync.ts
+++ b/apps/app/hooks/useWebviewCookieSync.ts
@@ -44,10 +44,10 @@ export const useWebviewCookieSync = () => {
 
           if (refreshResponse.ok) {
             const refreshBody = (await refreshResponse.json()) as {
-              data: { access_token: string; refresh_token: string };
+              data: { accessToken: string; refreshToken: string };
             };
-            accessToken = refreshBody.data.access_token;
-            refreshToken = refreshBody.data.refresh_token;
+            accessToken = refreshBody.data.accessToken;
+            refreshToken = refreshBody.data.refreshToken;
             await TokenStorage.setTokens(accessToken, refreshToken);
           } else if (refreshResponse.status === 401) {
             /** 토큰 갱신 401 응답 시 만료된 토큰 정리 */

--- a/apps/app/hooks/useWebviewCookieSync.ts
+++ b/apps/app/hooks/useWebviewCookieSync.ts
@@ -1,3 +1,4 @@
+import { getTokenExpiresIso, isFresherToken, isTokenValid } from '@piki/core';
 import CookieManager from '@react-native-cookies/cookies';
 import { useEffect, useState } from 'react';
 import { Platform } from 'react-native';
@@ -15,16 +16,29 @@ export const useWebviewCookieSync = () => {
   const [isSynced, setIsSynced] = useState(false);
 
   useEffect(() => {
+    const useWebKit = Platform.OS === 'ios';
+
     const sync = async () => {
       let accessToken = await TokenStorage.getAccessToken();
       let refreshToken = await TokenStorage.getRefreshToken();
 
-      /**
-       * 부팅 시 한 번 갱신해 SecureStore 를 최신 rotation 토큰으로 맞춘다.
-       * server proxy 의 갱신은 네이티브 SecureStore 를 못 건드려, 저장된 토큰이 죽은 채로 남아
-       * 딥링크 진입 시 갱신 실패 → 로그인 튕김이 나던 문제를 방지.
-       */
-      if (refreshToken) {
+      /** SecureStore vs 웹뷰 쿠키 중 최신 토큰 채택 */
+      const cookies = await CookieManager.get(WEB_URL, useWebKit);
+      const cookieAccessToken = cookies['access_token']?.value ?? null;
+      const cookieRefreshToken = cookies['refresh_token']?.value ?? null;
+
+      if (
+        cookieAccessToken &&
+        cookieRefreshToken &&
+        isFresherToken(cookieRefreshToken, refreshToken)
+      ) {
+        accessToken = cookieAccessToken;
+        refreshToken = cookieRefreshToken;
+        await TokenStorage.setTokens(accessToken, refreshToken);
+      }
+
+      /** access 가 아직 유효하면 refresh 생략 */
+      if (refreshToken && !isTokenValid(accessToken, 60_000)) {
         try {
           const refreshResponse = await postTokenRefresh(refreshToken);
 
@@ -36,9 +50,9 @@ export const useWebviewCookieSync = () => {
             refreshToken = refreshBody.data.refresh_token;
             await TokenStorage.setTokens(accessToken, refreshToken);
           } else if (refreshResponse.status === 401) {
-            /** 죽은 토큰(SecureStore + WebView 쿠키) 정리 —  */
+            /** 토큰 갱신 401 응답 시 만료된 토큰 정리 */
             await TokenStorage.clearTokens();
-            await CookieManager.clearAll(Platform.OS === 'ios');
+            await CookieManager.clearAll(useWebKit);
             accessToken = null;
             refreshToken = null;
           }
@@ -47,21 +61,31 @@ export const useWebviewCookieSync = () => {
         }
       }
 
-      // iOS WKWebView는 WKHTTPCookieStore를 사용하므로 useWebKit: true 필요
-      const useWebKit = Platform.OS === 'ios';
-
+      /** expires 미지정 시 세션 쿠키가 되어 앱 종료 때 증발 — 토큰 exp 를 그대로 부여 */
       if (accessToken) {
+        const expires = getTokenExpiresIso(accessToken);
         await CookieManager.set(
           WEB_URL,
-          { name: 'access_token', value: accessToken, path: '/' },
+          {
+            name: 'access_token',
+            value: accessToken,
+            path: '/',
+            ...(expires ? { expires } : {}),
+          },
           useWebKit
         );
       }
 
       if (refreshToken) {
+        const expires = getTokenExpiresIso(refreshToken);
         await CookieManager.set(
           WEB_URL,
-          { name: 'refresh_token', value: refreshToken, path: '/' },
+          {
+            name: 'refresh_token',
+            value: refreshToken,
+            path: '/',
+            ...(expires ? { expires } : {}),
+          },
           useWebKit
         );
       }

--- a/apps/app/hooks/useWebviewCookieSync.ts
+++ b/apps/app/hooks/useWebviewCookieSync.ts
@@ -1,7 +1,7 @@
 import { getTokenExpiresIso, isFresherToken, isTokenValid } from '@piki/core';
 import CookieManager from '@react-native-cookies/cookies';
 import { useEffect, useState } from 'react';
-import { Platform } from 'react-native';
+import { AppState, Platform } from 'react-native';
 
 import { postTokenRefresh } from '@/apis/postTokenRefresh';
 import { TokenStorage } from '@/utils/tokenStorage';
@@ -9,13 +9,24 @@ import { TokenStorage } from '@/utils/tokenStorage';
 const WEB_URL = process.env.EXPO_PUBLIC_WEB_URL ?? 'http://localhost:3000';
 
 /**
- * expo-secure-store의 토큰을 WebView 쿠키 저장소에 동기화
- * WebView 첫 요청 전에 쿠키가 심어져야 RSC 프리페치가 정상 동작함
+ * SecureStore ↔ WebView 쿠키 저장소 양방향 동기화
+ *
+ * @param isWebviewReady 웹뷰 로드 완료 여부
+ *
+ * - 부팅 시(isWebviewReady): SecureStore → 웹뷰 쿠키 (웹뷰 첫 요청 전에 심어야 RSC 프리페치 정상 동작)
+ * - 포그라운드 복귀, 백그라운드 진입 시: 웹뷰 쿠키 → SecureStore (웹/proxy 가 갱신한 토큰 회수)
  */
-export const useWebviewCookieSync = () => {
+export const useWebviewCookieSync = (isWebviewReady: boolean) => {
   const [isSynced, setIsSynced] = useState(false);
 
+  /** SecureStore → 웹뷰 쿠키 동기화 */
   useEffect(() => {
+    /**
+     * NOTE: iOS 웹뷰 쿠키 저장소(WKHTTPCookieStore)는 WKWebView 인스턴스가 최소 하나 살아있어야 제대로 동작함.
+     * 인스턴스 없이 싱크를 시도하면 토큰 유실되므로, 웹뷰 로드 완료 후(isWebviewReady)에만 동기화 시도
+     */
+    if (!isWebviewReady) return;
+
     const useWebKit = Platform.OS === 'ios';
 
     const sync = async () => {
@@ -53,47 +64,61 @@ export const useWebviewCookieSync = () => {
             /** 토큰 갱신 401 응답 시 만료된 토큰 정리 */
             await TokenStorage.clearTokens();
             await CookieManager.clearAll(useWebKit);
+            if (useWebKit) await CookieManager.clearAll(false);
             accessToken = null;
             refreshToken = null;
           }
         } catch {
-          /** 네트워크 등 일시적 실패 → 기존 토큰 유지 (로그아웃되지 않도록) */
+          /** 네트워크 등 일시적 실패 → 기존 토큰 유지 */
         }
       }
 
-      /** expires 미지정 시 세션 쿠키가 되어 앱 종료 때 증발 — 토큰 exp 를 그대로 부여 */
-      if (accessToken) {
-        const expires = getTokenExpiresIso(accessToken);
-        await CookieManager.set(
-          WEB_URL,
-          {
-            name: 'access_token',
-            value: accessToken,
-            path: '/',
-            ...(expires ? { expires } : {}),
-          },
-          useWebKit
-        );
-      }
+      const setAuthCookie = async (name: string, value: string) => {
+        /** expires 미지정 시 세션 쿠키가 되어 앱 종료 때 증발 — 토큰 exp 를 그대로 부여 */
+        const expires = getTokenExpiresIso(value);
+        const cookie = { name, value, path: '/', ...(expires ? { expires } : {}) };
 
-      if (refreshToken) {
-        const expires = getTokenExpiresIso(refreshToken);
-        await CookieManager.set(
-          WEB_URL,
-          {
-            name: 'refresh_token',
-            value: refreshToken,
-            path: '/',
-            ...(expires ? { expires } : {}),
-          },
-          useWebKit
-        );
-      }
+        await CookieManager.set(WEB_URL, cookie, useWebKit);
+        if (useWebKit) await CookieManager.set(WEB_URL, cookie, false);
+      };
 
-      setIsSynced(true);
+      /** 앱 진입 시 유효한 최신 토큰을 웹뷰 쿠키에 주입 */
+      if (accessToken) await setAuthCookie('access_token', accessToken);
+      if (refreshToken) await setAuthCookie('refresh_token', refreshToken);
     };
 
-    sync();
+    sync()
+      .catch(error => {
+        if (__DEV__) console.warn('[COOKIE_SYNC] 동기화 실패:', String(error));
+      })
+      /** 싱크 실패하더라도 스플래시가 무한으로 뜨는 현상을 방지 */
+      .finally(() => setIsSynced(true));
+  }, [isWebviewReady]);
+
+  /**
+   * 웹뷰 쿠키 → SecureStore 동기화
+   *
+   * - 포그라운드 복귀·백그라운드 진입 시
+   * - 단, proxy에서 토큰 갱신 시 WebBridge 호출 불가 → AppState로 커버
+   */
+  useEffect(() => {
+    const useWebKit = Platform.OS === 'ios';
+
+    const syncCookiesToStore = async () => {
+      const cookies = await CookieManager.get(WEB_URL, useWebKit);
+      const accessToken = cookies['access_token']?.value;
+      const refreshToken = cookies['refresh_token']?.value;
+      if (accessToken && refreshToken) {
+        await TokenStorage.setTokens(accessToken, refreshToken);
+      }
+    };
+
+    const subscription = AppState.addEventListener('change', nextState => {
+      if (nextState !== 'active' && nextState !== 'background') return;
+      syncCookiesToStore();
+    });
+
+    return () => subscription.remove();
   }, []);
 
   return { isSynced };

--- a/apps/app/utils/postWishLinkFromShare.ts
+++ b/apps/app/utils/postWishLinkFromShare.ts
@@ -43,12 +43,12 @@ export const postWishLinkFromShare = async (
 
       /** 토큰 갱신 후 토큰 저장 */
       const refreshBody = (await refreshResponse.json()) as {
-        data: { access_token: string; refresh_token: string };
+        data: { accessToken: string; refreshToken: string };
       };
-      await TokenStorage.setTokens(refreshBody.data.access_token, refreshBody.data.refresh_token);
+      await TokenStorage.setTokens(refreshBody.data.accessToken, refreshBody.data.refreshToken);
 
       /** 위시 등록 재시도 */
-      postWishResponse = await postWishLink(productUrl, refreshBody.data.access_token);
+      postWishResponse = await postWishLink(productUrl, refreshBody.data.accessToken);
     }
 
     if (!postWishResponse.ok) return { ok: false, message: '요청 처리 중 오류가 발생했습니다.' };

--- a/apps/app/utils/tokenStorage.ts
+++ b/apps/app/utils/tokenStorage.ts
@@ -1,3 +1,4 @@
+import { isFresherToken } from '@piki/core';
 import * as SecureStore from 'expo-secure-store';
 import { Platform } from 'react-native';
 
@@ -11,7 +12,13 @@ const getSecureStoreOptions = (): SecureStore.SecureStoreOptions =>
   Platform.OS === 'ios' ? { accessGroup: 'group.day.no30s.piki' } : {};
 
 export const TokenStorage = {
+  /** 저장된 refresh 보다 최신일 때만 저장 */
   async setTokens(accessToken: string, refreshToken: string) {
+    const storedRefreshToken = await TokenStorage.getRefreshToken();
+
+    if (storedRefreshToken === refreshToken) return;
+    if (storedRefreshToken && !isFresherToken(refreshToken, storedRefreshToken)) return;
+
     const options = getSecureStoreOptions();
 
     await Promise.all([

--- a/apps/web/src/apis/postTokenRefresh.ts
+++ b/apps/web/src/apis/postTokenRefresh.ts
@@ -1,18 +1,22 @@
+import type { AuthTokensT } from '@piki/core';
+
 import { ENDPOINTS } from '@/consts/api';
 import type { ApiResponseT } from '@/types/api';
 
 import { serverApi } from './server';
 
 export const postTokenRefreshServer = async (cookies: string) => {
-  const response = await serverApi.post<
-    ApiResponseT<{ accessToken: string | null; refreshToken: string | null }>
-  >(ENDPOINTS.AUTH_TOKEN_REFRESH, void 0, {
-    headers: {
-      Cookie: cookies,
-      /** Refresh는 Content-Type 헤더 있으면 415 에러 발생 */
-      'Content-Type': false,
-    },
-  });
+  const response = await serverApi.post<ApiResponseT<AuthTokensT>>(
+    ENDPOINTS.AUTH_TOKEN_REFRESH,
+    void 0,
+    {
+      headers: {
+        Cookie: cookies,
+        /** Refresh는 Content-Type 헤더 있으면 415 에러 발생 */
+        'Content-Type': false,
+      },
+    }
+  );
 
   return response;
 };

--- a/apps/web/src/apis/postTokenRefresh.ts
+++ b/apps/web/src/apis/postTokenRefresh.ts
@@ -5,7 +5,7 @@ import { serverApi } from './server';
 
 export const postTokenRefreshServer = async (cookies: string) => {
   const response = await serverApi.post<
-    ApiResponseT<{ access_token: string; refresh_token: string }>
+    ApiResponseT<{ accessToken: string | null; refreshToken: string | null }>
   >(ENDPOINTS.AUTH_TOKEN_REFRESH, void 0, {
     headers: {
       Cookie: cookies,

--- a/apps/web/src/app/archive/wish/layout.tsx
+++ b/apps/web/src/app/archive/wish/layout.tsx
@@ -6,32 +6,27 @@ import { redirect } from 'next/navigation';
 import { getMe } from '@/apis/getMe';
 import WishLoginRequired from '@/components/common/wish-login-required';
 import { QUERY_ACTION } from '@/consts/queryAction';
-import { ROUTES } from '@/consts/route';
 import type { ApiErrorResponseT } from '@/types/api';
+import type { UserT } from '@/types/user';
 import { getLoginPath } from '@/utils/loginRedirect';
 import { getQueryClient } from '@/utils/queryClient';
 
-type ArchiveLayoutProps = {
+type WishArchiveLayoutProps = {
   children: React.ReactNode;
 };
 
-async function ArchiveLayout({ children }: ArchiveLayoutProps) {
+async function WishArchiveLayout({ children }: WishArchiveLayoutProps) {
   const headerStore = await headers();
   const redirectPath = headerStore.get('x-redirect-path');
   const queryClient = getQueryClient();
 
   /** MEMBER 권한 조회 - 멤버 권한 없으면 로그인 페이지로 리다이렉트 */
+  let user: UserT;
   try {
-    const user = await queryClient.fetchQuery({
+    user = await queryClient.fetchQuery({
       queryKey: ['me'],
       queryFn: getMe,
     });
-    if (user.identityType !== 'MEMBER') {
-      /** 위시 페이지는 로그인 유도 화면을 렌더 */
-      if (redirectPath?.startsWith(ROUTES.WISHLIST)) return <WishLoginRequired />;
-
-      redirect(getLoginPath(redirectPath));
-    }
   } catch (error) {
     if (!isAxiosError<ApiErrorResponseT>(error)) throw error;
 
@@ -41,7 +36,10 @@ async function ArchiveLayout({ children }: ArchiveLayoutProps) {
     throw error;
   }
 
+  /** 위시 페이지는 멤버가 아니면 로그인 유도 화면을 렌더 */
+  if (user.identityType !== 'MEMBER') return <WishLoginRequired />;
+
   return <HydrationBoundary state={dehydrate(queryClient)}>{children}</HydrationBoundary>;
 }
 
-export default ArchiveLayout;
+export default WishArchiveLayout;

--- a/apps/web/src/hooks/useFcmTokenSync.ts
+++ b/apps/web/src/hooks/useFcmTokenSync.ts
@@ -1,11 +1,10 @@
 'use client';
 
-import { WEBBRIDGE_MESSAGE_TYPE } from '@piki/core';
+import { WEBBRIDGE_MESSAGE_TYPE, isTokenValid } from '@piki/core';
 import { useCallback, useEffect } from 'react';
 
 import { postFcmToken } from '@/apis/postFcmToken';
 import { useWebBridgeMessage } from '@/hooks/useWebBridgeMessage';
-import { isTokenValid } from '@/utils/auth';
 import { captureError } from '@/utils/captureError';
 import { getCookie } from '@/utils/cookie';
 import { WebBridge, isWebview as isWebviewFn } from '@/utils/webBridge';

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,8 +1,8 @@
+import { getTokenMaxAge, isTokenValid } from '@piki/core';
 import { type NextRequest, NextResponse } from 'next/server';
 
 import { postTokenRefreshServer } from './apis/postTokenRefresh';
 import { postGuestLoginServer } from './app/login/_apis/postGuestLogin';
-import { isTokenValid } from './utils/auth';
 import { getRouteType } from './utils/getRouteType';
 import { getLoginPath } from './utils/loginRedirect';
 import { isWebview } from './utils/webBridge';
@@ -46,8 +46,16 @@ const handleGuestLogin = async (request: NextRequest) => {
   if (isApp) {
     if (bodyAccess && bodyRefresh) {
       const cookieOptions = `Path=/; SameSite=Lax${process.env.NODE_ENV === 'production' ? '; Secure' : ''}`;
-      nextResponse.headers.append('set-cookie', `access_token=${bodyAccess}; ${cookieOptions}`);
-      nextResponse.headers.append('set-cookie', `refresh_token=${bodyRefresh}; ${cookieOptions}`);
+      const accessMaxAge = getTokenMaxAge(bodyAccess);
+      const refreshMaxAge = getTokenMaxAge(bodyRefresh);
+      nextResponse.headers.append(
+        'set-cookie',
+        `access_token=${bodyAccess}; ${cookieOptions}${accessMaxAge === null ? '' : `; Max-Age=${accessMaxAge}`}`
+      );
+      nextResponse.headers.append(
+        'set-cookie',
+        `refresh_token=${bodyRefresh}; ${cookieOptions}${refreshMaxAge === null ? '' : `; Max-Age=${refreshMaxAge}`}`
+      );
     }
   } else setCookieHeaders.forEach(cookie => nextResponse.headers.append('set-cookie', cookie));
 
@@ -143,8 +151,16 @@ const handleTokenRefresh = async (request: NextRequest) => {
     if (isApp) {
       if (bodyAccess && bodyRefresh) {
         const cookieOptions = `Path=/; SameSite=Lax${process.env.NODE_ENV === 'production' ? '; Secure' : ''}`;
-        nextResponse.headers.append('set-cookie', `access_token=${bodyAccess}; ${cookieOptions}`);
-        nextResponse.headers.append('set-cookie', `refresh_token=${bodyRefresh}; ${cookieOptions}`);
+        const accessMaxAge = getTokenMaxAge(bodyAccess);
+        const refreshMaxAge = getTokenMaxAge(bodyRefresh);
+        nextResponse.headers.append(
+          'set-cookie',
+          `access_token=${bodyAccess}; ${cookieOptions}${accessMaxAge === null ? '' : `; Max-Age=${accessMaxAge}`}`
+        );
+        nextResponse.headers.append(
+          'set-cookie',
+          `refresh_token=${bodyRefresh}; ${cookieOptions}${refreshMaxAge === null ? '' : `; Max-Age=${refreshMaxAge}`}`
+        );
       }
     } else setCookieHeaders.forEach(cookie => nextResponse.headers.append('set-cookie', cookie));
 

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -118,8 +118,7 @@ const handleTokenRefresh = async (request: NextRequest) => {
      * 쿠키 옵션 제거 후 key, value만 추출하여 페이지로 전달
      */
     const setCookieHeaders = response.headers['set-cookie'] ?? [];
-    /** app: 토큰이 응답 body(snake_case) 로, web: Set-Cookie 로 온다 */
-    const { access_token: bodyAccess, refresh_token: bodyRefresh } = response.data?.data ?? {};
+    const { accessToken: bodyAccess, refreshToken: bodyRefresh } = response.data?.data ?? {};
 
     if (isApp) {
       if (bodyAccess) cookieMap.set('access_token', bodyAccess);

--- a/apps/web/src/utils/auth.ts
+++ b/apps/web/src/utils/auth.ts
@@ -1,41 +1,11 @@
+import { decodeJwtPayload, isTokenValid } from '@piki/core';
+
 import type { UserIdentityTypeT } from '@/types/user';
-
-/** JWT 토큰 페이로드 추출 */
-const decodeJwt = (token: string) => {
-  try {
-    const base64Url = token.split('.')[1];
-    if (!base64Url) return null;
-
-    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-
-    const jsonPayload = decodeURIComponent(
-      atob(base64)
-        .split('')
-        .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
-        .join('')
-    );
-
-    return JSON.parse(jsonPayload);
-  } catch {
-    return null;
-  }
-};
-
-/** JWT 토큰 유효성 검증 */
-export const isTokenValid = (token: string) => {
-  const payload = decodeJwt(token);
-  if (!payload || !payload.exp) return false;
-
-  const expiryTime = payload.exp * 1000;
-  const currentTime = Date.now();
-
-  return currentTime < expiryTime;
-};
 
 /** access token 의 role(GUEST/MEMBER) 추출 — 만료·손상 토큰은 null */
 export const getRoleFromToken = (token?: string): UserIdentityTypeT | null => {
   if (!token || !isTokenValid(token)) return null;
 
-  const role = decodeJwt(token)?.role;
+  const role = decodeJwtPayload(token)?.role;
   return role === 'GUEST' || role === 'MEMBER' ? role : null;
 };

--- a/apps/web/src/utils/refreshClientToken.ts
+++ b/apps/web/src/utils/refreshClientToken.ts
@@ -31,8 +31,8 @@ import { WebBridge, isWebview } from './webBridge';
 
 type RefreshResponseT = {
   data: {
-    access_token: string | null;
-    refresh_token: string | null;
+    accessToken: string | null;
+    refreshToken: string | null;
   };
 };
 
@@ -47,9 +47,8 @@ const performRefresh = async (): Promise<void> => {
     },
   });
 
-  // 웹뷰는 백엔드 Set-Cookie 가 그대로 안 박히는 케이스가 있어 응답 body 의 토큰을 직접 저장.
   if (isWebview()) {
-    const { access_token: newAccessToken, refresh_token: newRefreshToken } = data.data;
+    const { accessToken: newAccessToken, refreshToken: newRefreshToken } = data.data;
     if (newAccessToken && newRefreshToken) {
       setCookie('access_token', newAccessToken, { hours: 1 });
       setCookie('refresh_token', newRefreshToken, { days: 14 });

--- a/apps/web/src/utils/refreshClientToken.ts
+++ b/apps/web/src/utils/refreshClientToken.ts
@@ -1,4 +1,4 @@
-import { WEBBRIDGE_MESSAGE_TYPE } from '@piki/core';
+import { type AuthTokensT, WEBBRIDGE_MESSAGE_TYPE } from '@piki/core';
 import axios from 'axios';
 
 import { ENDPOINTS } from '@/consts/api';
@@ -30,10 +30,7 @@ import { WebBridge, isWebview } from './webBridge';
  */
 
 type RefreshResponseT = {
-  data: {
-    accessToken: string | null;
-    refreshToken: string | null;
-  };
+  data: AuthTokensT;
 };
 
 let inflightRefresh: Promise<void> | null = null;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,7 +56,6 @@ export type {
 export type { WebBridgeMessageT, WebReqReadyMessageT } from './types/webBridge';
 
 /** 유틸 */
-export type { JwtPayloadT } from './utils/jwt';
 export {
   decodeJwtPayload,
   getTokenExpiresIso,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export {
 } from './consts/webBridge';
 
 /** 타입 */
+export type { AuthTokensT } from './types/auth';
 export type {
   AnalyticsEventParamT,
   AnalyticsEventParamsT,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,4 +55,12 @@ export type {
 export type { WebBridgeMessageT, WebReqReadyMessageT } from './types/webBridge';
 
 /** 유틸 */
+export type { JwtPayloadT } from './utils/jwt';
+export {
+  decodeJwtPayload,
+  getTokenExpiresIso,
+  getTokenMaxAge,
+  isFresherToken,
+  isTokenValid,
+} from './utils/jwt';
 export { isWebBridgeMessageT } from './utils/webBridge';

--- a/packages/core/src/types/auth.ts
+++ b/packages/core/src/types/auth.ts
@@ -1,0 +1,5 @@
+/** 토큰 갱신/발급 응답 body — APP=값, WEB=null(쿠키로 전달) */
+export type AuthTokensT = {
+  accessToken: string | null;
+  refreshToken: string | null;
+};

--- a/packages/core/src/utils/jwt.ts
+++ b/packages/core/src/utils/jwt.ts
@@ -1,4 +1,4 @@
-export type JwtPayloadT = {
+type JwtPayloadT = {
   iat?: number;
   exp?: number;
   role?: string;
@@ -78,7 +78,7 @@ export const getTokenExpiresIso = (token: string): string | null => {
 /**
  * 토큰 만료시간(exp)까지 남은 시간(초) 반환
  *
- * - 만료·손상 토큰은 null 반환
+ * - 손상된 토큰은 null 반환
  */
 export const getTokenMaxAge = (token: string): number | null => {
   const exp = decodeJwtPayload(token)?.exp;

--- a/packages/core/src/utils/jwt.ts
+++ b/packages/core/src/utils/jwt.ts
@@ -1,0 +1,88 @@
+export type JwtPayloadT = {
+  iat?: number;
+  exp?: number;
+  role?: string;
+};
+
+/** JWT payload 디코드 — 실패 시 null */
+export const decodeJwtPayload = (token: string): JwtPayloadT | null => {
+  try {
+    const base64Url = token.split('.')[1];
+    if (!base64Url) return null;
+
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+
+    const jsonPayload = decodeURIComponent(
+      atob(base64)
+        .split('')
+        .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join('')
+    );
+
+    return JSON.parse(jsonPayload) as JwtPayloadT;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * 토큰 유효 여부 반환
+ *
+ * @param leewayMs - 여유시간. 설정 시 현재 시간 + 여유시간 < exp 이면 유효한 토큰으로 판단.
+ */
+export const isTokenValid = (token: string | null, leewayMs = 0): boolean => {
+  if (!token) return false;
+
+  const exp = decodeJwtPayload(token)?.exp;
+  return typeof exp === 'number' && Date.now() + leewayMs < exp * 1000;
+};
+
+/**
+ * 토큰 발급 시각 반환
+ * — iat 없거나 디코드 실패 시 null
+ */
+const getTokenIssuedAt = (token: string | null): number | null => {
+  if (!token) return null;
+
+  const iat = decodeJwtPayload(token)?.iat;
+  return typeof iat === 'number' ? iat * 1000 : null;
+};
+
+/**
+ * candidate 가 base 보다 최신 토큰인지 iat 비교로 판단
+ *
+ * - candidate가 최신인 경우 true 반환
+ * - base가 최신인 경우 false 반환
+ * - iat 판단 불가 시 false 반환
+ */
+export const isFresherToken = (candidate: string | null, base: string | null): boolean => {
+  const candidateIssuedAt = getTokenIssuedAt(candidate);
+  if (candidateIssuedAt === null) return false;
+
+  const baseIssuedAt = getTokenIssuedAt(base);
+  if (baseIssuedAt === null) return true;
+
+  return candidateIssuedAt > baseIssuedAt;
+};
+
+/**
+ * 토큰 exp 를 쿠키 expires(ISO)로 반환
+ *
+ * - 디코드 실패 시 null 반환
+ */
+export const getTokenExpiresIso = (token: string): string | null => {
+  const exp = decodeJwtPayload(token)?.exp;
+  return typeof exp === 'number' ? new Date(exp * 1000).toISOString() : null;
+};
+
+/**
+ * 토큰 만료시간(exp)까지 남은 시간(초) 반환
+ *
+ * - 만료·손상 토큰은 null 반환
+ */
+export const getTokenMaxAge = (token: string): number | null => {
+  const exp = decodeJwtPayload(token)?.exp;
+  if (typeof exp !== 'number') return null;
+
+  return Math.max(0, Math.floor(exp - Date.now() / 1000));
+};


### PR DESCRIPTION
## 작업 요약

- 앱(WebView) 로그인이 유지되지 않고 풀리던 문제 해결
- 근본 원인: 토큰 갱신 응답을 snake_case로 잘못 파싱 → 새 토큰 저장 실패 → 옛 토큰 재사용으로 서버가 세션 무효화
- iOS `WKWebView` 쿠키 저장 특성으로 인한 쿠키 동기화 타이밍 문제 동반
- 파싱 camelCase 수정 + 웹뷰 워밍업 후 SecureStore ↔ 쿠키 양방향 동기화로 정리
- 웹 환경은 영향 없음 (토큰을 Set-Cookie로 받아 파싱 경로를 타지 않음)

## 배경

- 앱은 토큰이 **SecureStore**와 **WebView 쿠키** 두 곳에 존재, rotation은 여러 경로(앱 부팅 / 웹 axios·SSE / Next proxy / 공유 익스텐션)에서 발생
- 서버는 refresh rotation + grace(10초) + 재사용 감지 시 family invalidation 정책 → 오래되거나 잘못된 토큰 제시 시 유효 세션까지 무효화

## 작업 내용

### 1. 토큰 갱신 응답 body를 camelCase로 파싱

- 응답 body는 `{ accessToken, refreshToken }`인데 여러 곳에서 `access_token`(snake_case)으로 파싱 → 새 토큰을 `undefined`로 받아 저장 실패
- 대상: `useWebviewCookieSync`, `postWishLinkFromShare`, `proxy`, `refreshClientToken`, `postTokenRefresh`

### 2. 웹뷰 워밍업 후 쿠키 동기화 + 양방향 동기화 통합

- iOS `WKHTTPCookieStore`는 살아있는 `WKWebView` 없이 쿠키 읽기/쓰기가 유실 → 기존엔 웹뷰 렌더 전 동기화로 시딩 누락
- 웹뷰를 빈 HTML로 먼저 마운트(워밍업)하고, 로드 완료 후에만 쿠키 동기화 시작
- `sharedCookiesEnabled` + iOS 쿠키 이중 저장(WKHTTPCookieStore / NSHTTPCookieStorage)
- 부팅(SecureStore→쿠키)·복귀(쿠키→SecureStore) 양방향 동기화를 `useWebviewCookieSync`로 통합
- 동기화 실패 시에도 웹뷰 렌더(무한 스플래시 방지)

### 3. JWT 유틸 `@piki/core` 이전 + iat 기반 최신 토큰 판별

- `packages/core/src/utils/jwt.ts` 신규 — `decodeJwtPayload` / `isTokenValid` / `isFresherToken` / `getTokenExpiresIso` / `getTokenMaxAge`
- 두 저장소 중 `iat`가 최신인 토큰만 채택 → 오래된 사본이 최신 토큰을 덮어쓰지 않도록
- access 유효 시 부팅 refresh 생략(불필요한 rotation 방지)

### 4. proxy 세션 쿠키 → 만료 시간 지정

- app 분기 쿠키에 `Max-Age`가 없어 앱 종료 시 증발 → 토큰 `exp` 기반 `Max-Age` 부여

### 5. 토큰 갱신 응답 타입 `AuthTokensT` 추출

- 응답 구조를 여러 곳에서 반복 선언한 것이 파싱 버그 배경 → 재발 방지용 공용 타입 추출
- `packages/core/src/types/auth.ts` 신규 — `AuthTokensT = { accessToken: string | null; refreshToken: string | null }`
- `postTokenRefresh`, `refreshClientToken`, `proxy`(반환 타입 경유) 적용

## 연관 이슈

closes #367


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 앱 실행 시 웹 콘텐츠가 안정적으로 준비된 후 화면이 표시되도록 초기 로딩 흐름을 개선했습니다.
  - 초기 로딩 중에도 딥링크가 정상적으로 처리됩니다.
  - 앱과 웹 간 로그인 세션 및 인증 토큰 동기화를 강화했습니다.
  - 백그라운드 복귀 후에도 최신 로그인 상태가 유지됩니다.
  - 토큰 만료 시간이 쿠키에 반영되어 인증 상태가 더 안정적으로 유지됩니다.
  - 최신 토큰만 저장하도록 개선해 예기치 않은 로그아웃을 줄였습니다.
  - 토큰 갱신 후 위시 등록 재시도가 정상적으로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->