### PR TITLE
fix: 아카이브 위시/토너먼트 + 버튼 위치·크기를 시안 기준으로 통일

### DIFF
--- a/apps/web/src/app/archive/tournament/_components/TournamentFab.tsx
+++ b/apps/web/src/app/archive/tournament/_components/TournamentFab.tsx
@@ -14,7 +14,7 @@ function TournamentFab() {
           aria-label="토너먼트 만들기"
           className="fixed right-[max(20px,calc(50%-480px/2+20px))] bottom-[103px] z-30"
         >
-          <AddIconFill width={30} height={30} />
+          <AddIconFill width={33.101} height={33.101} />
         </Button>
       </DialogTrigger>
       <CreateTournamentDialogContent />

--- a/apps/web/src/app/archive/wish/_components/WishlistFabArea.tsx
+++ b/apps/web/src/app/archive/wish/_components/WishlistFabArea.tsx
@@ -10,7 +10,7 @@ function WishlistFabArea({ isDeleteMode, onAddItem }: WishlistFabAreaProps) {
   if (isDeleteMode) return null;
 
   return (
-    <div className="pointer-events-none fixed right-0 bottom-[103px] left-0 z-30 mx-auto flex w-full max-w-120 justify-end pr-8">
+    <div className="pointer-events-none fixed right-0 bottom-[103px] left-0 z-30 mx-auto flex w-full max-w-120 justify-end pr-5">
       <Button
         variant="primary"
         size="xl"


### PR DESCRIPTION
## 작업 요약

- 아카이브 위시/토너먼트 탭의 + 버튼 위치·크기를 시안 기준으로 통일합니다

## 작업 세부 내용

`/archive/wish` 와 `/archive/tournament` 의 우측 하단 + (FAB) 버튼이 서로 위치·크기가 달라, 탭 전환 시 버튼이 좌우로 움직이고 크기도 달라 보이던 문제를 Figma 시안 기준으로 통일했습니다.

두 페이지가 각각 다른 항목에서 시안과 어긋나 있어(wish=위치, tournament=아이콘), 틀린 쪽만 시안 값으로 보정했습니다.

| 항목 | 시안 | 수정 전 | 수정 후 |
| --- | --- | --- | --- |
| wish 우측 여백 | ~20px | `pr-8` (32px) | `pr-5` (20px) |
| tournament 아이콘 크기 | 33.101px | 30px | 33.101px |
| 하단 위치 | — | `bottom-[103px]` | 동일 (변경 없음) |

- **wish**: 아이콘 크기(33.101px)는 시안과 일치해 유지, 우측 여백만 32px → 20px
- **tournament**: 위치(우측 20px)는 시안과 일치해 유지, 아이콘만 30px → 33.101px

## 연관 이슈

closes #397


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 토너먼트 생성 버튼 아이콘 크기를 조정했습니다.
  * 위시리스트 추가 버튼 영역의 오른쪽 여백을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->