### PR TITLE
fix: 결승 선택 후 결과 화면 전환 시 결승 매치가 다시 보이는 문제

### DIFF
--- a/apps/web/src/app/tournament/[id]/match/_hooks/useTournament.ts
+++ b/apps/web/src/app/tournament/[id]/match/_hooks/useTournament.ts
@@ -54,6 +54,9 @@ const useTournament = ({ tournamentId, inProgress }: UseTournamentArgs) => {
   // 카드 선택 락 해제용 — 매치가 바뀌지 않는 기록 실패에서 VsSection 을 remount 시켜
   // 재선택을 가능하게 한다 (락은 useCardSelectionAnimation 내부 상태)
   const [selectionEpoch, setSelectionEpoch] = useState(0);
+  // 결승 기록 후 결과 페이지로 이동하는 동안 true — 라우팅이 끝나기 전에
+  // 방금 고른 결승 매치가 다시 그려지는 깜빡임을 막는다
+  const [isNavigatingToResult, setIsNavigatingToResult] = useState(false);
 
   // 준결승/결승 바텀시트 표시 중 재조회 없이 적용할 다음 라운드 데이터
   const pendingNextRoundRef = useRef<InProgressT | null>(null);
@@ -72,6 +75,7 @@ const useTournament = ({ tournamentId, inProgress }: UseTournamentArgs) => {
     queryClient.setQueryData(['tournament', tournamentId], next);
 
     if (next.status === 'COMPLETED') {
+      setIsNavigatingToResult(true);
       router.replace(ROUTES.TOURNAMENT_RESULT(tournamentId));
       return;
     }
@@ -134,6 +138,7 @@ const useTournament = ({ tournamentId, inProgress }: UseTournamentArgs) => {
         onSuccess: async data => {
           // 토너먼트 종료 — 캐시 정리(훅 onSuccess)까지 끝난 뒤 결과 페이지로
           if (data.completed) {
+            setIsNavigatingToResult(true);
             router.push(ROUTES.TOURNAMENT_RESULT(tournamentId));
             return;
           }
@@ -199,8 +204,11 @@ const useTournament = ({ tournamentId, inProgress }: UseTournamentArgs) => {
     isFinalRound,
     transitionStage,
     selectionEpoch,
-    /** 기록 요청 대기 중 — 다음 매치를 서버가 주므로 이 동안 스켈레톤을 노출한다 */
-    isRecordingMatch: isPostRecordMatchPending,
+    /**
+     * 기록 요청 대기 중 — 다음 매치를 서버가 주므로 이 동안 스켈레톤을 노출한다.
+     * 결과 페이지로 이동하는 중에도 유지해 방금 고른 매치가 다시 보이지 않게 한다.
+     */
+    isRecordingMatch: isPostRecordMatchPending || isNavigatingToResult,
     handleSelect,
     handleTransitionComplete,
   };


### PR DESCRIPTION
## 작업 요약

- 결승 선택 후 결과 화면으로 넘어갈 때 결승 매치가 다시 보이던 문제를 수정합니다

## 작업 세부 내용

결승에서 최종 선택을 하면 방금 고른 매치가 한 번 더 보였다가 결과 화면으로 전환됐습니다.

```
결승 선택
 → isRecordingMatch = true        → 스켈레톤
 → 서버 응답(completed) 도착      → router.push (비동기)
 → isRecordingMatch = false 복귀
 → currentMatch 는 결승 그대로     → 결승이 다시 그려짐  ← 깜빡임
 → 라우팅 완료 → 결과 화면
```

`isRecordingMatch` 가 `false` 로 돌아가는 시점과 실제 페이지 전환 사이에 공백이 있고, 그 사이 `currentMatch` 가 아직 결승을 가리켜 이전 화면이 되돌아옵니다.

이동 중 상태(`isNavigatingToResult`)를 두어 결과 페이지로 넘어갈 때까지 스켈레톤을 유지하도록 했습니다. 두 경로 모두 해당됩니다.

- 기록 응답의 `completed` 수신 (`router.push`)
- 재조회에서 `COMPLETED` 확인 (`router.replace`)

## 연관 이슈

closes #441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 결승 매치 기록 후 결과 페이지로 이동하는 동안 진행 상태가 표시됩니다.
  * 토너먼트 완료 처리부터 결과 페이지 전환까지 기록 중 상태가 안정적으로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->