### PR TITLE
fix: 프로필 수정 카메라 버튼이 프로필 이미지에 가려지는 문제 수정

### DIFF
--- a/apps/web/src/app/mypage/edit/_components/ProfileImageField.tsx
+++ b/apps/web/src/app/mypage/edit/_components/ProfileImageField.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { CameraIconFill } from '@/assets/icons';
 import BaseImage from '@/components/base-image';
 import Skeleton from '@/components/skeleton';
+import { Z_INDEX } from '@/consts/zIndex';
 import { useImagePicker } from '@/hooks/useImagePicker';
 import type { UserIdentityTypeT } from '@/types/user';
 
@@ -60,6 +61,7 @@ function ProfileImageField({ userIdentityType, profileImage, onImageSelect }: Pr
             disabled={isPending}
             aria-label="프로필 이미지 변경"
             className="absolute top-[54.5px] left-[59px] flex size-10 shrink-0 cursor-pointer items-center justify-center rounded-full bg-bg-layer-default"
+            style={{ zIndex: Z_INDEX.BASE_IMAGE + 1 }}
           >
             <CameraIconFill className="size-6 shrink-0 text-icon-neutral-secondary" />
           </button>


### PR DESCRIPTION
## 작업 요약

- 내 프로필 수정 페이지에서 프로필 이미지 변경(카메라) 버튼이 프로필 이미지 뒤에 가려져 보이지 않던 문제를 수정했습니다.

## 작업 내용

- 카메라 버튼에 `zIndex: Z_INDEX.BASE_IMAGE + 1`을 지정 — `BaseImage`가 이미지에 `z-index: 10`을 직접 부여하는데, 이미지를 감싼 래퍼(`relative` + `overflow-hidden`)가 스택 컨텍스트를 만들지 않아 그 값이 밖으로 새어나와 형제인 버튼(z-index auto)보다 위에 그려지고 있었습니다.
- `user-profile-group`, `wish-grid` 등 BaseImage 위에 요소를 겹칠 때 쓰는 기존 패턴과 동일하게 맞췄습니다.

## 스크린샷

<img width="489" height="400" alt="스크린샷 2026-08-01 오전 8 15 07" src="https://github.com/user-attachments/assets/32a6f629-233b-40cb-be67-bd84744b4bac" />


## 연관 이슈

closes #391


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 프로필 이미지 변경 버튼이 이미지 위에 올바르게 표시되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->