### PR TITLE
feat: 아이템 수정 상태 제약 해제 및 위시리스트 응답 구조 서버 기준으로 정리

### DIFF
--- a/apps/web/e2e/helpers/apiResponse.ts
+++ b/apps/web/e2e/helpers/apiResponse.ts
@@ -6,6 +6,10 @@ export const createApiSuccess = <T>(data: T, status = 200): ApiResponseT<T> => (
   data,
   detail: '요청이 정상적으로 처리되었습니다.',
   code: 'COMMON_SUCCESS',
+  pageResponse: {
+    nextCursor: null,
+    hasNext: false,
+  },
 });
 
 type CreateApiErrorOptionsT = {

--- a/apps/web/e2e/mocks/wish.ts
+++ b/apps/web/e2e/mocks/wish.ts
@@ -1,20 +1,13 @@
-import type { ItemT } from '@/types/item';
-import type { WishT } from '@/types/wish';
+import type { GetWishlistResponseT } from '@/types/wish';
 
 import { MOCK_IMAGE_URLS } from './images';
 import { MOCK_TOURNAMENT_ITEMS } from './tournament';
-
-/** getWishlist 원 응답의 data 항목 형태 (apis/getWishlist.ts 의 WishlistEntryT 와 동일) */
-type WishlistEntryT = {
-  wish: WishT;
-  item: ItemT;
-};
 
 /**
  * by-wish 담기 spec 용 위시 4개.
  * item.id 를 토너먼트 목의 itemId 와 맞춰, 담기 후 pending.items 와 자연스럽게 이어지게 한다.
  */
-export const MOCK_WISHLIST_ENTRIES: WishlistEntryT[] = MOCK_TOURNAMENT_ITEMS.map(
+export const MOCK_WISHLIST_ENTRIES: GetWishlistResponseT[] = MOCK_TOURNAMENT_ITEMS.map(
   (tournamentItem, index) => ({
     wish: { id: index + 1, createdAt: '2026-01-01T00:00:00Z' },
     item: {
@@ -27,5 +20,7 @@ export const MOCK_WISHLIST_ENTRIES: WishlistEntryT[] = MOCK_TOURNAMENT_ITEMS.map
       sourceUrl: null,
       sourcePlatform: null,
     },
+    reused: null,
+    refreshNeeded: null,
   })
 );

--- a/apps/web/e2e/mocks/wish.ts
+++ b/apps/web/e2e/mocks/wish.ts
@@ -14,7 +14,7 @@ export const MOCK_WISHLIST_ENTRIES: GetWishlistResponseT[] = MOCK_TOURNAMENT_ITE
       id: tournamentItem.itemId,
       status: 'READY',
       name: tournamentItem.name,
-      currentPrice: tournamentItem.price,
+      price: tournamentItem.price,
       currency: 'KRW',
       imageUrl: MOCK_IMAGE_URLS.product,
       sourceUrl: null,

--- a/apps/web/src/apis/getWishlist.ts
+++ b/apps/web/src/apis/getWishlist.ts
@@ -4,54 +4,23 @@ import { clientApi } from '@/apis/client';
 import { serverApi } from '@/apis/server';
 import { ENDPOINTS } from '@/consts/api';
 import type { ApiResponseT } from '@/types/api';
-import type { ItemT } from '@/types/item';
-import type { WishItemT, WishT } from '@/types/wish';
+import type { GetWishlistResponseT } from '@/types/wish';
 
-type WishlistEntryT = {
-  wish: WishT;
-  item: ItemT;
-};
-
-type WishlistApiResponseT = ApiResponseT<WishlistEntryT[]> & {
-  pageResponse: {
-    nextCursor: string | null;
-    hasNext: boolean;
-  };
-};
-
-export type WishlistPageT = {
-  items: WishItemT[];
-  nextCursor: string | null;
-  hasNext: boolean;
-};
-
-const mapWishlist = (entries: WishlistEntryT[]): WishItemT[] =>
-  entries.map(({ wish, item }) => ({
-    id: wish.id,
-    itemId: item.id,
-    status: item.status,
-    name: item.name ?? '',
-    price: item.currentPrice ?? 0,
-    imageUrl: item.imageUrl ?? null,
-    sourcePlatform: item.sourcePlatform ?? null,
-  }));
-
-export const getWishlist = async (cursor: string | null = null): Promise<WishlistPageT> => {
+export const getWishlist = async (cursor: string | null = null) => {
   const params = { size: 20, ...(cursor ? { cursor } : {}) };
 
   if (environmentManager.isServer()) {
-    const { data } = await serverApi.get<WishlistApiResponseT>(ENDPOINTS.WISHLISTS, { params });
-    return {
-      items: mapWishlist(data.data),
-      nextCursor: data.pageResponse.nextCursor,
-      hasNext: data.pageResponse.hasNext,
-    };
+    const { data } = await serverApi.get<ApiResponseT<GetWishlistResponseT[]>>(
+      ENDPOINTS.WISHLISTS,
+      {
+        params,
+      }
+    );
+    return data;
   }
 
-  const { data } = await clientApi.get<WishlistApiResponseT>(ENDPOINTS.WISHLISTS, { params });
-  return {
-    items: mapWishlist(data.data),
-    nextCursor: data.pageResponse.nextCursor,
-    hasNext: data.pageResponse.hasNext,
-  };
+  const { data } = await clientApi.get<ApiResponseT<GetWishlistResponseT[]>>(ENDPOINTS.WISHLISTS, {
+    params,
+  });
+  return data;
 };

--- a/apps/web/src/app/archive/wish/[id]/_components/EditContent.tsx
+++ b/apps/web/src/app/archive/wish/[id]/_components/EditContent.tsx
@@ -26,7 +26,7 @@ function EditContent({ wishId }: EditContentProps) {
           itemStatus={wishData.item.status}
           initialImageUrl={wishData.item.imageUrl ?? ''}
           initialName={wishData.item.name ?? ''}
-          initialPrice={wishData.item.currentPrice ?? 0}
+          initialPrice={wishData.item.price ?? 0}
         />
 
         {wishData.item.sourceUrl && <ItemLinkBanner href={wishData.item.sourceUrl} />}

--- a/apps/web/src/app/archive/wish/[id]/_components/EditContent.tsx
+++ b/apps/web/src/app/archive/wish/[id]/_components/EditContent.tsx
@@ -24,7 +24,7 @@ function EditContent({ wishId }: EditContentProps) {
         <ItemEditForm
           wishId={wishId}
           itemStatus={wishData.item.status}
-          initialImageUrl={wishData.item.imageUrl ?? ''}
+          initialImageUrl={wishData.item.imageUrl}
           initialName={wishData.item.name ?? ''}
           initialPrice={wishData.item.price ?? 0}
         />

--- a/apps/web/src/app/archive/wish/[id]/_components/EditContent.tsx
+++ b/apps/web/src/app/archive/wish/[id]/_components/EditContent.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Header, HeaderIcon } from '@/components/header';
 import ItemLinkBanner from '@/components/common/item-link-banner';
+import { Header, HeaderIcon } from '@/components/header';
 
 import { useGetWish } from '../_hooks/useGetWish';
 import ItemEditForm from './ItemEditForm';
@@ -24,9 +24,9 @@ function EditContent({ wishId }: EditContentProps) {
         <ItemEditForm
           wishId={wishId}
           itemStatus={wishData.item.status}
-          initialImageUrl={wishData.item.status === 'READY' ? wishData.item.imageUrl : null}
-          initialName={wishData.item.status === 'READY' ? wishData.item.name : ''}
-          initialPrice={wishData.item.status === 'READY' ? wishData.item.currentPrice : 0}
+          initialImageUrl={wishData.item.imageUrl ?? ''}
+          initialName={wishData.item.name ?? ''}
+          initialPrice={wishData.item.currentPrice ?? 0}
         />
 
         {wishData.item.sourceUrl && <ItemLinkBanner href={wishData.item.sourceUrl} />}

--- a/apps/web/src/app/archive/wish/[id]/_components/ItemEditForm.tsx
+++ b/apps/web/src/app/archive/wish/[id]/_components/ItemEditForm.tsx
@@ -10,7 +10,7 @@ import { usePostWishRefresh } from '../_hooks/usePostWishRefresh';
 type ItemEditFormProps = {
   wishId: number;
   itemStatus: ItemStatusT;
-  initialImageUrl: string;
+  initialImageUrl: string | null;
   initialName: string;
   initialPrice: number;
 };

--- a/apps/web/src/app/archive/wish/[id]/_components/ItemEditForm.tsx
+++ b/apps/web/src/app/archive/wish/[id]/_components/ItemEditForm.tsx
@@ -10,7 +10,7 @@ import { usePostWishRefresh } from '../_hooks/usePostWishRefresh';
 type ItemEditFormProps = {
   wishId: number;
   itemStatus: ItemStatusT;
-  initialImageUrl: string | null;
+  initialImageUrl: string;
   initialName: string;
   initialPrice: number;
 };

--- a/apps/web/src/app/archive/wish/[id]/_hooks/usePatchWish.ts
+++ b/apps/web/src/app/archive/wish/[id]/_hooks/usePatchWish.ts
@@ -17,9 +17,9 @@ export const usePatchWish = (wishId: number) => {
     mutationFn: (body: Omit<PatchItemRequestT, 'currency'>) => {
       const formData = new FormData();
       formData.append('name', body.name);
-      formData.append('currentPrice', String(body.currentPrice));
       formData.append('currency', 'KRW');
       formData.append('image', body.image);
+      formData.append('price', String(body.price));
       return patchWish(wishId, formData);
     },
     onSuccess: () => {

--- a/apps/web/src/app/archive/wish/[id]/_hooks/usePatchWish.ts
+++ b/apps/web/src/app/archive/wish/[id]/_hooks/usePatchWish.ts
@@ -14,12 +14,11 @@ export const usePatchWish = (wishId: number) => {
   const queryClient = useQueryClient();
 
   const { mutate: patchWishMutation, isPending: isPatchWishPending } = useMutation({
-    mutationFn: (body: Omit<PatchItemRequestT, 'currency'>) => {
+    mutationFn: (body: PatchItemRequestT) => {
       const formData = new FormData();
       formData.append('name', body.name);
-      formData.append('currency', 'KRW');
-      formData.append('image', body.image);
       formData.append('price', String(body.price));
+      if (body.image) formData.append('image', body.image);
       return patchWish(wishId, formData);
     },
     onSuccess: () => {

--- a/apps/web/src/app/archive/wish/[id]/_hooks/usePatchWish.ts
+++ b/apps/web/src/app/archive/wish/[id]/_hooks/usePatchWish.ts
@@ -16,8 +16,8 @@ export const usePatchWish = (wishId: number) => {
   const { mutate: patchWishMutation, isPending: isPatchWishPending } = useMutation({
     mutationFn: (body: PatchItemRequestT) => {
       const formData = new FormData();
-      formData.append('name', body.name);
-      formData.append('price', String(body.price));
+      if (body.name) formData.append('name', body.name);
+      if (body.price) formData.append('price', String(body.price));
       if (body.image) formData.append('image', body.image);
       return patchWish(wishId, formData);
     },

--- a/apps/web/src/app/archive/wish/[id]/_types/wish.ts
+++ b/apps/web/src/app/archive/wish/[id]/_types/wish.ts
@@ -8,7 +8,7 @@ export type GetWishResponseT = {
         status: (typeof ITEM_STATUS)['PROCESSING'] | (typeof ITEM_STATUS)['FAILED'];
         name: null;
         imageUrl: null;
-        currentPrice: null;
+        price: null;
         currency: null;
         sourceUrl: string | null; // 확인필
       }
@@ -16,7 +16,7 @@ export type GetWishResponseT = {
         status: (typeof ITEM_STATUS)['READY'] | (typeof ITEM_STATUS)['PENDING'];
         name: string;
         imageUrl: string;
-        currentPrice: number;
+        price: number;
         currency: string;
         sourceUrl: string | null;
       }

--- a/apps/web/src/app/archive/wish/[id]/_types/wish.ts
+++ b/apps/web/src/app/archive/wish/[id]/_types/wish.ts
@@ -21,6 +21,18 @@ export type GetWishResponseT = {
         sourceUrl: string | null;
       }
   );
+  /**
+   * 갱신 필요 여부
+   * - 이미지로 등록한 경우: null
+   * - 링크로 등록한 경우: boolean
+   */
+  refreshNeeded: boolean | null;
+  /**
+   * 재사용 여부
+   * - 이미지로 등록한 경우: null
+   * - 링크로 등록한 경우: boolean
+   */
+  reused: boolean | null;
 };
 
 export type PatchWishResponseT = GetWishResponseT;

--- a/apps/web/src/app/archive/wish/_components/WishCardSkeleton.tsx
+++ b/apps/web/src/app/archive/wish/_components/WishCardSkeleton.tsx
@@ -2,11 +2,14 @@ import Skeleton from '@/components/skeleton';
 
 function WishCardSkeleton() {
   return (
-    <div className="flex flex-col overflow-hidden bg-white">
-      <Skeleton className="h-[143px] w-full rounded-none" />
-      <div className="flex flex-col items-center gap-[9px] px-3 py-3">
-        <Skeleton className="h-4 w-3/4 rounded-none" />
-        <Skeleton className="h-5 w-1/2 rounded-none" />
+    <div className="flex flex-col overflow-hidden bg-bg-layer-basement">
+      <Skeleton className="aspect-[201/166] w-full rounded-none" />
+      <div className="flex h-[124px] flex-col items-start gap-2.5 self-stretch p-4">
+        <div className="flex flex-col gap-1 self-stretch">
+          <Skeleton className="h-5 w-full" />
+          <Skeleton className="h-5 w-1/2" />
+        </div>
+        <Skeleton className="h-5 w-12 rounded-[4px]" />
       </div>
     </div>
   );

--- a/apps/web/src/app/archive/wish/_components/WishContent.tsx
+++ b/apps/web/src/app/archive/wish/_components/WishContent.tsx
@@ -1,7 +1,8 @@
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 
-import type { WishlistPageT } from '@/apis/getWishlist';
 import { getWishlist } from '@/apis/getWishlist';
+import type { ApiResponseT } from '@/types/api';
+import type { GetWishlistResponseT } from '@/types/wish';
 import { getQueryClient } from '@/utils/queryClient';
 
 import WishContentClient from './WishContentClient';
@@ -11,9 +12,10 @@ async function WishContent() {
 
   await queryClient.prefetchInfiniteQuery({
     queryKey: ['wishlists'],
-    queryFn: ({ pageParam }) => getWishlist(pageParam as string | null),
+    queryFn: ({ pageParam }) => getWishlist(pageParam),
     initialPageParam: null as string | null,
-    getNextPageParam: (page: WishlistPageT) => (page.hasNext ? page.nextCursor : null),
+    getNextPageParam: (page: ApiResponseT<GetWishlistResponseT[]>) =>
+      page.pageResponse.hasNext ? page.pageResponse.nextCursor : null,
   });
 
   return (

--- a/apps/web/src/app/archive/wish/_components/WishContentClient.tsx
+++ b/apps/web/src/app/archive/wish/_components/WishContentClient.tsx
@@ -38,10 +38,10 @@ function WishContentClient() {
   const { wishlistData } = useGetWishlist();
   const selectableIds = wishlistData
     .filter(
-      item =>
+      ({ item }) =>
         item.status !== 'FAILED' && item.status !== 'PENDING' && item.status !== 'PROCESSING'
     )
-    .map(item => item.id);
+    .map(({ wish }) => wish.id);
   const isAllSelected =
     selectableIds.length > 0 && selectableIds.every(id => selectedIds.has(id));
 

--- a/apps/web/src/app/archive/wish/_components/WishGridContent.tsx
+++ b/apps/web/src/app/archive/wish/_components/WishGridContent.tsx
@@ -1,10 +1,10 @@
 import { HeartIconFill } from '@/assets/icons';
-import type { WishItemT } from '@/types/wish';
+import type { GetWishlistResponseT } from '@/types/wish';
 
 import WishGrid from './wish-grid';
 
 type WishGridContentProps = {
-  items: WishItemT[];
+  items: GetWishlistResponseT[];
   isDeleteMode?: boolean;
   selectedIds?: Set<number>;
   onToggleSelect?: (id: number) => void;

--- a/apps/web/src/app/archive/wish/_components/WishlistList.tsx
+++ b/apps/web/src/app/archive/wish/_components/WishlistList.tsx
@@ -20,7 +20,7 @@ function WishlistList({ isDeleteMode, selectedIds, onToggleSelect }: WishlistLis
   const sentinelRef = useRef<HTMLDivElement>(null);
 
   const { wishlistData, fetchNextPage, hasNextPage, isFetchingNextPage } = useGetWishlist();
-  const hasPendingItem = hasParsingItems(wishlistData);
+  const hasPendingItem = hasParsingItems(wishlistData.map(({ item }) => item));
 
   useSSEFallback(['wishlists'], hasPendingItem);
   useScrollRestoration();

--- a/apps/web/src/app/archive/wish/_components/wish-grid/index.tsx
+++ b/apps/web/src/app/archive/wish/_components/wish-grid/index.tsx
@@ -55,7 +55,7 @@ function WishGrid({ items, isDeleteMode = false, selectedIds, onToggleSelect }: 
             >
               <WishCard
                 name={item.name}
-                price={item.currentPrice}
+                price={item.price}
                 imageUrl={item.imageUrl}
                 sourcePlatform={item.sourcePlatform}
               />
@@ -86,7 +86,7 @@ function WishGrid({ items, isDeleteMode = false, selectedIds, onToggleSelect }: 
           >
             <WishCard
               name={item.name}
-              price={item.currentPrice}
+              price={item.price}
               imageUrl={item.imageUrl}
               sourcePlatform={item.sourcePlatform}
               preload={index < 4}

--- a/apps/web/src/app/archive/wish/_components/wish-grid/index.tsx
+++ b/apps/web/src/app/archive/wish/_components/wish-grid/index.tsx
@@ -5,14 +5,14 @@ import { CheckboxEmptyIconFill, CheckboxSelectedIconFill } from '@/assets/icons'
 import WishCard from '@/components/common/wish-card';
 import { ROUTES } from '@/consts/route';
 import { Z_INDEX } from '@/consts/zIndex';
-import type { WishItemT } from '@/types/wish';
+import type { GetWishlistResponseT } from '@/types/wish';
 
 import { saveWishScroll } from '../../_utils/wishScroll';
 import WishFailedCard from './WishFailedCard';
 import WishProcessingCard from './WishProcessingCard';
 
 type WishGridProps = {
-  items: WishItemT[];
+  items: GetWishlistResponseT[];
   isDeleteMode?: boolean;
   selectedIds?: Set<number>;
   onToggleSelect?: (id: number) => void;
@@ -28,34 +28,34 @@ function WishGrid({ items, isDeleteMode = false, selectedIds, onToggleSelect }: 
 
   return (
     <div className="grid grid-cols-2">
-      {items.map((item, index) => {
+      {items.map(({ wish, item }, index) => {
         if (item.status === 'FAILED')
           return (
             <Link
-              href={ROUTES.WISH_EDIT(item.id)}
-              key={item.id}
-              data-wish-id={item.id}
-              onClick={event => handleCardClick(event, item.id)}
+              href={ROUTES.WISH_EDIT(wish.id)}
+              key={wish.id}
+              data-wish-id={wish.id}
+              onClick={event => handleCardClick(event, wish.id)}
             >
-              <WishFailedCard key={item.id} />
+              <WishFailedCard />
             </Link>
           );
         else if (item.status === 'PENDING' || item.status === 'PROCESSING')
-          return <WishProcessingCard key={item.id} />;
+          return <WishProcessingCard key={wish.id} />;
 
         if (isDeleteMode) {
-          const isSelected = selectedIds?.has(item.id) ?? false;
+          const isSelected = selectedIds?.has(wish.id) ?? false;
           return (
             <button
-              key={item.id}
+              key={wish.id}
               type="button"
-              onClick={() => onToggleSelect?.(item.id)}
+              onClick={() => onToggleSelect?.(wish.id)}
               aria-pressed={isSelected}
               className="relative cursor-pointer text-left transition-opacity active:opacity-80"
             >
               <WishCard
                 name={item.name}
-                price={item.price}
+                price={item.currentPrice}
                 imageUrl={item.imageUrl}
                 sourcePlatform={item.sourcePlatform}
               />
@@ -79,14 +79,14 @@ function WishGrid({ items, isDeleteMode = false, selectedIds, onToggleSelect }: 
 
         return (
           <Link
-            href={ROUTES.WISH_EDIT(item.id)}
-            key={item.id}
-            data-wish-id={item.id}
-            onClick={event => handleCardClick(event, item.id)}
+            href={ROUTES.WISH_EDIT(wish.id)}
+            key={wish.id}
+            data-wish-id={wish.id}
+            onClick={event => handleCardClick(event, wish.id)}
           >
             <WishCard
               name={item.name}
-              price={item.price}
+              price={item.currentPrice}
               imageUrl={item.imageUrl}
               sourcePlatform={item.sourcePlatform}
               preload={index < 4}

--- a/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
@@ -29,11 +29,8 @@ function ByWishContent({ tournamentId }: ByWishContentProps) {
   const pending = 'pending' in tournamentData ? tournamentData.pending : null;
   const existingItemIds = new Set(pending?.items.map(i => i.itemId) ?? []);
   const items = wishlistData.filter(
-    item =>
-      item.status !== 'FAILED' &&
-      item.status !== 'PROCESSING' &&
-      item.itemId != null &&
-      !existingItemIds.has(item.itemId)
+    ({ item }) =>
+      item.status !== 'FAILED' && item.status !== 'PROCESSING' && !existingItemIds.has(item.id)
   );
 
   useEffect(() => {
@@ -50,8 +47,8 @@ function ByWishContent({ tournamentId }: ByWishContentProps) {
 
   const handleNext = () => {
     const itemIds = items
-      .filter(item => selectedIds.includes(item.id))
-      .map(item => item.itemId as number);
+      .filter(({ wish }) => selectedIds.includes(wish.id))
+      .map(({ item }) => item.id);
     postTournamentItemsByWishMutation(itemIds);
   };
 
@@ -72,15 +69,15 @@ function ByWishContent({ tournamentId }: ByWishContentProps) {
 
       <main className="mt-6 hide-scrollbar flex flex-1 flex-col overflow-y-auto pb-32">
         <div className="grid grid-cols-2">
-          {items.map(item => (
+          {items.map(({ wish, item }) => (
             <WishSelectCard
-              key={item.id}
+              key={wish.id}
               name={item.name}
-              price={item.price}
+              price={item.currentPrice}
               imageUrl={item.imageUrl}
               sourcePlatform={item.sourcePlatform}
-              isSelected={selectedIds.includes(item.id)}
-              onSelect={() => handleSelect(item.id)}
+              isSelected={selectedIds.includes(wish.id)}
+              onSelect={() => handleSelect(wish.id)}
             />
           ))}
         </div>

--- a/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
@@ -57,7 +57,9 @@ function ByWishContent({ tournamentId }: ByWishContentProps) {
       <div className="px-5">
         <Header
           left={<HeaderIcon name="BACK" />}
-          center={<h1 className="heading-1-bold text-text-neutral-primary">내 위시에서 가져오기</h1>}
+          center={
+            <h1 className="heading-1-bold text-text-neutral-primary">내 위시에서 가져오기</h1>
+          }
         />
         <WishSelectHeader
           selectedCount={selectedIds.length}
@@ -73,7 +75,7 @@ function ByWishContent({ tournamentId }: ByWishContentProps) {
             <WishSelectCard
               key={wish.id}
               name={item.name}
-              price={item.currentPrice}
+              price={item.price}
               imageUrl={item.imageUrl}
               sourcePlatform={item.sourcePlatform}
               isSelected={selectedIds.includes(wish.id)}

--- a/apps/web/src/app/tournament/[id]/item/[itemId]/_apis/patchTournamentItem.ts
+++ b/apps/web/src/app/tournament/[id]/item/[itemId]/_apis/patchTournamentItem.ts
@@ -2,17 +2,13 @@ import { clientApi } from '@/apis/client';
 import { ENDPOINTS } from '@/consts/api';
 import type { ApiResponseT } from '@/types/api';
 
-import type { PatchTournamentItemResponseT } from '../_types/tournamentItem';
-
 export const patchTournamentItem = async (
   tournamentId: number,
   tournamentItemId: number,
   formData: FormData
 ) => {
-  const { data } = await clientApi.patch<ApiResponseT<PatchTournamentItemResponseT>>(
+  await clientApi.patch<ApiResponseT<null>>(
     ENDPOINTS.TOURNAMENT_ITEM(tournamentId, tournamentItemId),
     formData
   );
-
-  return data.data;
 };

--- a/apps/web/src/app/tournament/[id]/item/[itemId]/_components/EditContent.tsx
+++ b/apps/web/src/app/tournament/[id]/item/[itemId]/_components/EditContent.tsx
@@ -31,7 +31,7 @@ function EditContent({ tournamentId, tournamentItemId }: EditContentProps) {
           tournamentId={tournamentId}
           tournamentItemId={tournamentItemId}
           itemStatus={tournamentItemData.status}
-          initialImageUrl={tournamentItemData.imageUrl ?? ''}
+          initialImageUrl={tournamentItemData.imageUrl ?? null}
           initialName={tournamentItemData.name ?? ''}
           initialPrice={tournamentItemData.price ?? 0}
         />

--- a/apps/web/src/app/tournament/[id]/item/[itemId]/_components/EditContent.tsx
+++ b/apps/web/src/app/tournament/[id]/item/[itemId]/_components/EditContent.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Header, HeaderIcon } from '@/components/header';
 import ItemLinkBanner from '@/components/common/item-link-banner';
+import { Header, HeaderIcon } from '@/components/header';
 import { cn } from '@/utils/cn';
 
 import { useGetTournamentItem } from '../_hooks/useGetTournamentItem';
@@ -31,11 +31,9 @@ function EditContent({ tournamentId, tournamentItemId }: EditContentProps) {
           tournamentId={tournamentId}
           tournamentItemId={tournamentItemId}
           itemStatus={tournamentItemData.status}
-          initialImageUrl={
-            tournamentItemData.status === 'READY' ? tournamentItemData.imageUrl : null
-          }
-          initialName={tournamentItemData.status === 'READY' ? tournamentItemData.name : ''}
-          initialPrice={tournamentItemData.status === 'READY' ? tournamentItemData.price : 0}
+          initialImageUrl={tournamentItemData.imageUrl ?? ''}
+          initialName={tournamentItemData.name ?? ''}
+          initialPrice={tournamentItemData.price ?? 0}
         />
 
         {tournamentItemData.status === 'READY' && tournamentItemData.sourceUrl && (

--- a/apps/web/src/app/tournament/[id]/item/[itemId]/_hooks/usePatchTournamentItem.ts
+++ b/apps/web/src/app/tournament/[id]/item/[itemId]/_hooks/usePatchTournamentItem.ts
@@ -17,8 +17,8 @@ export const usePatchTournamentItem = (tournamentId: number, tournamentItemId: n
     useMutation({
       mutationFn: (body: PatchItemRequestT) => {
         const formData = new FormData();
-        formData.append('name', body.name);
-        formData.append('price', String(body.price));
+        if (body.name) formData.append('name', body.name);
+        if (body.price) formData.append('price', String(body.price));
         if (body.image) formData.append('image', body.image);
         return patchTournamentItem(tournamentId, tournamentItemId, formData);
       },

--- a/apps/web/src/app/tournament/[id]/item/[itemId]/_hooks/usePatchTournamentItem.ts
+++ b/apps/web/src/app/tournament/[id]/item/[itemId]/_hooks/usePatchTournamentItem.ts
@@ -18,9 +18,9 @@ export const usePatchTournamentItem = (tournamentId: number, tournamentItemId: n
       mutationFn: (body: Omit<PatchItemRequestT, 'currency'>) => {
         const formData = new FormData();
         formData.append('name', body.name);
-        formData.append('price', String(body.currentPrice));
         formData.append('currency', 'KRW');
         formData.append('image', body.image);
+        formData.append('price', String(body.price));
         return patchTournamentItem(tournamentId, tournamentItemId, formData);
       },
       onSuccess: () => {

--- a/apps/web/src/app/tournament/[id]/item/[itemId]/_hooks/usePatchTournamentItem.ts
+++ b/apps/web/src/app/tournament/[id]/item/[itemId]/_hooks/usePatchTournamentItem.ts
@@ -15,12 +15,11 @@ export const usePatchTournamentItem = (tournamentId: number, tournamentItemId: n
 
   const { mutate: patchTournamentItemMutation, isPending: isPatchTournamentItemPending } =
     useMutation({
-      mutationFn: (body: Omit<PatchItemRequestT, 'currency'>) => {
+      mutationFn: (body: PatchItemRequestT) => {
         const formData = new FormData();
         formData.append('name', body.name);
-        formData.append('currency', 'KRW');
-        formData.append('image', body.image);
         formData.append('price', String(body.price));
+        if (body.image) formData.append('image', body.image);
         return patchTournamentItem(tournamentId, tournamentItemId, formData);
       },
       onSuccess: () => {

--- a/apps/web/src/app/tournament/[id]/item/[itemId]/_types/tournamentItem.ts
+++ b/apps/web/src/app/tournament/[id]/item/[itemId]/_types/tournamentItem.ts
@@ -3,25 +3,23 @@ import type { ITEM_STATUS } from '@/consts/item';
 export type GetTournamentItemResponseT = {
   tournamentItemId: number;
   itemId: number;
+  /** 이미지로 등록한 경우 undefined */
+  sourceUrl?: string;
+  currency?: string;
 } & (
   | {
-      status: (typeof ITEM_STATUS)['PROCESSING'] | (typeof ITEM_STATUS)['PENDING'];
-      name: null;
-      imageUrl: null;
-      price: null;
-      currency: string;
+      status:
+        | (typeof ITEM_STATUS)['PENDING']
+        | (typeof ITEM_STATUS)['PROCESSING']
+        | (typeof ITEM_STATUS)['FAILED'];
+      name?: undefined;
+      imageUrl?: undefined;
+      price?: undefined;
     }
   | {
       status: (typeof ITEM_STATUS)['READY'];
       name: string;
       imageUrl: string;
       price: number;
-      currency: string;
-      sourceUrl?: string;
-    }
-  | {
-      status: (typeof ITEM_STATUS)['FAILED'];
     }
 );
-
-export type PatchTournamentItemResponseT = GetTournamentItemResponseT;

--- a/apps/web/src/components/common/item-edit-form/index.tsx
+++ b/apps/web/src/components/common/item-edit-form/index.tsx
@@ -70,11 +70,7 @@ function ItemEditForm({
 
   return (
     <>
-      <ItemImageSection
-        imageUrl={initialImageUrl}
-        onImageSelect={setSelectedImage}
-        disabled={itemStatus === 'READY'}
-      />
+      <ItemImageSection imageUrl={initialImageUrl} onImageSelect={setSelectedImage} />
 
       <Spacing size={24} />
 
@@ -86,7 +82,6 @@ function ItemEditForm({
           onChange={event => setName(event.target.value)}
           maxLength={50}
           autoCorrect="off"
-          disabled={itemStatus === 'READY'}
         />
         <Input
           label="가격"
@@ -97,7 +92,6 @@ function ItemEditForm({
           onBlur={() => setPrice(prev => formatPrice(prev))}
           inputMode="numeric"
           autoCorrect="off"
-          disabled={itemStatus === 'READY'}
         />
       </div>
 
@@ -113,6 +107,21 @@ function ItemEditForm({
           >
             삭제하기
           </Button>
+        </BottomCta>
+      )}
+
+      <BottomCta>
+        <Button
+          variant="secondary"
+          size="lg"
+          className="flex-1"
+          isLoading={isDeletePending}
+          disabled={isRefreshPending || isSavePending}
+          onClick={handleDelete}
+        >
+          삭제하기
+        </Button>
+        {itemStatus === 'READY' && onRefresh && (
           <Button
             variant="primary"
             size="lg"
@@ -123,33 +132,18 @@ function ItemEditForm({
           >
             다시 불러오기
           </Button>
-        </BottomCta>
-      )}
-
-      {itemStatus === 'FAILED' && (
-        <BottomCta>
-          <Button
-            variant="secondary"
-            size="lg"
-            className="flex-1"
-            isLoading={isDeletePending}
-            disabled={isRefreshPending || isSavePending}
-            onClick={handleDelete}
-          >
-            삭제하기
-          </Button>
-          <Button
-            variant="primary"
-            size="lg"
-            className="flex-1"
-            isLoading={isSavePending}
-            disabled={isDeletePending || isRefreshPending || !isValid}
-            onClick={handleSave}
-          >
-            저장하기
-          </Button>
-        </BottomCta>
-      )}
+        )}
+        <Button
+          variant="primary"
+          size="lg"
+          className="flex-1"
+          isLoading={isSavePending}
+          disabled={isDeletePending || isRefreshPending || !isValid}
+          onClick={handleSave}
+        >
+          저장하기
+        </Button>
+      </BottomCta>
     </>
   );
 }

--- a/apps/web/src/components/common/item-edit-form/index.tsx
+++ b/apps/web/src/components/common/item-edit-form/index.tsx
@@ -6,7 +6,7 @@ import BottomCta from '@/components/bottom-cta';
 import Button from '@/components/button';
 import Input from '@/components/input';
 import Spacing from '@/components/spacing';
-import type { ItemStatusT } from '@/types/item';
+import type { ItemStatusT, PatchItemRequestT } from '@/types/item';
 import formatPrice from '@/utils/formatPrice';
 import parsePriceToNumber from '@/utils/parsePriceToNumber';
 
@@ -17,7 +17,7 @@ type ItemEditFormProps = {
   initialImageUrl: string | null;
   initialName: string;
   initialPrice: number;
-  onSave?: (data: { name: string; price: number; image?: File }) => void;
+  onSave?: (data: PatchItemRequestT) => void;
   isSavePending?: boolean;
   onDelete: () => void;
   isDeletePending?: boolean;
@@ -46,9 +46,11 @@ function ItemEditForm({
 
   const isActionPending = isSavePending || isDeletePending || isRefreshPending;
 
+  const isNameChanged = trimmedName !== initialName.trim();
+  const isPriceChanged = parsedPrice !== initialPrice;
+
   const hasImage = initialImageUrl !== null || selectedImage !== null;
-  const isChanged =
-    trimmedName !== initialName.trim() || parsedPrice !== initialPrice || selectedImage !== null;
+  const isChanged = isNameChanged || isPriceChanged || selectedImage !== null;
   /**
    * 저장 가능한 경우
    * - READY: 이미지, 상품명, 가격 필드 중 일부 수정 가능. 생략은 불가
@@ -56,10 +58,11 @@ function ItemEditForm({
    */
   const isSavable = isChanged && hasImage && trimmedName.length > 0 && parsedPrice > 0;
 
+  /** 폼은 name·price 를 항상 검증하되, 전송은 실제로 바뀐 필드만 한다 */
   const handleSave = () => {
     onSave?.({
-      name: trimmedName,
-      price: parsedPrice,
+      ...(isNameChanged && { name: trimmedName }),
+      ...(isPriceChanged && { price: parsedPrice }),
       ...(selectedImage && { image: selectedImage }),
     });
   };

--- a/apps/web/src/components/common/item-edit-form/index.tsx
+++ b/apps/web/src/components/common/item-edit-form/index.tsx
@@ -17,7 +17,7 @@ type ItemEditFormProps = {
   initialImageUrl: string | null;
   initialName: string;
   initialPrice: number;
-  onSave?: (data: { name: string; currentPrice: number; image: File }) => void;
+  onSave?: (data: { name: string; price: number; image?: File }) => void;
   isSavePending?: boolean;
   onDelete: () => void;
   isDeletePending?: boolean;
@@ -46,16 +46,23 @@ function ItemEditForm({
   const isActionPending = isDeletePending || isRefreshPending || isSavePending;
   const trimmedName = name.trim();
   const parsedPrice = parsePriceToNumber(price);
-  const isValid = trimmedName.length > 0 && parsedPrice > 0 && selectedImage !== null;
+  /** 기존 이미지가 없으면 이미지 선택이 필수 */
+  const isImageRequired = !initialImageUrl;
+  const isValid =
+    trimmedName.length > 0 && parsedPrice > 0 && (!isImageRequired || selectedImage !== null);
+  const isChanged =
+    trimmedName !== initialName.trim() ||
+    formatPrice(price) !== initialPriceFormatted ||
+    selectedImage !== null;
 
   const handleSave = () => {
-    const isChanged =
-      trimmedName !== initialName.trim() ||
-      formatPrice(price) !== initialPriceFormatted ||
-      selectedImage !== null;
-    if (!isChanged || isActionPending || !selectedImage) return;
+    if (!isChanged || isActionPending || !isValid) return;
 
-    onSave?.({ name: trimmedName, currentPrice: parsedPrice, image: selectedImage });
+    onSave?.({
+      name: trimmedName,
+      price: parsedPrice,
+      ...(selectedImage && { image: selectedImage }),
+    });
   };
 
   const handleDelete = () => {
@@ -95,21 +102,6 @@ function ItemEditForm({
         />
       </div>
 
-      {itemStatus === 'READY' && onRefresh && (
-        <BottomCta>
-          <Button
-            variant="secondary"
-            size="lg"
-            className="flex-1"
-            isLoading={isDeletePending}
-            disabled={isRefreshPending || isSavePending}
-            onClick={handleDelete}
-          >
-            삭제하기
-          </Button>
-        </BottomCta>
-      )}
-
       <BottomCta>
         <Button
           variant="secondary"
@@ -138,7 +130,7 @@ function ItemEditForm({
           size="lg"
           className="flex-1"
           isLoading={isSavePending}
-          disabled={isDeletePending || isRefreshPending || !isValid}
+          disabled={isDeletePending || isRefreshPending || !isValid || !isChanged}
           onClick={handleSave}
         >
           저장하기

--- a/apps/web/src/components/common/item-edit-form/index.tsx
+++ b/apps/web/src/components/common/item-edit-form/index.tsx
@@ -37,42 +37,31 @@ function ItemEditForm({
   onRefresh,
   isRefreshPending = false,
 }: ItemEditFormProps) {
-  const initialPriceFormatted = initialPrice ? formatPrice(String(initialPrice)) : '';
-
   const [name, setName] = useState(initialName);
-  const [price, setPrice] = useState(initialPriceFormatted);
+  const [price, setPrice] = useState(initialPrice ? formatPrice(String(initialPrice)) : '');
   const [selectedImage, setSelectedImage] = useState<File | null>(null);
 
-  const isActionPending = isDeletePending || isRefreshPending || isSavePending;
   const trimmedName = name.trim();
   const parsedPrice = parsePriceToNumber(price);
-  /** 기존 이미지가 없으면 이미지 선택이 필수 */
-  const isImageRequired = !initialImageUrl;
-  const isValid =
-    trimmedName.length > 0 && parsedPrice > 0 && (!isImageRequired || selectedImage !== null);
+
+  const isActionPending = isSavePending || isDeletePending || isRefreshPending;
+
+  const hasImage = initialImageUrl !== null || selectedImage !== null;
   const isChanged =
-    trimmedName !== initialName.trim() ||
-    formatPrice(price) !== initialPriceFormatted ||
-    selectedImage !== null;
+    trimmedName !== initialName.trim() || parsedPrice !== initialPrice || selectedImage !== null;
+  /**
+   * 저장 가능한 경우
+   * - READY: 이미지, 상품명, 가격 필드 중 일부 수정 가능. 생략은 불가
+   * - FAILED: 이미지, 상품명, 가격 필드가 모두 추가되어야 함
+   */
+  const isSavable = isChanged && hasImage && trimmedName.length > 0 && parsedPrice > 0;
 
   const handleSave = () => {
-    if (!isChanged || isActionPending || !isValid) return;
-
     onSave?.({
       name: trimmedName,
       price: parsedPrice,
       ...(selectedImage && { image: selectedImage }),
     });
-  };
-
-  const handleDelete = () => {
-    if (isActionPending) return;
-    onDelete();
-  };
-
-  const handleRefresh = () => {
-    if (isActionPending) return;
-    onRefresh?.();
   };
 
   return (
@@ -108,29 +97,32 @@ function ItemEditForm({
           size="lg"
           className="flex-1"
           isLoading={isDeletePending}
-          disabled={isRefreshPending || isSavePending}
-          onClick={handleDelete}
+          disabled={isActionPending}
+          onClick={onDelete}
         >
           삭제하기
         </Button>
-        {itemStatus === 'READY' && onRefresh && (
+
+        {/** 정보 갱신은 READY만 가능 */}
+        {itemStatus === 'READY' && !!onRefresh && (
           <Button
             variant="primary"
             size="lg"
             className="flex-1"
             isLoading={isRefreshPending}
-            disabled={isDeletePending || isSavePending}
-            onClick={handleRefresh}
+            disabled={isActionPending}
+            onClick={onRefresh}
           >
             다시 불러오기
           </Button>
         )}
+
         <Button
           variant="primary"
           size="lg"
           className="flex-1"
           isLoading={isSavePending}
-          disabled={isDeletePending || isRefreshPending || !isValid || !isChanged}
+          disabled={isActionPending || !isSavable}
           onClick={handleSave}
         >
           저장하기

--- a/apps/web/src/hooks/useGetWishlist.ts
+++ b/apps/web/src/hooks/useGetWishlist.ts
@@ -7,10 +7,10 @@ export const useGetWishlist = () => {
     queryKey: ['wishlists'],
     queryFn: ({ pageParam }) => getWishlist(pageParam),
     initialPageParam: null as string | null,
-    getNextPageParam: page => (page.hasNext ? page.nextCursor : null),
+    getNextPageParam: page => (page.pageResponse.hasNext ? page.pageResponse.nextCursor : null),
   });
 
-  const wishlistData = data.pages.flatMap(page => page.items);
+  const wishlistData = data.pages.flatMap(page => page.data);
 
   return { wishlistData, fetchNextPage, hasNextPage, isFetchingNextPage };
 };

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -4,6 +4,10 @@ export type ApiResponseT<T> = {
   data: T;
   detail: string;
   code: string;
+  pageResponse: {
+    nextCursor: string | null;
+    hasNext: boolean;
+  };
 };
 
 // 공통 에러 응답 타입

--- a/apps/web/src/types/item.ts
+++ b/apps/web/src/types/item.ts
@@ -16,9 +16,8 @@ export type ItemT = {
 export type ItemStatusT = (typeof ITEM_STATUS)[keyof typeof ITEM_STATUS];
 
 export type PatchItemRequestT = {
-  /** NOTE: name, price가 서버에서는 optional 이지만, 클라이언트에서는 required로 처리함 */
-  name: string;
-  price: number;
+  name?: string;
+  price?: number;
   image?: File;
   /** NOTE: currency는 optional이지만, 사용하지 않는 필드이므로 삭제함. 추후 필요할 때 다시 추가할 수 있음 */
   // currency?: string;

--- a/apps/web/src/types/item.ts
+++ b/apps/web/src/types/item.ts
@@ -16,8 +16,10 @@ export type ItemT = {
 export type ItemStatusT = (typeof ITEM_STATUS)[keyof typeof ITEM_STATUS];
 
 export type PatchItemRequestT = {
+  /** NOTE: name, price가 서버에서는 optional 이지만, 클라이언트에서는 required로 처리함 */
   name: string;
-  image: File;
-  currency: string;
   price: number;
+  image?: File;
+  /** NOTE: currency는 optional이지만, 사용하지 않는 필드이므로 삭제함. 추후 필요할 때 다시 추가할 수 있음 */
+  // currency?: string;
 };

--- a/apps/web/src/types/item.ts
+++ b/apps/web/src/types/item.ts
@@ -6,7 +6,7 @@ export type ItemT = {
   id: number;
   status: ItemStatusT;
   name: string;
-  currentPrice: number;
+  price: number;
   currency: string | null;
   imageUrl: string | null;
   sourceUrl: string | null;
@@ -17,7 +17,7 @@ export type ItemStatusT = (typeof ITEM_STATUS)[keyof typeof ITEM_STATUS];
 
 export type PatchItemRequestT = {
   name: string;
-  currentPrice: number;
   image: File;
   currency: string;
+  price: number;
 };

--- a/apps/web/src/types/wish.ts
+++ b/apps/web/src/types/wish.ts
@@ -1,26 +1,37 @@
-import type { ItemStatusT, ItemT } from './item';
-
-export type PostWishOCRResponseT = {
-  wish: WishT;
-  item: ItemT;
-};
-
-export type PostWishLinkResponseT = {
-  wish: WishT;
-  item: ItemT;
-};
+import type { ItemT } from './item';
 
 export type WishT = {
   id: number;
   createdAt: string;
 };
 
-export type WishItemT = {
-  id: number;
-  itemId: number;
-  name: string;
-  price: number;
-  imageUrl: string | null;
-  status: ItemStatusT;
-  sourcePlatform: string | null;
+export type GetWishlistResponseT = {
+  wish: WishT;
+  item: ItemT;
+  /**
+   * 갱신 필요 여부
+   * - 이미지로 등록한 경우: null
+   * - 링크로 등록한 경우: boolean
+   */
+  refreshNeeded: boolean | null;
+  /**
+   * 재사용 여부
+   * - 이미지로 등록한 경우: null
+   * - 링크로 등록한 경우: boolean
+   */
+  reused: boolean | null;
+};
+
+export type PostWishLinkResponseT = {
+  wish: WishT;
+  item: ItemT;
+  refreshNeeded: boolean;
+  reused: boolean;
+};
+
+export type PostWishOCRResponseT = {
+  wish: WishT;
+  item: ItemT;
+  refreshNeeded: null;
+  reused: null;
 };


### PR DESCRIPTION
## 작업 요약

- 위시·토너먼트 아이템을 status가 READY일 때도 수정할 수 있도록 변경합니다
- 위시리스트 응답을 프론트에서 매핑하지 않고 서버 구조 그대로 사용합니다
- 위시 응답에 refreshNeeded, reused 필드 타입을 추가합니다

## 작업 세부 내용

**아이템 수정 화면 (`item-edit-form`)**

- 기존에는 status가 `READY`면 이미지·이름·가격 입력이 전부 `disabled`였고, 하단 CTA도 `READY` / `FAILED` 분기로 나뉘어 있었습니다.
- 이제 상태와 무관하게 입력이 항상 열려 있고, CTA는 `삭제하기` + `저장하기` 한 벌로 통합했습니다.
- `다시 불러오기`는 `READY`이면서 `onRefresh`가 있을 때만 추가로 노출됩니다.

**위시리스트 응답 구조 (`getWishlist` / `useGetWishlist`)**

- `WishlistEntryT` → `WishItemT` 로 평탄화하던 `mapWishlist`를 제거하고 서버 응답(`{ wish, item }`)을 그대로 내려보냅니다.
- 페이지네이션도 커스텀 `WishlistPageT` 대신 공통 `ApiResponseT` + `pageResponse`를 사용합니다.
- 소비처(`WishGridContent`, `wish-grid`, `ByWishContent` 등)는 `wish.id` / `item.name` 형태로 접근하도록 맞췄습니다.

**타입 정리**

- 공통 `ApiResponseT`에 `pageResponse`(`nextCursor`, `hasNext`)를 추가했습니다.
- `GetWishlistResponseT`에 `refreshNeeded`, `reused`를 추가했습니다. 이미지로 등록한 경우 `null`, 링크로 등록한 경우 `boolean`이라 주석으로 명시했습니다.
- `GetTournamentItemResponseT`에서 `sourceUrl`, `currency`를 공통 필드로 올리고 `FAILED`를 미완성 상태 유니온에 합쳤습니다. 동일했던 `PatchTournamentItemResponseT`는 제거했습니다.

**위시리스트 스켈레톤**

- 실제 카드에 `rounded`가 없어 스켈레톤의 `rounded-2xl`을 제거했습니다.
- 스켈레톤 치수를 실제 카드에 맞췄습니다 (이미지 `aspect-[201/166]`, 텍스트 영역 `h-[124px]`). 로딩 → 실제 카드 전환 시 리스트 높이가 튀지 않습니다.


## 연관 이슈

closes #416


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 위시리스트 페이지네이션과 항목 상태 정보가 개선되었습니다.
  * 초대 링크에서 참여 여부와 만료 상태를 자동으로 안내합니다.
  * 회원은 토너먼트 초대 링크를 통해 자동 참여할 수 있습니다.
  * 결과 화면에서 영수증을 이미지로 저장·복사·공유할 수 있습니다.
* **버그 수정**
  * 영수증 아이콘 표시 오류와 일부 오류 화면 UI를 수정했습니다.
  * 위시 정보 편집 및 가격·이미지 저장 동작을 개선했습니다.
* **스타일**
  * 위시 관련 문구와 입력 안내, 토스트 위치 및 화면 스타일을 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->