### PR TITLE
design: 로그인 화면 로고 색상·구글 버튼 문구 시안 반영

### DIFF
--- a/apps/web/src/app/login/_components/LoginButtons.tsx
+++ b/apps/web/src/app/login/_components/LoginButtons.tsx
@@ -127,7 +127,7 @@ function LoginButtons({ redirect, action, showAppleLogin }: LoginButtonsProps) {
       <SocialLoginButton
         variant="google"
         icon={<GoogleIcon width={20} height={20} aria-hidden />}
-        label="구글 계정으로 시작하기"
+        label="Google로 시작하기"
         isLoading={activePendingProvider === 'google'}
         disabled={isAnyPending && activePendingProvider !== 'google'}
         onClick={handleGoogleLogin}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -33,10 +33,7 @@ async function LoginPage({ searchParams }: LoginPageProps) {
   return (
     <div className="flex min-h-dvh flex-col items-center bg-gray-50 px-4 pt-padding-top pb-10">
       <div className="mt-15 flex flex-col items-center gap-6">
-        <PikiLogo
-          aria-label="PiKi"
-          className="h-[106px] w-[146px] shrink-0 text-text-neutral-primary"
-        />
+        <PikiLogo aria-label="PiKi" className="h-[106px] w-[146px] shrink-0 text-sky-blue-400" />
         <p className="animate-in text-center body-1-bold whitespace-pre-line text-text-neutral-secondary duration-500 fade-in-0">
           {'매일 쌓여만 가던\n위시리스트가 오늘의 결정으로'}
         </p>


### PR DESCRIPTION
## 작업 요약

- 로그인 화면 PiKi 로고 색상을 하늘색으로 변경합니다
- 구글 로그인 버튼 문구를 시안 기준으로 변경합니다

## 작업 세부 내용

| 항목 | 변경 전 | 변경 후 |
| --- | --- | --- |
| 로고 색상 | `text-neutral-primary` (검정) | `sky-blue-400` (`#4DC1FF`) |
| 구글 버튼 | 구글 계정으로 시작하기 | Google로 시작하기 |

- 로고 SVG 가 `currentColor` 를 사용해 클래스 교체만으로 적용됩니다
- 시안 색상이 기존 토큰 `sky-blue-400` 과 일치해 새 색상을 추가하지 않았습니다
- Apple · 카카오 버튼 문구는 이미 시안과 동일해 변경 없습니다

## 스크린샷
<img width="481" height="855" alt="image" src="https://github.com/user-attachments/assets/e23d7c3f-d8fd-4a0b-9612-9b1ae7b8b0c4" />

## 연관 이슈

closes #439
