### PR TITLE
chore: 리뷰어 자동 지정을 랜덤에서 git blame 기반으로 변경

### DIFF
--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -127,12 +127,16 @@ jobs:
               reviewer = FALLBACK_REVIEWER;
             }
 
-            await github.rest.issues.addAssignees({
-              owner,
-              repo,
-              issue_number: pullNumber,
-              assignees: [author],
-            });
+            try {
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: pullNumber,
+                assignees: [author],
+              });
+            } catch (error) {
+              core.warning(`Failed to assign author ${author}: ${error.message}`);
+            }
 
             if (reviewer) {
               try {
@@ -146,12 +150,18 @@ jobs:
                 // blame 대상자가 콜라보레이터가 아닌 경우(팀 탈퇴 등) fallback 리뷰어로 재시도
                 core.warning(`Failed to request review from ${reviewer}: ${error.message}`);
                 if (reviewer !== FALLBACK_REVIEWER && author !== FALLBACK_REVIEWER) {
-                  await github.rest.pulls.requestReviewers({
-                    owner,
-                    repo,
-                    pull_number: pullNumber,
-                    reviewers: [FALLBACK_REVIEWER],
-                  });
+                  try {
+                    await github.rest.pulls.requestReviewers({
+                      owner,
+                      repo,
+                      pull_number: pullNumber,
+                      reviewers: [FALLBACK_REVIEWER],
+                    });
+                  } catch (fallbackError) {
+                    core.warning(
+                      `Failed to request review from fallback reviewer ${FALLBACK_REVIEWER}: ${fallbackError.message}`
+                    );
+                  }
                 }
               }
             }

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -45,10 +45,10 @@ jobs:
                   oldLine = Number(hunkHeader[1]);
                   continue;
                 }
-                if (line.startsWith('-') && !line.startsWith('---')) {
+                if (line.startsWith('-')) {
                   changedLines.add(oldLine);
                   oldLine += 1;
-                } else if (!line.startsWith('+')) {
+                } else if (!line.startsWith('+') && !line.startsWith('\\')) {
                   oldLine += 1;
                 }
               }
@@ -120,18 +120,31 @@ jobs:
               reviewer = FALLBACK_REVIEWER;
             }
 
-            if (reviewer) {
-              await github.rest.pulls.requestReviewers({
-                owner,
-                repo,
-                pull_number: pullNumber,
-                reviewers: [reviewer],
-              });
-            }
-
             await github.rest.issues.addAssignees({
               owner,
               repo,
               issue_number: pullNumber,
               assignees: [author],
             });
+
+            if (reviewer) {
+              try {
+                await github.rest.pulls.requestReviewers({
+                  owner,
+                  repo,
+                  pull_number: pullNumber,
+                  reviewers: [reviewer],
+                });
+              } catch (error) {
+                // blame 대상자가 콜라보레이터가 아닌 경우(팀 탈퇴 등) fallback 리뷰어로 재시도
+                core.warning(`Failed to request review from ${reviewer}: ${error.message}`);
+                if (reviewer !== FALLBACK_REVIEWER && author !== FALLBACK_REVIEWER) {
+                  await github.rest.pulls.requestReviewers({
+                    owner,
+                    repo,
+                    pull_number: pullNumber,
+                    reviewers: [FALLBACK_REVIEWER],
+                  });
+                }
+              }
+            }

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -1,4 +1,4 @@
-name: Assign Random Reviewers
+name: Assign Reviewer by Blame
 
 on:
   pull_request:
@@ -10,30 +10,128 @@ jobs:
   assign-reviewer:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
       issues: write
     steps:
-      - name: Assign random reviewers
+      - name: Assign reviewer by git blame
         uses: actions/github-script@v7
         with:
           script: |
-            const candidates = ['kanghaeun','iOdiO89', 'ychany', 'soyeong0115'];
+            const FALLBACK_REVIEWER = 'iOdiO89';
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pullNumber = context.payload.pull_request.number;
             const author = context.payload.pull_request.user.login;
+            const baseSha = context.payload.pull_request.base.sha;
 
-            const filtered = candidates.filter(id => id !== author);
-            const shuffled = filtered.sort(() => Math.random() - 0.5);
-            const reviewers = shuffled.slice(0, 2);
-
-            await github.rest.pulls.requestReviewers({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              reviewers,
+            // 변경 파일 목록 조회
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
             });
 
+            // patch(unified diff)에서 base 파일 기준으로 삭제/변경된 줄 번호 집합을 구함
+            const getChangedOldLines = patch => {
+              const changedLines = new Set();
+              let oldLine = 0;
+
+              for (const line of patch.split('\n')) {
+                const hunkHeader = line.match(/^@@ -(\d+)/);
+                if (hunkHeader) {
+                  oldLine = Number(hunkHeader[1]);
+                  continue;
+                }
+                if (line.startsWith('-') && !line.startsWith('---')) {
+                  changedLines.add(oldLine);
+                  oldLine += 1;
+                } else if (!line.startsWith('+')) {
+                  oldLine += 1;
+                }
+              }
+
+              return changedLines;
+            };
+
+            const blameQuery = `
+              query($owner: String!, $repo: String!, $sha: GitObjectID!, $path: String!) {
+                repository(owner: $owner, name: $repo) {
+                  object(oid: $sha) {
+                    ... on Commit {
+                      blame(path: $path) {
+                        ranges {
+                          startingLine
+                          endingLine
+                          commit {
+                            author {
+                              user { login }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const candidateCounts = {};
+
+            for (const file of files) {
+              // 신규 파일은 base ref에 없으므로 blame 대상이 아님
+              if (file.status === 'added' || !file.patch) continue;
+
+              const path = file.previous_filename ?? file.filename;
+              const changedOldLines = getChangedOldLines(file.patch);
+              if (changedOldLines.size === 0) continue;
+
+              const result = await github.graphql(blameQuery, {
+                owner,
+                repo,
+                sha: baseSha,
+                path,
+              });
+
+              const ranges = result.repository?.object?.blame?.ranges ?? [];
+              for (const range of ranges) {
+                const login = range.commit?.author?.user?.login;
+                if (!login || login === author) continue;
+
+                let overlap = 0;
+                for (let l = range.startingLine; l <= range.endingLine; l++) {
+                  if (changedOldLines.has(l)) overlap += 1;
+                }
+                if (overlap > 0) {
+                  candidateCounts[login] = (candidateCounts[login] ?? 0) + overlap;
+                }
+              }
+            }
+
+            core.info(`Blame candidate counts: ${JSON.stringify(candidateCounts)}`);
+
+            let reviewer = null;
+            const entries = Object.entries(candidateCounts);
+            if (entries.length > 0) {
+              reviewer = entries.reduce((top, current) => (current[1] > top[1] ? current : top))[0];
+            } else if (author !== FALLBACK_REVIEWER) {
+              reviewer = FALLBACK_REVIEWER;
+            }
+
+            if (reviewer) {
+              await github.rest.pulls.requestReviewers({
+                owner,
+                repo,
+                pull_number: pullNumber,
+                reviewers: [reviewer],
+              });
+            }
+
             await github.rest.issues.addAssignees({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
+              owner,
+              repo,
+              issue_number: pullNumber,
               assignees: [author],
             });

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -88,14 +88,21 @@ jobs:
               const changedOldLines = getChangedOldLines(file.patch);
               if (changedOldLines.size === 0) continue;
 
-              const result = await github.graphql(blameQuery, {
-                owner,
-                repo,
-                sha: baseSha,
-                path,
-              });
+              let ranges;
+              try {
+                const result = await github.graphql(blameQuery, {
+                  owner,
+                  repo,
+                  sha: baseSha,
+                  path,
+                });
+                ranges = result.repository?.object?.blame?.ranges ?? [];
+              } catch (error) {
+                // 파일 하나의 blame 조회 실패로 전체 워크플로가 중단되지 않도록 skip
+                core.warning(`Failed to fetch blame for ${path}: ${error.message}`);
+                continue;
+              }
 
-              const ranges = result.repository?.object?.blame?.ranges ?? [];
               for (const range of ranges) {
                 const login = range.commit?.author?.user?.login;
                 if (!login || login === author) continue;

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -34,24 +34,40 @@ jobs:
               per_page: 100,
             });
 
-            // patch(unified diff)에서 base 파일 기준으로 삭제/변경된 줄 번호 집합을 구함
+            // patch(unified diff)에서 base 파일 기준으로 삭제/변경된 줄 번호 집합을 구함.
+            // 순수 삽입 hunk(삭제 줄 없이 추가만 있는 경우)는 old 파일에 직접 대응하는 줄이 없으므로,
+            // 삽입 지점 주변 context 줄을 대신 후보로 포함시킨다.
             const getChangedOldLines = patch => {
               const changedLines = new Set();
               let oldLine = 0;
+              let hunkHasDeletion = false;
+              let hunkContextLines = [];
+
+              const flushHunk = () => {
+                if (!hunkHasDeletion) {
+                  for (const l of hunkContextLines) changedLines.add(l);
+                }
+                hunkHasDeletion = false;
+                hunkContextLines = [];
+              };
 
               for (const line of patch.split('\n')) {
                 const hunkHeader = line.match(/^@@ -(\d+)/);
                 if (hunkHeader) {
+                  flushHunk();
                   oldLine = Number(hunkHeader[1]);
                   continue;
                 }
                 if (line.startsWith('-')) {
                   changedLines.add(oldLine);
+                  hunkHasDeletion = true;
                   oldLine += 1;
                 } else if (!line.startsWith('+') && !line.startsWith('\\')) {
+                  hunkContextLines.push(oldLine);
                   oldLine += 1;
                 }
               }
+              flushHunk();
 
               return changedLines;
             };


### PR DESCRIPTION
## 작업 요약

PR 리뷰어를 랜덤 2명 지정하던 방식을, 변경된 코드의 git blame 기여자 기반으로 1명 지정하도록 변경 — 컨텍스트가 있는 사람이 리뷰하게 되어 리뷰 품질 향상 목적

## 작업 세부 내용


### 리뷰어 지정 로직 변경

**기존**: 랜덤 2명 지정
**변경**: PR 변경 코드의 git blame 기여자 기반 1명 지정

**동작 방식**
1. PR의 변경 파일 목록 조회
2. GitHub GraphQL blame API로 각 파일의 base 커밋 기준 blame 조회
   - 로컬 체크아웃, 이메일 → 계정 매핑 불필요
3. 변경 라인과 겹치는 blame 구간의 author 집계 → 상위 1명을 리뷰어로 지정
----
### 예외 처리

| 상황 | 처리 |
|------|------|
| PR 작성자 본인 | 집계에서 제외 |
| blame 대상 없음(신규 파일 등) 또는 전부 본인인 경우 | `iOdiO89` 리뷰어 지정 (단, PR 작성자가 본인이면 미지정) |
| 리뷰어 지정 실패 (콜라보레이터 아님 등) | `iOdiO89`로 fallback 재시도 |
----
### 유지
- PR 작성자를 assignee로 지정하는 기존 동작 유지
----
### 제거 및 권한 추가
- 랜덤 지정 로직 제거
- `permissions`에 `contents: read` 추가 (blame GraphQL 조회에 필요)

## 연관 이슈

closes #373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 리뷰어 자동 추천이 무작위 방식에서, git blame 기반 “가장 영향 큰 변경 기여자” 중심으로 변경되어 단일 리뷰어를 지정합니다.
  * 변경 파일의 반영 범위를 조정해 관련 작성자를 계산하며, 적합한 후보가 없을 경우 대체 리뷰어로 안정성을 강화했습니다.
  * 리뷰 요청 실패 시 대체 경로로 재시도하도록 처리했습니다.
* **변경 사항**
  * 워크플로 이름과 권한 범위를 명확히 했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->