### PR TITLE
style: 체크박스 selected 컬러 디자인 시스템 적용

### DIFF
--- a/apps/web/src/app/archive/wish/_components/WishContentClient.tsx
+++ b/apps/web/src/app/archive/wish/_components/WishContentClient.tsx
@@ -77,7 +77,7 @@ function WishContentClient() {
             >
               <span className="block size-3">
                 {isAllSelected ? (
-                  <CheckboxSelectedIconFill className="size-3 text-uac-light" />
+                  <CheckboxSelectedIconFill className="size-3 text-bg-accent" />
                 ) : (
                   <span className="block size-3 rounded-[2.4px] border-[0.84px] border-gray-400" />
                 )}

--- a/apps/web/src/app/archive/wish/_components/wish-grid/index.tsx
+++ b/apps/web/src/app/archive/wish/_components/wish-grid/index.tsx
@@ -42,7 +42,7 @@ function WishGrid({ items, isDeleteMode = false, selectedIds, onToggleSelect }: 
               <div className={`pointer-events-none absolute top-0 left-0 right-0 z-[11] aspect-[201/166] bg-black/20 transition-opacity duration-200 ${isSelected ? 'opacity-100' : 'opacity-0'}`} />
               <span className="pointer-events-none absolute top-3 left-3 z-[12] block size-5">
                 {isSelected ? (
-                  <CheckboxSelectedIconFill className="size-5 text-uac-light" />
+                  <CheckboxSelectedIconFill className="size-5 text-bg-accent" />
                 ) : (
                   <CheckboxEmptyIconFill className="size-5 text-black/8" />
                 )}

--- a/apps/web/src/app/tournament/[id]/create/by-wish/_components/WishSelectCard.tsx
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_components/WishSelectCard.tsx
@@ -21,7 +21,7 @@ function WishSelectCard({ name, price, imageUrl, sourcePlatform, isSelected, onS
       <WishCard name={name} price={price} imageUrl={imageUrl} sourcePlatform={sourcePlatform} />
       <span className="pointer-events-none absolute top-3 left-3 z-10 block size-5">
         {isSelected ? (
-          <CheckboxSelectedIconFill className="size-5 text-uac-light" />
+          <CheckboxSelectedIconFill className="size-5 text-bg-accent" />
         ) : (
           <CheckboxEmptyIconFill className="size-5 text-black/8" />
         )}


### PR DESCRIPTION
## 작업 요약

- 체크박스 selected 컬러를 디자인 시스템 토큰에 맞게 수정합니다

## 작업 세부 내용

- `text-uac-light` (#0a7aff) → `text-bg-accent` (#1BAEFD, Sky-blue-500) 로 교체
  - 위시리스트 삭제 모드 체크박스 (`wish-grid/index.tsx`)
  - 위시에서 가져오기 체크박스 (`WishSelectCard.tsx`)
  - 전체선택 체크박스 (`WishContentClient.tsx`)

## 스크린샷
<img width="480" height="794" alt="스크린샷 2026-07-24 오후 11 57 33" src="https://github.com/user-attachments/assets/5083bfeb-660c-4b5b-a1bf-2c08228b1396" />


## 연관 이슈

closes #377


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일 개선**
  * 항목 선택 상태를 나타내는 체크 아이콘의 색상을 일관된 강조 색상으로 변경했습니다.
  * 보관함 및 토너먼트 생성 화면에서 선택 상태를 더 명확하게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->