### PR TITLE
chore: CI에서 중복 build 스텝 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   ci:
-    name: Lint, Type Check, Build
+    name: Lint, Type Check
     runs-on: ubuntu-latest
 
     steps:
@@ -44,11 +44,6 @@ jobs:
 
       - name: Type Check
         run: pnpm check-types
-
-      - name: Build
-        env:
-          NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
-        run: pnpm build
 
   e2e:
     name: E2E (Playwright)


### PR DESCRIPTION
## 작업 요약

- GitHub Actions CI의 `pnpm build` 스텝이 Vercel Preview 빌드와 중복 검증이라 제거하여 CI 실행 시간 단축

## 작업 세부 내용

브랜치마다 Vercel preview 빌드가 이미 돌고 있어, GitHub Actions CI(`ci.yml`)의 `pnpm build` 스텝은 중복 검증이었습니다. 이를 제거해 CI 실행 시간을 단축합니다.


### 제거
- `ci` job에서 `Build` 스텝(`NEXT_PUBLIC_API_URL` env 포함) 삭제
- job 이름 변경: `Lint, Type Check, Build` → `Lint, Type Check`

### 유지 (Vercel이 커버하지 못하는 검사)

| 검사 | 사유 |
|------|------|
| `pnpm lint` | Next 16은 빌드 시 ESLint를 돌리지 않음 |
| `pnpm check-types` | 타입 체크는 Vercel 빌드와 별개로 필요 |
| E2E (Playwright) | Vercel과 무관, 별도 job으로 계속 실행 |


## 연관 이슈

closes #374 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/품질 관리**
  * CI 검사에서 빌드 단계가 제거되고, 린트 및 타입 검사만 수행하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->