### PR TITLE
design: 영수증 공유 시트의 카카오 공유를 링크 공유로 교체

### DIFF
--- a/apps/web/src/app/tournament/[id]/result/_components/receipt-share-dialog/ReceiptShareDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/receipt-share-dialog/ReceiptShareDialog.tsx
@@ -3,8 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
-import { CopyIconFill, DownloadIconFill } from '@/assets/icons';
-import KakaoIcon from '@/assets/icons/social/kakao.svg';
+import { CopyIconFill, DownloadIconFill, LinkIconOutline } from '@/assets/icons';
 import { Drawer, DrawerContent, DrawerDescription, DrawerTitle } from '@/components/drawer';
 import Skeleton from '@/components/skeleton';
 import { ANALYTICS_EVENT } from '@/consts/analytics';
@@ -32,7 +31,7 @@ type ReceiptShareDialogProps = {
 type ShareActionProps = {
   icon: React.ReactNode;
   label: string;
-  /** 원형 배경색 클래스 — 브랜드 액션(카카오 등)은 고유 색을 쓴다 */
+  /** 원형 배경색 클래스 — 브랜드 아이콘은 고유 배경을 쓴다 */
   iconBackgroundClassName?: string;
   disabled?: boolean;
   onClick: () => void;
@@ -141,7 +140,7 @@ function ReceiptShareDialog({
     toast.success('이미지를 복사했어요.');
   };
 
-  const handleShareToChat = async () => {
+  const handleShareLink = async () => {
     if (!imageBlob) return;
 
     const shareResult = await shareReceiptImageFile(imageBlob);
@@ -153,7 +152,7 @@ function ReceiptShareDialog({
 
     logAnalyticsEvent(ANALYTICS_EVENT.RECEIPT_SHARE, {
       tournament_id: tournamentId,
-      method: 'share',
+      method: 'link',
     });
     onOpenChange(false);
   };
@@ -208,11 +207,10 @@ function ReceiptShareDialog({
                 onClick={handleCopy}
               />
               <ShareAction
-                icon={<KakaoIcon className="size-7" />}
-                iconBackgroundClassName="bg-[#FEE500]"
-                label="채팅방에 공유"
+                icon={<LinkIconOutline className="size-6 text-text-neutral-secondary" />}
+                label="링크 공유"
                 disabled={!imageBlob}
-                onClick={handleShareToChat}
+                onClick={handleShareLink}
               />
             </div>
           </div>


### PR DESCRIPTION
## 작업 요약

- 영수증 공유 시트의 카카오 공유를 링크 공유로 교체합니다

## 작업 세부 내용

카카오 SDK 도입이 무산되어, 시안 기준으로 아이콘·라벨을 실제 동작에 맞게 정리했습니다.

기존에는 카카오 아이콘 + "채팅방에 공유" 라벨이지만 실제로는 시스템 공유 시트(Web Share API)가 떠서, 카카오톡으로 바로 갈 것처럼 보이는 문제가 있었습니다.

| 항목 | 변경 |
| --- | --- |
| 아이콘 | 카카오(노란 배경) → 링크(회색 배경) |
| 라벨 | 채팅방에 공유 → 링크 공유 |
| 애널리틱스 | `method: 'share'` → `'link'` |
| 동작 | 변경 없음 (Web Share API) |

- 링크 아이콘은 기존 에셋(`assets/icons/outline/link.svg`) 을 재사용했습니다
- `kakao.svg` 는 로그인 화면에서 계속 사용해 그대로 뒀습니다

## 연관 이슈

closes #437