### PR TITLE
feat: 결과 하단 CTA 라벨·아이콘을 시안 기준으로 변경 (영수증 공유·트로피)

### DIFF
--- a/apps/web/e2e/specs/tournament/tournamentResult.spec.ts
+++ b/apps/web/e2e/specs/tournament/tournamentResult.spec.ts
@@ -14,7 +14,7 @@ import {
  * 영수증 이미지 실제 저장(html-to-image + Web Share)과 공유 동작은 headless 환경이
  * 실제 유저 환경(모바일 공유 시트)을 대변하지 못해 버튼 노출까지만 검증한다.
  */
-test('결과 페이지에 영수증과 순위, 저장·공유 버튼이 렌더링된다', async ({ page, api }) => {
+test('결과 페이지에 영수증과 순위, 공유 버튼이 렌더링된다', async ({ page, api }) => {
   api.get(ENDPOINTS.USER, MOCK_MEMBER_ME);
   api.get(ENDPOINTS.TOURNAMENT(3), MOCK_TOURNAMENT_COMPLETED);
 
@@ -30,7 +30,7 @@ test('결과 페이지에 영수증과 순위, 저장·공유 버튼이 렌더�
     await expect(page.getByText(rankedItem.name).last()).toBeVisible();
   }
 
-  await expect(page.getByRole('button', { name: '영수증 저장' })).toBeVisible();
+  await expect(page.getByRole('button', { name: '영수증 공유' })).toBeVisible();
   /** isRoot && isOwner — 플레이 링크 공유 버튼 노출 */
   await expect(page.getByRole('button', { name: '토너먼트 공유' })).toBeVisible();
 });

--- a/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
-import { ChevronForwardIconFill, DownloadIconFill, UploadIconFill } from '@/assets/icons';
+import { ChevronForwardIconFill, ReciptIconFill, TrophyIconFill } from '@/assets/icons';
 import BottomCta from '@/components/bottom-cta';
 import Button from '@/components/button';
 import { Header } from '@/components/header';
@@ -136,25 +136,25 @@ function ResultClient({ tournamentId }: ResultClientProps) {
 
       {/* 하단 CTA — 저장/공유 버튼 → 홈으로 가기 순 위계, 항상 화면 하단 고정 */}
       <BottomCta hasGradient className="flex-col items-stretch gap-6.5 pb-[30px]">
-        {/* 영수증 저장 (모든 사용자) + 토너먼트 공유 (ROOT 소유자만, 플레이 링크 공유) */}
+        {/* 영수증 공유 (모든 사용자) + 토너먼트 공유 (ROOT 소유자만, 플레이 링크 공유) */}
         <div className="flex gap-3">
           <Button
             variant="secondary"
             size="lg"
             icon="leading"
-            leadingIcon={<DownloadIconFill aria-hidden className="size-5" />}
+            leadingIcon={<ReciptIconFill aria-hidden className="size-5" />}
             onClick={handleShareReceiptImage}
             disabled={isCapturing}
             className="flex-1 border-gray-75 bg-gray-75 text-text-neutral-secondary"
           >
-            {isCapturing ? '이미지 만드는 중...' : '영수증 저장'}
+            {isCapturing ? '이미지 만드는 중...' : '영수증 공유'}
           </Button>
           {canSharePlayLink && (
             <Button
               variant="primary"
               size="lg"
               icon="leading"
-              leadingIcon={<UploadIconFill aria-hidden className="size-5" />}
+              leadingIcon={<TrophyIconFill aria-hidden className="size-5" />}
               onClick={handleSharePlayLink}
               className="flex-1"
             >

--- a/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
-import { ChevronForwardIconFill, ReciptIconFill, TrophyIconFill } from '@/assets/icons';
+import { ChevronForwardIconFill, ReciptIconOutline, TrophyIconOutline } from '@/assets/icons';
 import BottomCta from '@/components/bottom-cta';
 import Button from '@/components/button';
 import { Header } from '@/components/header';
@@ -142,7 +142,7 @@ function ResultClient({ tournamentId }: ResultClientProps) {
             variant="secondary"
             size="lg"
             icon="leading"
-            leadingIcon={<ReciptIconFill aria-hidden className="size-5" />}
+            leadingIcon={<ReciptIconOutline aria-hidden className="size-5" />}
             onClick={handleShareReceiptImage}
             disabled={isCapturing}
             className="flex-1 border-gray-75 bg-gray-75 text-text-neutral-secondary"
@@ -154,7 +154,7 @@ function ResultClient({ tournamentId }: ResultClientProps) {
               variant="primary"
               size="lg"
               icon="leading"
-              leadingIcon={<TrophyIconFill aria-hidden className="size-5" />}
+              leadingIcon={<TrophyIconOutline aria-hidden className="size-5" />}
               onClick={handleSharePlayLink}
               className="flex-1"
             >


### PR DESCRIPTION
## 작업 요약

- 토너먼트 결과 하단 CTA 를 시안 기준으로 변경합니다 (영수증 공유 라벨·아이콘)

## 작업 세부 내용

- 결과 화면 하단 CTA 의 라벨과 아이콘을 변경했습니다.

| 버튼 | 변경 전 | 변경 후 |
| --- | --- | --- |
| 왼쪽 | "영수증 저장" + 다운로드 아이콘 | **"영수증 공유"** + 영수증 아이콘 (ReciptIconFill) |
| 오른쪽 | "토너먼트 공유" + 업로드 아이콘 | 라벨 동일 + **트로피 아이콘** (TrophyIconFill) |

- **동작은 기존 그대로 유지합니다.** 왼쪽 버튼을 누르면 기존처럼 영수증을 캡처해 네이티브 공유 시트(미지원 환경은 다운로드)를 띄웁니다.
- 시안의 영수증 공유 바텀시트(이미지 저장 · 이미지 복사 · 채팅방에 공유 · 스토리 공유)는 #416 에서 구현하며, 이 CTA 가 해당 바텀시트를 여는 트리거로 연결됩니다.
- 라벨 변경에 맞춰 e2e 스펙의 버튼 단언도 함께 수정했습니다 (영수증 저장 → 영수증 공유).

## 연관 이슈

closes #400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 결과 화면의 영수증 CTA가 ‘영수증 저장’에서 ‘영수증 공유’로 변경되었습니다.
  * 토너먼트 관련 아이콘이 트로피 아이콘으로 업데이트되어 의미를 더 명확하게 전달합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->