### PR TITLE
style: 토너먼트, 위시 관련 전체 워딩 수정

### DIFF
--- a/apps/web/e2e/specs/home/home.spec.ts
+++ b/apps/web/e2e/specs/home/home.spec.ts
@@ -10,7 +10,7 @@ test('홈에 진입하면 최근 생성한 토너먼트 목록이 렌더링된�
 
   await page.goto('/home');
 
-  await expect(page.getByRole('heading', { name: '최근 생성한 토너먼트' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: '최근 토너먼트' })).toBeVisible();
   await expect(page.getByText('E2E 토너먼트')).toBeVisible();
 });
 

--- a/apps/web/src/app/archive/wish/[id]/_components/EditContent.tsx
+++ b/apps/web/src/app/archive/wish/[id]/_components/EditContent.tsx
@@ -17,7 +17,7 @@ function EditContent({ wishId }: EditContentProps) {
     <div className="hide-scrollbar min-h-dvh overflow-y-auto bg-bg-layer-basement px-5 pt-padding-top pb-[78px]">
       <Header
         left={<HeaderIcon name="BACK" />}
-        center="위시템 정보 확인"
+        center="위시 정보 확인"
         centerClassName="heading-1-bold"
       />
       <main>

--- a/apps/web/src/app/archive/wish/_components/WishGridContent.tsx
+++ b/apps/web/src/app/archive/wish/_components/WishGridContent.tsx
@@ -20,7 +20,7 @@ function WishGridContent({
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-3">
         <HeartIconFill width={32} height={32} className="text-gray-200" />
-        <p className="body-1-semibold text-text-neutral-tertiary">아직 담긴 위시템이 없어요</p>
+        <p className="body-1-semibold text-text-neutral-tertiary">아직 담긴 위시가 없어요</p>
       </div>
     );
   }

--- a/apps/web/src/app/home/_components/CreateTournamentDialog.tsx
+++ b/apps/web/src/app/home/_components/CreateTournamentDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 
-import { BasketIconFill, EditIconFill } from '@/assets/icons';
+import { BasketIconFill } from '@/assets/icons';
 import Button from '@/components/button';
 import {
   Dialog,
@@ -61,12 +61,11 @@ function CreateTournamentDialog() {
         <form onSubmit={handleCreate} className="flex flex-col gap-[15px]">
           <Input
             label="토너먼트 이름"
-            placeholder="ex.이번주 신발 고르기"
+            placeholder="이번주 신발 고르기"
             value={name}
             onChange={e => setName(e.target.value)}
             autoFocus
             maxLength={30}
-            right={isDisabled ? <EditIconFill className="size-5" /> : null}
           />
           <Button type="submit" size="lg" variant="primary" disabled={isDisabled}>
             생성하기

--- a/apps/web/src/app/home/_components/InviteTournamentDialog.tsx
+++ b/apps/web/src/app/home/_components/InviteTournamentDialog.tsx
@@ -98,25 +98,25 @@ function InviteTournamentDialog() {
         <DialogTrigger asChild onClick={handleTriggerClick}>
           <button
             type="button"
-            aria-label="초대받은 토너먼트 참여하기"
+            aria-label="공유받은 토너먼트 참여하기"
             className="flex h-[104px] cursor-pointer flex-col rounded-2xl bg-gray-50 p-4"
           >
             <span className="text-left body-1-semibold whitespace-pre-line text-text-neutral-primary">
-              {'초대받은 토너먼트\n참여하기'}
+              {'공유받은 토너먼트\n참여하기'}
             </span>
             <GroupIconFill className="size-7.5 self-end text-icon-neutral-secondary" />
           </button>
         </DialogTrigger>
         <DialogContent showCloseButton={false} className="flex flex-col gap-5 p-6">
           <DialogTitle className="text-center heading-1-bold text-text-neutral-primary">
-            초대받은 토너먼트
+            공유받은 토너먼트
           </DialogTitle>
           <DialogDescription className="sr-only">초대 코드를 입력해 입장합니다.</DialogDescription>
 
           <form onSubmit={handleSubmit} className="flex flex-col gap-5">
             <Input
               label="초대 코드"
-              placeholder="ex. ABC123"
+              placeholder="pik123"
               value={code}
               onChange={event => handleChange(event.target.value)}
               aria-invalid={showFormatError}

--- a/apps/web/src/app/home/_components/tournament-list/index.tsx
+++ b/apps/web/src/app/home/_components/tournament-list/index.tsx
@@ -25,7 +25,7 @@ function TournamentList() {
     <HydrationBoundary state={dehydrate(queryClient)}>
       <section className="flex flex-1 flex-col gap-3">
         <div className="flex items-center justify-between">
-          <h2 className="heading-2-semibold text-black">최근 생성한 토너먼트</h2>
+          <h2 className="heading-2-semibold text-black">최근 토너먼트</h2>
           <Link href={ROUTES.TOURNAMENT_HISTORY} aria-label="토너먼트 히스토리 보기">
             <ChevronForwardIconFill className="size-6 text-icon-neutral-secondary" aria-hidden />
           </Link>

--- a/apps/web/src/app/mypage/withdraw/page.tsx
+++ b/apps/web/src/app/mypage/withdraw/page.tsx
@@ -22,7 +22,7 @@ function MypageWithdrawPage() {
           <SadIconFill className="size-[74px] text-gray-100" aria-hidden />
           <WithdrawGreeting />
           <p className="text-center body-2-medium break-keep text-text-neutral-tertiary">
-            지금까지의 토너먼트 기록, 위시템 기록이 전부 사라져요.
+            지금까지의 토너먼트 기록, 위시 기록이 전부 사라져요.
           </p>
         </div>
 

--- a/apps/web/src/app/tournament/[id]/item/[itemId]/_components/EditContent.tsx
+++ b/apps/web/src/app/tournament/[id]/item/[itemId]/_components/EditContent.tsx
@@ -23,7 +23,7 @@ function EditContent({ tournamentId, tournamentItemId }: EditContentProps) {
     >
       <Header
         left={<HeaderIcon name="BACK" />}
-        center="위시템 정보 확인"
+        center="위시 정보 확인"
         centerClassName="heading-1-bold"
       />
       <main>

--- a/apps/web/src/app/tournament/join/[id]/_components/JoinPreviewClient.tsx
+++ b/apps/web/src/app/tournament/join/[id]/_components/JoinPreviewClient.tsx
@@ -181,7 +181,7 @@ function JoinPreviewClient({ tournamentId, inviteCode }: JoinPreviewClientProps)
         />
 
         <section className="mt-8.75 flex flex-col gap-2 px-5">
-          <p className="body-2-semibold text-text-neutral-primary">초대받은 토너먼트</p>
+          <p className="body-2-semibold text-text-neutral-primary">공유받은 토너먼트</p>
           <div className="flex flex-col gap-1 rounded-xl bg-gray-50 p-4">
             <p className="body-1-semibold text-text-neutral-primary">
               {invitePreviewData.tournamentName}

--- a/apps/web/src/components/common/create-tournament-dialog/index.tsx
+++ b/apps/web/src/components/common/create-tournament-dialog/index.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 
-import { EditIconFill } from '@/assets/icons';
+
 import Button from '@/components/button';
 import { DialogContent, DialogDescription, DialogTitle } from '@/components/dialog';
 import Input from '@/components/input';
@@ -36,12 +36,12 @@ function CreateTournamentDialogContent() {
       <form onSubmit={handleCreate} className="flex flex-col gap-[15px]">
         <Input
           label="토너먼트 이름"
-          placeholder="ex.이번주 신발 고르기"
+          placeholder="이번주 신발 고르기"
           value={name}
           onChange={e => setName(e.target.value)}
           autoFocus
           maxLength={30}
-          right={isDisabled ? <EditIconFill className="size-5" /> : null}
+
         />
         <Button type="submit" size="lg" variant="primary" disabled={isDisabled}>
           생성하기

--- a/apps/web/src/components/get-item-dialog/index.tsx
+++ b/apps/web/src/components/get-item-dialog/index.tsx
@@ -31,7 +31,7 @@ function GetItemDialogContent({ type }: GetItemDialogContentProps) {
     <>
       <DialogContent showCloseButton={false} className="flex flex-col gap-[15px]">
         <DialogTitle className="text-center heading-1-bold text-text-neutral-primary">
-          위시템 담기
+          위시 담기
         </DialogTitle>
         <DialogDescription className="sr-only">
           위시, 링크, 이미지 중 하나를 선택해 상품을 담습니다.

--- a/apps/web/src/components/input/index.tsx
+++ b/apps/web/src/components/input/index.tsx
@@ -48,7 +48,7 @@ function Input({
           aria-invalid={ariaInvalid}
           {...(helperText ? { 'aria-describedby': helperTextId } : {})}
           className={cn(
-            'w-full overflow-hidden bg-transparent body-1-medium text-ellipsis whitespace-nowrap text-gray-600 outline-none placeholder:text-gray-300 focus:text-gray-900 disabled:text-gray-300',
+            'w-full overflow-hidden bg-transparent body-1-medium text-ellipsis whitespace-nowrap text-gray-600 outline-none placeholder:text-text-neutral-tertiary focus:text-gray-900 disabled:text-gray-300',
             className
           )}
           {...props}


### PR DESCRIPTION
## 작업 요약

- QA 과정에서 결정된 서비스 전반 워딩을 통일합니다

## 작업 세부 내용

- `위시템` → `위시` 전수 변경
- `초대받은 토너먼트` → `공유받은 토너먼트` 변경
- `최근 생성한 토너먼트` → `최근 토너먼트` 변경
- `위시템 담기` 모달 타이틀 → `위시 담기`
- placeholder `ex.` 제거 (`이번주 신발 고르기`, `pik123`)
- 새 토너먼트 모달 연필 아이콘 제거
- Input 컴포넌트 placeholder 색상 → `text-text-neutral-tertiary` 토큰 적용

## 스크린샷
<img width="481" height="855" alt="스크린샷 2026-08-03 오후 10 45 11" src="https://github.com/user-attachments/assets/b916942d-542f-46df-84f6-2a7116f209df" />
<img width="483" height="856" alt="스크린샷 2026-08-03 오후 10 45 23" src="https://github.com/user-attachments/assets/6e28410d-57e3-4611-a078-bc2142a12fee" />


## 연관 이슈

closes #425



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 위시 관련 화면의 용어를 ‘위시템’에서 ‘위시’로 통일했습니다.
  * 초대 토너먼트 표현을 ‘공유받은 토너먼트’로 변경했습니다.
  * 토너먼트 생성 및 참여 입력창의 안내 문구를 보다 간결하고 명확하게 개선했습니다.
  * 최근 토너먼트 목록 제목과 빈 목록 안내 문구를 정리했습니다.
  * 입력창의 불필요한 아이콘을 제거하고, 플레이스홀더 텍스트 색상을 조정했습니다.
  * 위시 담기 대화상자의 제목을 간결하게 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->