### PR TITLE
style: UI 일관성 정리 및 입력 다이얼로그 엔터 제출 지원

### DIFF
--- a/apps/web/src/app/(legal)/privacy/page.tsx
+++ b/apps/web/src/app/(legal)/privacy/page.tsx
@@ -9,7 +9,7 @@ function PrivacyPage() {
       <Header
         left={<HeaderIcon name="BACK" />}
         center="개인정보 처리방침"
-        centerClassName="title-1"
+        centerClassName="heading-1-bold"
       />
       <Spacing size={48} />
 

--- a/apps/web/src/app/(legal)/terms/page.tsx
+++ b/apps/web/src/app/(legal)/terms/page.tsx
@@ -9,7 +9,7 @@ function TermsPage() {
       <Header
         left={<HeaderIcon name="BACK" />}
         center="서비스 이용약관"
-        centerClassName="title-1"
+        centerClassName="heading-1-bold"
       />
       <Spacing size={48} />
 

--- a/apps/web/src/app/archive/tournament/_components/TournamentHistoryList.tsx
+++ b/apps/web/src/app/archive/tournament/_components/TournamentHistoryList.tsx
@@ -14,9 +14,9 @@ function TournamentHistoryList({ statuses }: Props) {
 
   if (tournamentListData.length === 0)
     return (
-      <main className="flex flex-1 flex-col items-center justify-center pb-24">
+      <div className="flex flex-1 flex-col items-center justify-center pb-24">
         <TournamentEmptyState />
-      </main>
+      </div>
     );
 
   return (

--- a/apps/web/src/app/archive/tournament/_components/TournamentHistorySection.tsx
+++ b/apps/web/src/app/archive/tournament/_components/TournamentHistorySection.tsx
@@ -29,11 +29,11 @@ function TournamentHistorySection({ initialTab }: Props) {
         <Spacing size={16} />
         <TournamentStatusTab activeTab={activeTab} onTabChange={handleTabChange} />
       </div>
-      <main className="hide-scrollbar flex flex-1 flex-col gap-4 overflow-y-auto pt-6 pb-24">
+      <div className="hide-scrollbar flex flex-1 flex-col gap-4 overflow-y-auto pt-6 pb-24">
         <Suspense key={activeTab} fallback={<TournamentHistorySkeleton />}>
           <TournamentHistoryList statuses={STATUS_BY_TAB[activeTab]} />
         </Suspense>
-      </main>
+      </div>
     </>
   );
 }

--- a/apps/web/src/app/archive/tournament/page.tsx
+++ b/apps/web/src/app/archive/tournament/page.tsx
@@ -23,12 +23,12 @@ async function ArchiveTournamentPage({ searchParams }: Props) {
   });
 
   return (
-    <div className="flex min-h-dvh flex-col bg-bg-layer-basement px-5">
+    <main className="flex min-h-dvh flex-col bg-bg-layer-basement px-5">
       <HydrationBoundary state={dehydrate(queryClient)}>
         <TournamentHistorySection initialTab={initialTab} />
       </HydrationBoundary>
       <TournamentFab />
-    </div>
+    </main>
   );
 }
 

--- a/apps/web/src/app/archive/wish/_components/WishCardSkeleton.tsx
+++ b/apps/web/src/app/archive/wish/_components/WishCardSkeleton.tsx
@@ -2,11 +2,11 @@ import Skeleton from '@/components/skeleton';
 
 function WishCardSkeleton() {
   return (
-    <div className="flex flex-col overflow-hidden rounded-2xl bg-white">
-      <Skeleton className="h-[143px] w-full" />
+    <div className="flex flex-col overflow-hidden bg-white">
+      <Skeleton className="h-[143px] w-full rounded-none" />
       <div className="flex flex-col items-center gap-[9px] px-3 py-3">
-        <Skeleton className="h-4 w-3/4" />
-        <Skeleton className="h-5 w-1/2" />
+        <Skeleton className="h-4 w-3/4 rounded-none" />
+        <Skeleton className="h-5 w-1/2 rounded-none" />
       </div>
     </div>
   );

--- a/apps/web/src/app/archive/wish/_components/WishContentClient.tsx
+++ b/apps/web/src/app/archive/wish/_components/WishContentClient.tsx
@@ -64,7 +64,7 @@ function WishContentClient() {
   };
 
   return (
-    <div className="flex min-h-dvh flex-col bg-bg-layer-basement">
+    <main className="flex min-h-dvh flex-col bg-bg-layer-basement">
       <div className="sticky top-0 z-20 flex flex-col gap-7 bg-bg-layer-basement px-5 pt-padding-top pb-6">
         <h1 className="heading-1-bold text-text-neutral-primary">내 위시리스트</h1>
 
@@ -135,7 +135,7 @@ function WishContentClient() {
         isPending={isDeleteWishesPending}
         onConfirm={handleDeleteWishes}
       />
-    </div>
+    </main>
   );
 }
 

--- a/apps/web/src/app/home/_components/CreateTournamentDialog.tsx
+++ b/apps/web/src/app/home/_components/CreateTournamentDialog.tsx
@@ -25,7 +25,8 @@ function CreateTournamentDialog() {
   const trimmedName = name.trim();
   const isDisabled = trimmedName.length === 0 || isPostCreateTournamentPending;
 
-  const handleCreate = () => {
+  const handleCreate = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     if (isDisabled) return;
     postCreateTournamentMutation(
       { name: trimmedName, inviteDurationMinutes: DEFAULT_INVITE_DURATION_MINUTES },
@@ -57,7 +58,7 @@ function CreateTournamentDialog() {
         <DialogTitle className="text-center heading-1-bold text-text-neutral-primary">
           새 토너먼트
         </DialogTitle>
-        <div className="flex flex-col gap-[15px]">
+        <form onSubmit={handleCreate} className="flex flex-col gap-[15px]">
           <Input
             label="토너먼트 이름"
             placeholder="ex.이번주 신발 고르기"
@@ -67,10 +68,10 @@ function CreateTournamentDialog() {
             maxLength={30}
             right={isDisabled ? <EditIconFill className="size-5" /> : null}
           />
-          <Button size="lg" variant="primary" disabled={isDisabled} onClick={handleCreate}>
+          <Button type="submit" size="lg" variant="primary" disabled={isDisabled}>
             생성하기
           </Button>
-        </div>
+        </form>
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/app/home/_components/InviteTournamentDialog.tsx
+++ b/apps/web/src/app/home/_components/InviteTournamentDialog.tsx
@@ -80,7 +80,8 @@ function InviteTournamentDialog() {
     if (showFormatError) setShowFormatError(false);
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     if (!canSubmit) return;
 
     if (!isValidInviteCodeFormat(code)) {
@@ -112,25 +113,27 @@ function InviteTournamentDialog() {
           </DialogTitle>
           <DialogDescription className="sr-only">초대 코드를 입력해 입장합니다.</DialogDescription>
 
-          <Input
-            label="초대 코드"
-            placeholder="ex. ABC123"
-            value={code}
-            onChange={event => handleChange(event.target.value)}
-            aria-invalid={showFormatError}
-            {...(showFormatError
-              ? { helperText: '영문 대문자 3자 + 숫자 3자로 입력해주세요.' }
-              : {})}
-            maxLength={CODE_LENGTH}
-            autoCapitalize="characters"
-            autoCorrect="off"
-            spellCheck={false}
-            autoFocus
-          />
+          <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+            <Input
+              label="초대 코드"
+              placeholder="ex. ABC123"
+              value={code}
+              onChange={event => handleChange(event.target.value)}
+              aria-invalid={showFormatError}
+              {...(showFormatError
+                ? { helperText: '영문 대문자 3자 + 숫자 3자로 입력해주세요.' }
+                : {})}
+              maxLength={CODE_LENGTH}
+              autoCapitalize="characters"
+              autoCorrect="off"
+              spellCheck={false}
+              autoFocus
+            />
 
-          <Button size="lg" variant="primary" disabled={!canSubmit} onClick={handleSubmit}>
-            {isPreviewPending ? <Spinner size={20} /> : '입장하기'}
-          </Button>
+            <Button type="submit" size="lg" variant="primary" disabled={!canSubmit}>
+              {isPreviewPending ? <Spinner size={20} /> : '입장하기'}
+            </Button>
+          </form>
         </DialogContent>
       </Dialog>
 

--- a/apps/web/src/app/mypage/_components/ProfileSection.tsx
+++ b/apps/web/src/app/mypage/_components/ProfileSection.tsx
@@ -13,8 +13,6 @@ function ProfileSection() {
 
   return (
     <section className="flex w-full flex-col gap-3">
-      <h2 className="body-1-bold text-text-neutral-primary">프로필</h2>
-
       <Link
         href={ROUTES.MYPAGE_EDIT}
         className="flex items-center gap-4 rounded-xl bg-bg-layer-default p-5"

--- a/apps/web/src/app/mypage/edit/page.tsx
+++ b/apps/web/src/app/mypage/edit/page.tsx
@@ -19,7 +19,7 @@ function MypageEditPage() {
       <Header
         left={<HeaderIcon name="BACK" className="size-7.5" />}
         center="내 프로필 수정"
-        centerClassName="title-1 text-text-neutral-primary"
+        centerClassName="heading-1-bold text-text-neutral-primary"
       />
 
       <Spacing size={60} />

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -1,7 +1,6 @@
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 
 import { getMe } from '@/apis/getMe';
-import { Header, HeaderIcon } from '@/components/header';
 import Spacing from '@/components/spacing';
 import { getQueryClient } from '@/utils/queryClient';
 
@@ -18,8 +17,8 @@ function MypagePage() {
 
   return (
     <div className="flex h-dvh flex-col bg-bg-layer-basement px-5 pt-padding-top">
-      <Header left={<HeaderIcon name="BACK" />} center="설정" centerClassName="title-1" />
-      <Spacing size={48} />
+      <h1 className="heading-1-bold text-text-neutral-primary">내 정보</h1>
+      <Spacing size={24} />
 
       <main className="hide-scrollbar flex flex-1 flex-col overflow-y-auto pb-32">
         {/** 프로필 */}
@@ -35,7 +34,6 @@ function MypagePage() {
 
         <AppVersionFooter />
       </main>
-
     </div>
   );
 }

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -16,12 +16,11 @@ function MypagePage() {
   });
 
   return (
-    <div className="flex h-dvh flex-col bg-bg-layer-basement px-5 pt-padding-top">
+    <main className="flex h-dvh flex-col bg-bg-layer-basement px-5 pt-padding-top">
       <h1 className="heading-1-bold text-text-neutral-primary">내 정보</h1>
       <Spacing size={24} />
 
-      <main className="hide-scrollbar flex flex-1 flex-col overflow-y-auto pb-32">
-        {/** 프로필 */}
+      <div className="hide-scrollbar flex flex-1 flex-col overflow-y-auto pb-32">
         <HydrationBoundary state={dehydrate(queryClient)}>
           <ProfileSection />
         </HydrationBoundary>
@@ -33,8 +32,8 @@ function MypagePage() {
         <Spacing size={24} />
 
         <AppVersionFooter />
-      </main>
-    </div>
+      </div>
+    </main>
   );
 }
 

--- a/apps/web/src/app/mypage/withdraw/page.tsx
+++ b/apps/web/src/app/mypage/withdraw/page.tsx
@@ -14,7 +14,7 @@ function MypageWithdrawPage() {
       <Header
         left={<HeaderIcon name="BACK" />}
         center="회원탈퇴"
-        centerClassName="title-1 text-text-neutral-primary"
+        centerClassName="heading-1-bold text-text-neutral-primary"
       />
 
       <div className="hide-scrollbar flex w-full flex-1 flex-col items-center justify-center gap-12 overflow-y-auto pb-[98px]">

--- a/apps/web/src/app/notification/_components/NotificationContent.tsx
+++ b/apps/web/src/app/notification/_components/NotificationContent.tsx
@@ -51,7 +51,11 @@ function NotificationContent() {
 
   return (
     <div className="flex h-dvh flex-col bg-gray-50 px-5 pt-padding-top">
-      <Header left={<HeaderIcon name="BACK" />} center="알림 히스토리" centerClassName="title-1" />
+      <Header
+        left={<HeaderIcon name="BACK" />}
+        center="알림 히스토리"
+        centerClassName="heading-1-bold"
+      />
       <Spacing size={16} />
 
       <div className="hide-scrollbar flex-1 overflow-y-auto pt-5">{renderContent()}</div>

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-header/TournamentHeader.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-header/TournamentHeader.tsx
@@ -36,7 +36,7 @@ function TournamentHeader({ name, hasFriends }: TournamentHeaderProps) {
       <Header
         left={<HeaderIcon name="BACK" onClick={handleBackClick} />}
         center={<span className="block w-full truncate">{name}</span>}
-        centerClassName="title-1 w-[calc(100%-40px-30px-30px)] text-center"
+        centerClassName="heading-1-bold w-[calc(100%-40px-30px-30px)] text-center"
         right={<TournamentGuidePopover />}
       />
 

--- a/apps/web/src/components/common/create-tournament-dialog/index.tsx
+++ b/apps/web/src/components/common/create-tournament-dialog/index.tsx
@@ -18,7 +18,8 @@ function CreateTournamentDialogContent() {
   const trimmedName = name.trim();
   const isDisabled = trimmedName.length === 0 || isPostCreateTournamentPending;
 
-  const handleCreate = () => {
+  const handleCreate = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     if (isDisabled) return;
     postCreateTournamentMutation({
       name: trimmedName,
@@ -32,7 +33,7 @@ function CreateTournamentDialogContent() {
       <DialogTitle className="text-center heading-1-bold text-text-neutral-primary">
         새 토너먼트
       </DialogTitle>
-      <div className="flex flex-col gap-[15px]">
+      <form onSubmit={handleCreate} className="flex flex-col gap-[15px]">
         <Input
           label="토너먼트 이름"
           placeholder="ex.이번주 신발 고르기"
@@ -42,10 +43,10 @@ function CreateTournamentDialogContent() {
           maxLength={30}
           right={isDisabled ? <EditIconFill className="size-5" /> : null}
         />
-        <Button size="lg" variant="primary" disabled={isDisabled} onClick={handleCreate}>
+        <Button type="submit" size="lg" variant="primary" disabled={isDisabled}>
           생성하기
         </Button>
-      </div>
+      </form>
     </DialogContent>
   );
 }

--- a/apps/web/src/components/common/wish-card/index.tsx
+++ b/apps/web/src/components/common/wish-card/index.tsx
@@ -22,7 +22,7 @@ function WishCard({ name, price, imageUrl, sourcePlatform, preload = false }: Wi
             alt={name}
             sizes="(max-width: 480px) calc(100vw - 40px - 8px), 216px"
             preload={preload}
-            loadingFallback={<Skeleton className="absolute inset-0 rounded-t-2xl rounded-b-none" />}
+            loadingFallback={<Skeleton className="absolute inset-0 rounded-none" />}
             errorFallback={
               <div className="absolute inset-0 flex items-center justify-center text-gray-200">
                 <ImageIconOutline width={40} height={40} />

--- a/apps/web/src/components/get-item-dialog/ByLinkDialog.tsx
+++ b/apps/web/src/components/get-item-dialog/ByLinkDialog.tsx
@@ -36,7 +36,8 @@ function ByLinkDialog({ type, open, onOpenChange }: ByLinkProps) {
     setHasError(false);
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     if (isEmpty) return;
 
     // 상품 설명과 URL 이 함께 붙여넣어진 경우 URL 만 추출해 제출한다 (onPaste 를 타지 않은 경로 안전망).
@@ -90,7 +91,7 @@ function ByLinkDialog({ type, open, onOpenChange }: ByLinkProps) {
           링크로 담기
         </DialogTitle>
         <DialogDescription className="sr-only">상품 URL을 입력해 담습니다.</DialogDescription>
-        <div className="flex flex-col gap-4">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <Input
             label="링크 URL"
             placeholder="복사한 링크를 입력해주세요."
@@ -103,16 +104,16 @@ function ByLinkDialog({ type, open, onOpenChange }: ByLinkProps) {
             autoFocus
           />
           <Button
+            type="submit"
             size="lg"
             variant="primary"
             disabled={isEmpty}
             isLoading={isPending}
-            onClick={handleSubmit}
           >
             {type === 'wish' && '위시리스트에 담기'}
             {type === 'tournament' && '후보 바구니에 담기'}
           </Button>
-        </div>
+        </form>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## 작업 요약
- Header 중앙 타이틀을 heading-1-bold(20px)로 통일
- 마이페이지 헤더를 좌측 정렬 형태로 수정
- 위시 카드 스켈레톤의 모서리를 실제 카드와 일치하도록 수정
- 입력이 하나뿐인 다이얼로그는 엔터만 쳐도 제출되도록 개선
## 작업 내용

UI 일관성이 어긋나 있던 부분들을 시안 기준으로 정리하고, 입력 다이얼로그의 사용성을 개선했습니다.

### 1. 헤더 타이틀 크기 통일 (24px → 20px)

`Header`의 중앙 타이틀이 화면마다 `title-1`(24px)과 `heading-1-bold`(20px)로 갈려 있어 `heading-1-bold`로 통일했습니다.

| 화면 | 타이틀 |
| --- | --- |
| 알림 히스토리 | 알림 히스토리 |
| 담기 화면 | 토너먼트 이름 |
| 프로필 수정 | 프로필 수정 |
| 탈퇴하기 | 탈퇴하기 |
| 이용약관 / 개인정보 처리방침 | 각 문서명 |

`TournamentHeader`는 폭·정렬 클래스(`w-[calc(...)] text-center`)를 그대로 두고 폰트 클래스만 교체했습니다.
매치 화면 질문 문구와 온보딩 문구는 헤더가 아닌 본문 제목이라 `title-1`을 유지했습니다.

### 2. 마이페이지 헤더를 위시리스트와 동일한 형태로

중앙 정렬 헤더 + 뒤로가기 버튼 구조를, 위시리스트(`내 위시리스트`)와 같은 좌측 정렬 `h1`으로 변경했습니다.

- 하단 탭으로 진입하는 화면이라 뒤로가기 버튼 제거
- 타이틀을 `설정` → `내 정보`로 변경 — 알림·앱 설정 같은 토글 항목 없이 프로필·계정 관리 위주라 실제 내용과 더 맞음
- 본문의 중복된 `프로필` 소제목 제거

### 3. 위시 상품 카드 스켈레톤 라운드 제거

실제 `WishCard`에는 라운드가 없는데 스켈레톤에만 남아 있어, 로딩 → 렌더 전환 시 모서리 모양이 튀었습니다.

- 위시리스트 무한스크롤 로딩 스켈레톤 (`WishCardSkeleton`)
- 카드 내부 이미지 로딩 스켈레톤 (`WishCard`) — 위시리스트·위시에서 가져오기 양쪽에 적용


### 4. 단일 입력 다이얼로그에서 엔터로 제출

입력 후 버튼을 눌러야만 진행되던 곳들을 엔터로도 제출되게 했습니다.

| 다이얼로그 | 입력 | 제출 |
| --- | --- | --- |
| 링크로 담기 | 링크 URL | 위시리스트에 담기 / 후보 바구니에 담기 |
| 새 토너먼트 (홈) | 토너먼트 이름 | 생성하기 |
| 새 토너먼트 (아카이브 FAB) | 토너먼트 이름 | 생성하기 |
| 초대받은 토너먼트 | 초대 코드 | 입장하기 |


**상품 파싱 실패 시 입력 폼(상품명 + 가격)은 의도적으로 제외**했습니다. 저장 조건에 이미지 선택이 포함돼 키보드만으로 완결되지 않고, 다중 필드에서는 엔터를 "다음 칸 이동"으로 기대하는 경우가 많으며, 바로 옆에 삭제 버튼이 있어서입니다. **단일 입력은 엔터 제출 / 다중 필드는 클릭**으로 기준을 잡았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 개인정보 처리방침, 이용약관, 마이페이지, 알림 및 토너먼트 화면의 제목 스타일을 일관되게 개선했습니다.
  * 마이페이지 화면 구성을 간소화하고 제목과 콘텐츠 간격을 조정했습니다.
  * 프로필 섹션의 중복 제목을 제거했습니다.
  * 위시 카드의 로딩 영역 모서리를 직각으로 통일했습니다.

* **버그 수정**
  * 토너먼트 생성, 초대 코드 입력, 링크를 통한 아이템 추가가 폼 제출 방식으로 안정적으로 동작하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->