### PR TITLE
refactor: 바텀탭 페이지 prefetch 적용

### DIFF
--- a/apps/web/src/components/bottom-tab-bar/index.tsx
+++ b/apps/web/src/components/bottom-tab-bar/index.tsx
@@ -115,7 +115,7 @@ function BottomTabBar() {
     if (lensOffTimerRef.current) clearTimeout(lensOffTimerRef.current);
     setIsGrabbing(true);
 
-    // 프레스 시점에 목적지 라우트를 미리 받아 릴리즈 후 즉시 push 시 대기를 없앤다
+    // 마운트 프리페치가 만료된(세그먼트 캐시 최소 유효시간 30s) 뒤 눌린 경우를 위한 재예열
     const pressTabForPrefetch = TABS[pressIndex];
     if (pressTabForPrefetch && pressIndex !== activeIndex)
       router.prefetch(pressTabForPrefetch.href);
@@ -316,6 +316,7 @@ function BottomTabBar() {
             <Link
               key={label}
               href={href}
+              prefetch={!isActive} // 현재 페이지 제외 나머지 페이지 전부 prefetch 적용
               draggable={false}
               className={cn(
                 'flex h-full w-[72px] cursor-pointer flex-col items-center justify-center rounded-full p-2 transition-colors',


### PR DESCRIPTION
## 작업 요약

- 바텀탭을 눌렀을 때 발생하던 서버 왕복 대기를, 탭바가 떠 있는 동안 다른 탭 라우트를 미리 받아두도록 바꿔 없앴습니다.

## 작업 내용

- 바텀탭 Link에 `prefetch={!isActive}` 추가 — 활성 탭을 뺀 3개 탭 라우트를 탭바 마운트 직후 full 프리페치해, 탭 누를 때의 서버 왕복 대기를 없앰
- 기존 `pointerdown` 시점의 `router.prefetch()`는 기본 kind가 `AUTO`라 `loading.tsx` 없는 동적 라우트(탭 4개)에서 빈 응답만 받아와 효과가 없었음 → 프리페치 만료(세그먼트 캐시 최소 유효시간 30초) 후 재예열용으로 남기고 주석만 정정
