### PR TITLE
feat: 링크로 담기 실패 사유를 토스트 대신 helper text로 안내

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/_hooks/usePostTournamentItemLink.ts
+++ b/apps/web/src/app/tournament/[id]/create/_hooks/usePostTournamentItemLink.ts
@@ -6,7 +6,15 @@ import type { ApiErrorResponseT } from '@/types/api';
 
 import { postTournamentItemLink } from '../_apis/postTournamentItemLink';
 
-export const usePostTournamentItemLink = (tournamentId: number) => {
+type UsePostTournamentItemLinkOptionsT = {
+  /** 입력 폼처럼 에러를 화면 안에서 안내하는 경우 false — 4xx 토스트를 끈다 */
+  showErrorToast?: boolean;
+};
+
+export const usePostTournamentItemLink = (
+  tournamentId: number,
+  { showErrorToast = true }: UsePostTournamentItemLinkOptionsT = {}
+) => {
   const queryClient = useQueryClient();
 
   const { mutate: postTournamentItemLinkMutation, isPending: isPostTournamentItemLinkPending } =
@@ -25,7 +33,7 @@ export const usePostTournamentItemLink = (tournamentId: number) => {
 
         if (status < 500) {
           const clientErrorMessage = detail ?? '요청을 처리하지 못했습니다.';
-          toast.error(clientErrorMessage);
+          if (showErrorToast) toast.error(clientErrorMessage);
           return;
         }
 

--- a/apps/web/src/components/get-item-dialog/ByLinkDialog.tsx
+++ b/apps/web/src/components/get-item-dialog/ByLinkDialog.tsx
@@ -11,6 +11,7 @@ import Input from '@/components/input';
 import { usePostWishLink } from '@/hooks/usePostWishLink';
 import type { ItemTypeT } from '@/types/item';
 import { URL_PATTERN, extractUrlFromText } from '@/utils/extractUrl';
+import { getApiErrorMessage } from '@/utils/getApiErrorMessage';
 
 type ByLinkProps = {
   type: ItemTypeT;
@@ -20,12 +21,15 @@ type ByLinkProps = {
 
 function ByLinkDialog({ type, open, onOpenChange }: ByLinkProps) {
   const { id: tournamentId } = useParams<{ id: string }>();
-  const { postWishLinkMutation, isPostWishLinkPending } = usePostWishLink();
+
+  const { postWishLinkMutation, isPostWishLinkPending } = usePostWishLink({
+    showErrorToast: false,
+  });
   const { postTournamentItemLinkMutation, isPostTournamentItemLinkPending } =
-    usePostTournamentItemLink(Number(tournamentId));
+    usePostTournamentItemLink(Number(tournamentId), { showErrorToast: false });
 
   const [url, setUrl] = useState('');
-  const [hasError, setHasError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const trimmedUrl = url.trim();
   const isEmpty = trimmedUrl.length === 0;
@@ -33,7 +37,7 @@ function ByLinkDialog({ type, open, onOpenChange }: ByLinkProps) {
 
   const resetState = () => {
     setUrl('');
-    setHasError(false);
+    setErrorMessage(null);
   };
 
   const handleSubmit = () => {
@@ -43,30 +47,31 @@ function ByLinkDialog({ type, open, onOpenChange }: ByLinkProps) {
     const submitUrl = URL_PATTERN.test(trimmedUrl) ? trimmedUrl : extractUrlFromText(trimmedUrl);
 
     if (!submitUrl) {
-      setHasError(true);
+      setErrorMessage('올바른 URL 형식으로 입력해주세요.');
+      return;
+    }
+
+    if (!submitUrl.startsWith('https://')) {
+      setErrorMessage('https 링크만 등록할 수 있어요');
       return;
     }
 
     /** 닫기/초기화는 성공 시에만 — 실패 시 URL을 고칠 수 있게 유지. 위시리스트 이동은 usePostWishLink 훅이 조건부로 처리 */
-    if (type === 'wish')
-      postWishLinkMutation(submitUrl, {
-        onSuccess: () => {
-          onOpenChange(false);
-          resetState();
-        },
-      });
-    else
-      postTournamentItemLinkMutation(submitUrl, {
-        onSuccess: () => {
-          onOpenChange(false);
-          resetState();
-        },
-      });
+    const mutationOptions = {
+      onSuccess: () => {
+        onOpenChange(false);
+        resetState();
+      },
+      onError: (error: Error) => setErrorMessage(getApiErrorMessage(error)),
+    };
+
+    if (type === 'wish') postWishLinkMutation(submitUrl, mutationOptions);
+    else postTournamentItemLinkMutation(submitUrl, mutationOptions);
   };
 
   const handleChange = (value: string) => {
     setUrl(value);
-    if (hasError) setHasError(false);
+    if (errorMessage) setErrorMessage(null);
   };
 
   /** 상품 설명 + URL 형태로 붙여넣으면 URL 만 입력창에 반영한다 */
@@ -98,8 +103,8 @@ function ByLinkDialog({ type, open, onOpenChange }: ByLinkProps) {
             onChange={event => handleChange(event.target.value)}
             onPaste={handlePaste}
             left={<LinkIconFill className="size-5" />}
-            aria-invalid={hasError}
-            {...(hasError ? { helperText: '올바른 URL 형식으로 입력해주세요.' } : {})}
+            aria-invalid={Boolean(errorMessage)}
+            {...(errorMessage ? { helperText: errorMessage } : {})}
             autoFocus
           />
           <Button

--- a/apps/web/src/hooks/usePostWishLink.ts
+++ b/apps/web/src/hooks/usePostWishLink.ts
@@ -9,7 +9,12 @@ import { ROUTES } from '@/consts/route';
 import type { ApiErrorResponseT } from '@/types/api';
 import { logAnalyticsEvent } from '@/utils/analytics';
 
-export const usePostWishLink = () => {
+type UsePostWishLinkOptionsT = {
+  /** 입력 폼처럼 에러를 화면 안에서 안내하는 경우 false — 4xx 토스트를 끈다 */
+  showErrorToast?: boolean;
+};
+
+export const usePostWishLink = ({ showErrorToast = true }: UsePostWishLinkOptionsT = {}) => {
   const router = useRouter();
   const pathname = usePathname();
   const queryClient = useQueryClient();
@@ -35,7 +40,7 @@ export const usePostWishLink = () => {
 
       if (status < 500) {
         const clientErrorMessage = detail ?? '요청을 처리하지 못했습니다.';
-        toast.error(clientErrorMessage);
+        if (showErrorToast) toast.error(clientErrorMessage);
         return;
       }
 


### PR DESCRIPTION
## 작업 요약
링크로 담기 모달에서 실패 시 모달 위에 토스트가 겹쳐 뜨던 것을, 입력창 아래 helper text로 수정

## 작업 세부 내용

링크로 담기 모달은 **실패 시 모달을 닫지 않습니다.** 사용자가 링크를 바로 고칠 수 있게 하려는 의도입니다 (`닫기/초기화는 성공 시에만 — 실패 시 URL을 고칠 수 있게 유지`).

그런데 실패 사유는 토스트로 띄우고 있어서, 모달 위에 토스트가 겹쳐 뜨고 정작 고쳐야 할 입력창과 안내가 멀리 떨어져 있었습니다. 모달을 열어둘 거면 안내도 모달 안에 있어야 한다고 판단해 helper text로 옮겼습니다.


### 1. 훅에 에러 토스트 비활성 옵션 추가

`usePostWishLink` / `usePostTournamentItemLink`가 4xx를 무조건 토스트로 띄우고 있어, 화면 안 안내와 중복됐습니다.

`showErrorToast` 옵션(기본 `true`)을 추가해 호출부가 끌 수 있게 했습니다. 기본값을 유지한 이유는 **입력창이 없는 경로 때문**입니다. 앱 공유 인텐트(`useShareIntentWish`)는 helper text를 띄울 자리가 없어 토스트가 유일한 안내 수단입니다.

5xx는 기존과 동일하게 전역 `MutationCache.onError`가 토스트 + Sentry로 처리합니다.

### 2. 실패 사유를 helper text로 노출

`hasError` 불리언을 `errorMessage: string | null`로 바꿔, **클라 검증 문구와 서버 응답 문구를 같은 자리에** 표시합니다. 입력을 수정하면 사라집니다.

| 문구 | 출처 | 시점 |
| --- | --- | --- |
| 올바른 URL 형식으로 입력해주세요. | 클라이언트 | 요청 전 |
| https 링크만 등록할 수 있어요 | 클라이언트 | 요청 전 |
| 이미 위시리스트에 등록된 상품이에요 등 | 서버 `detail` | 응답 후 |

서버 문구 변환은 기존 `getApiErrorMessage` 유틸을 재사용했습니다.

### 3. http 링크를 요청 전에 차단

서버가 https만 받는데 클라는 `http`를 통과시켜 서버 왕복 후에야 실패했습니다. 요청 전에 거르도록 했습니다.

| 입력 | 결과 |
| --- | --- |
| `https://` · `https:/` · `df` | 올바른 URL 형식으로 입력해주세요. |
| `http://a.com` · `신발 http://a.com` | https 링크만 등록할 수 있어요 |
| `https://s.zigzag.kr/AbC` | 전송 |

`URL_PATTERN`·`extractUrlFromText` 유틸 자체는 건드리지 않았습니다. 앱 공유 인텐트가 함께 쓰는 유틸이라 https 전용으로 바꾸면 `http` 링크의 공유 담기가 조용히 실패합니다. **다이얼로그 안에서만** 거르도록 범위를 좁혔습니다.

형식 오류(`submitUrl === null`)와 스킴 오류를 분리했습니다. 하나로 묶으면 `https://`만 입력한 사용자에게도 "https 링크만"이라는 맞지 않는 안내가 뜹니다.


## 스크린샷
| Before | After |
| :---: | :---: |
| <img width="464" height="638" alt="before" src="https://github.com/user-attachments/assets/258e5011-5cab-4955-9b8b-7cad43b96b55" /> | <img width="474" height="631" alt="after" src="https://github.com/user-attachments/assets/d07171db-b200-48f4-b725-64ca1d3e884c" /> |
## 연관 이슈

closes #402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 링크 등록 실패 시 API 오류 메시지를 다이얼로그에 표시합니다.
  * URL 형식 오류와 HTTPS가 아닌 URL을 구분해 안내합니다.
  * 오류 발생 시 입력한 링크를 유지해 수정할 수 있습니다.
  * 입력값을 변경하면 기존 오류 메시지가 자동으로 사라집니다.
  * 링크 등록이 성공한 경우에만 다이얼로그가 닫히고 입력 상태가 초기화됩니다.
  * 상황에 따라 오류 토스트 표시 여부를 선택할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->