### PR TITLE
feat: 홈 토너먼트 리스트 조회 조건 변경 및 쿼리 이중 호출 수정

### DIFF
--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -111,6 +111,8 @@ export const MOCK_TOURNAMENT_LIST: TournamentT[] = [
 RSC 가 prefetch 한 데이터는 클라이언트에서 그대로 하이드레이션되고 `staleTime`(60초) 안에는 다시 요청하지 않습니다. 즉 **`api.get(path, [])` 만으로는 화면이 비지 않습니다** — SSR 스텁이 준 목 데이터가 그대로 보입니다. `setSsrEmpty` 로 스텁 쪽도 비워주세요:
 
 ```ts
+import { setSsrEmpty } from '@e2e/helpers/ssrEmpty';
+
 api.get(ENDPOINTS.TOURNAMENTS, []);
 
 await setSsrEmpty(page, ENDPOINTS.TOURNAMENTS); // goto 전에

--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -106,6 +106,17 @@ export const MOCK_TOURNAMENT_LIST: TournamentT[] = [
 [`GET ${ENDPOINTS.TOURNAMENT(1)}`]: createApiSuccess(MOCK_TOURNAMENT_PENDING),
 ```
 
+#### "데이터 없음" 화면을 테스트할 때
+
+RSC 가 prefetch 한 데이터는 클라이언트에서 그대로 하이드레이션되고 `staleTime`(60초) 안에는 다시 요청하지 않습니다. 즉 **`api.get(path, [])` 만으로는 화면이 비지 않습니다** — SSR 스텁이 준 목 데이터가 그대로 보입니다. `setSsrEmpty` 로 스텁 쪽도 비워주세요:
+
+```ts
+api.get(ENDPOINTS.TOURNAMENTS, []);
+
+await setSsrEmpty(page, ENDPOINTS.TOURNAMENTS); // goto 전에
+await page.goto('/home');
+```
+
 ## 목킹 구조
 
 요청 경로별로 3겹입니다. 테스트 작성 시엔 몰라도 되지만, 구조가 궁금할 때:

--- a/apps/web/e2e/consts.ts
+++ b/apps/web/e2e/consts.ts
@@ -9,3 +9,9 @@ export const BASE_URL = 'http://localhost:3000';
 export const MOCK_API_PORT = 4010;
 
 export const MOCK_API_URL = `http://127.0.0.1:${MOCK_API_PORT}`;
+
+/**
+ * SSR 스텁이 빈 목록을 응답할 경로를 담는 쿠키 이름 (helpers/ssrEmpty.ts 참고).
+ * 스텁은 경로당 고정 응답이라, 테스트별 '데이터 없음' 은 이 쿠키로만 표현한다.
+ */
+export const SSR_EMPTY_COOKIE = 'e2e-ssr-empty';

--- a/apps/web/e2e/helpers/ssrEmpty.ts
+++ b/apps/web/e2e/helpers/ssrEmpty.ts
@@ -1,0 +1,20 @@
+import type { Page } from '@playwright/test';
+
+import { BASE_URL, SSR_EMPTY_COOKIE } from '../consts';
+
+/**
+ * 해당 경로의 SSR 응답을 빈 배열로 바꾼다 — `goto` 전에 호출.
+ *
+ * 서버 prefetch 와 클라이언트 훅의 쿼리키가 같으면 하이드레이션된 SSR 데이터가 그대로 쓰이고
+ * (staleTime 내에는 재요청 없음), page.route 목은 아예 호출되지 않는다.
+ * 따라서 'empty state' 류 테스트는 브라우저 목뿐 아니라 SSR 스텁도 비워야 한다.
+ *
+ * 쿠키는 Next 서버(serverApi 인터셉터)를 거쳐 스텁까지 전달되고 요청 단위로만 적용되므로
+ * 워커 병렬 실행에도 테스트 간 간섭이 없다.
+ */
+export const setSsrEmpty = (page: Page, ...paths: string[]) =>
+  page
+    .context()
+    .addCookies([
+      { name: SSR_EMPTY_COOKIE, value: encodeURIComponent(paths.join(',')), url: BASE_URL },
+    ]);

--- a/apps/web/e2e/setup/mockApiServer.ts
+++ b/apps/web/e2e/setup/mockApiServer.ts
@@ -47,9 +47,14 @@ const SSR_MOCK_ROUTES: Record<string, unknown> = {
   },
 };
 
-/** 테스트가 `setSsrEmpty` 로 심은 쿠키에 이 경로가 있으면 빈 목록을 응답한다 */
-const isEmptyRequested = (cookieHeader: string | undefined, pathname: string) => {
-  const cookie = cookieHeader
+/**
+ * 테스트가 `setSsrEmpty` 로 심은 쿠키에 이 경로가 있으면 빈 목록을 응답한다.
+ * 조회(GET)에만 적용한다 — 같은 경로의 POST 등 다른 메서드까지 빈 응답이 되면 안 된다.
+ */
+const isEmptyRequested = (req: http.IncomingMessage, pathname: string) => {
+  if (req.method !== 'GET') return false;
+
+  const cookie = req.headers.cookie
     ?.split(';')
     .map(part => part.trim())
     .find(part => part.startsWith(`${SSR_EMPTY_COOKIE}=`));
@@ -69,7 +74,7 @@ export const startMockApiServer = (port: number) =>
   new Promise<http.Server | null>((resolve, reject) => {
     const server = http.createServer((req, res) => {
       const pathname = new URL(req.url ?? '/', `http://127.0.0.1:${port}`).pathname;
-      const body = isEmptyRequested(req.headers.cookie, pathname)
+      const body = isEmptyRequested(req, pathname)
         ? createApiSuccess([])
         : SSR_MOCK_ROUTES[`${req.method} ${pathname}`];
 

--- a/apps/web/e2e/setup/mockApiServer.ts
+++ b/apps/web/e2e/setup/mockApiServer.ts
@@ -2,6 +2,7 @@ import http from 'node:http';
 
 import { ENDPOINTS } from '@/consts/api';
 
+import { SSR_EMPTY_COOKIE } from '../consts';
 import { createApiError, createApiSuccess } from '../helpers/apiResponse';
 import { MOCK_MEMBER_ME } from '../mocks/me';
 import {
@@ -46,6 +47,20 @@ const SSR_MOCK_ROUTES: Record<string, unknown> = {
   },
 };
 
+/** 테스트가 `setSsrEmpty` 로 심은 쿠키에 이 경로가 있으면 빈 목록을 응답한다 */
+const isEmptyRequested = (cookieHeader: string | undefined, pathname: string) => {
+  const cookie = cookieHeader
+    ?.split(';')
+    .map(part => part.trim())
+    .find(part => part.startsWith(`${SSR_EMPTY_COOKIE}=`));
+
+  if (!cookie) return false;
+
+  return decodeURIComponent(cookie.slice(SSR_EMPTY_COOKIE.length + 1))
+    .split(',')
+    .includes(pathname);
+};
+
 /**
  * 스텁 서버를 띄운다. 이미 다른 세션(UI 모드 등)이 같은 포트에 띄워둔 경우
  * null 을 반환하고 기존 서버를 재사용한다 — UI 모드를 켜둔 채 CLI 실행 시 크래시 방지.
@@ -54,7 +69,9 @@ export const startMockApiServer = (port: number) =>
   new Promise<http.Server | null>((resolve, reject) => {
     const server = http.createServer((req, res) => {
       const pathname = new URL(req.url ?? '/', `http://127.0.0.1:${port}`).pathname;
-      const body = SSR_MOCK_ROUTES[`${req.method} ${pathname}`];
+      const body = isEmptyRequested(req.headers.cookie, pathname)
+        ? createApiSuccess([])
+        : SSR_MOCK_ROUTES[`${req.method} ${pathname}`];
 
       if (!body) {
         res.writeHead(404, { 'content-type': 'application/json' });

--- a/apps/web/e2e/specs/home/home.spec.ts
+++ b/apps/web/e2e/specs/home/home.spec.ts
@@ -1,6 +1,7 @@
 import { ENDPOINTS } from '@/consts/api';
 
 import { expect, test } from '@e2e/fixtures/mockApiFixture';
+import { setSsrEmpty } from '@e2e/helpers/ssrEmpty';
 import { MOCK_GUEST_ME } from '@e2e/mocks/me';
 import { MOCK_TOURNAMENT_LIST } from '@e2e/mocks/tournament';
 
@@ -18,6 +19,8 @@ test('최근 생성한 토너먼트가 없으면 empty state가 렌더링된다'
   api.get(ENDPOINTS.TOURNAMENTS, []);
   api.get(ENDPOINTS.USER, MOCK_GUEST_ME);
 
+  /** 홈 리스트는 RSC 가 prefetch 한 데이터를 그대로 하이드레이션하므로 SSR 스텁도 비운다 */
+  await setSsrEmpty(page, ENDPOINTS.TOURNAMENTS);
   await page.goto('/home');
 
   await expect(page.getByRole('status')).toBeVisible();

--- a/apps/web/src/apis/getTournamentList.ts
+++ b/apps/web/src/apis/getTournamentList.ts
@@ -4,13 +4,13 @@ import { clientApi } from '@/apis/client';
 import { serverApi } from '@/apis/server';
 import { ENDPOINTS } from '@/consts/api';
 import type { ApiResponseT } from '@/types/api';
-import type { GetTournamentListResponseT, TournamentStatusT } from '@/types/tournament';
+import type { GetTournamentListRequestT, GetTournamentListResponseT } from '@/types/tournament';
 
-export const getTournamentList = async (status?: TournamentStatusT[], limit?: number) => {
+export const getTournamentList = async (params: GetTournamentListRequestT) => {
   if (environmentManager.isServer()) {
     const { data } = await serverApi.get<ApiResponseT<GetTournamentListResponseT>>(
       ENDPOINTS.TOURNAMENTS,
-      { params: { status, limit } }
+      { params }
     );
 
     return data.data;
@@ -18,7 +18,7 @@ export const getTournamentList = async (status?: TournamentStatusT[], limit?: nu
 
   const { data } = await clientApi.get<ApiResponseT<GetTournamentListResponseT>>(
     ENDPOINTS.TOURNAMENTS,
-    { params: { status, limit } }
+    { params }
   );
   return data.data;
 };

--- a/apps/web/src/app/archive/tournament/_components/TournamentHistoryList.tsx
+++ b/apps/web/src/app/archive/tournament/_components/TournamentHistoryList.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 function TournamentHistoryList({ statuses }: Props) {
-  const { tournamentListData } = useGetTournamentList(statuses);
+  const { tournamentListData } = useGetTournamentList({ status: statuses });
 
   if (tournamentListData.length === 0)
     return (

--- a/apps/web/src/app/archive/tournament/page.tsx
+++ b/apps/web/src/app/archive/tournament/page.tsx
@@ -16,10 +16,11 @@ async function ArchiveTournamentPage({ searchParams }: Props) {
   const initialTab: TournamentStatusTabT = tab === 'completed' ? 'completed' : 'ongoing';
 
   const queryClient = getQueryClient();
-  const statuses = STATUS_BY_TAB[initialTab];
+
+  const params = { status: STATUS_BY_TAB[initialTab] };
   await queryClient.prefetchQuery({
-    queryKey: ['tournamentList', statuses, null],
-    queryFn: () => getTournamentList(statuses),
+    queryKey: ['tournamentList', params],
+    queryFn: () => getTournamentList(params),
   });
 
   return (

--- a/apps/web/src/app/archive/tournament/page.tsx
+++ b/apps/web/src/app/archive/tournament/page.tsx
@@ -1,6 +1,7 @@
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 
 import { getTournamentList } from '@/apis/getTournamentList';
+import { QUERY_KEYS } from '@/consts/queryKeys';
 import { getQueryClient } from '@/utils/queryClient';
 
 import TournamentFab from './_components/TournamentFab';
@@ -19,7 +20,7 @@ async function ArchiveTournamentPage({ searchParams }: Props) {
 
   const params = { status: STATUS_BY_TAB[initialTab] };
   await queryClient.prefetchQuery({
-    queryKey: ['tournamentList', params],
+    queryKey: QUERY_KEYS.TOURNAMENT.LIST.BY_PARAMS(params),
     queryFn: () => getTournamentList(params),
   });
 

--- a/apps/web/src/app/archive/tournament/page.tsx
+++ b/apps/web/src/app/archive/tournament/page.tsx
@@ -18,7 +18,7 @@ async function ArchiveTournamentPage({ searchParams }: Props) {
   const queryClient = getQueryClient();
   const statuses = STATUS_BY_TAB[initialTab];
   await queryClient.prefetchQuery({
-    queryKey: ['tournamentList', statuses],
+    queryKey: ['tournamentList', statuses, null],
     queryFn: () => getTournamentList(statuses),
   });
 

--- a/apps/web/src/app/home/_components/tournament-list/client.tsx
+++ b/apps/web/src/app/home/_components/tournament-list/client.tsx
@@ -5,7 +5,7 @@ import TournamentCard from '@/components/tournament-card';
 import { useGetTournamentList } from '@/hooks/useGetTournamentList';
 
 function TournamentListClient() {
-  const { tournamentListData } = useGetTournamentList([], 3);
+  const { tournamentListData } = useGetTournamentList({ limit: 3, ownedOnly: true });
 
   if (tournamentListData.length === 0)
     return (

--- a/apps/web/src/app/home/_components/tournament-list/client.tsx
+++ b/apps/web/src/app/home/_components/tournament-list/client.tsx
@@ -3,14 +3,9 @@
 import TournamentEmptyState from '@/components/common/tournament-empty-state';
 import TournamentCard from '@/components/tournament-card';
 import { useGetTournamentList } from '@/hooks/useGetTournamentList';
-import type { TournamentStatusT } from '@/types/tournament';
 
-type Props = {
-  statuses: TournamentStatusT[];
-};
-
-function TournamentListClient({ statuses }: Props) {
-  const { tournamentListData } = useGetTournamentList(statuses, 3);
+function TournamentListClient() {
+  const { tournamentListData } = useGetTournamentList([], 3);
 
   if (tournamentListData.length === 0)
     return (

--- a/apps/web/src/app/home/_components/tournament-list/index.tsx
+++ b/apps/web/src/app/home/_components/tournament-list/index.tsx
@@ -6,19 +6,16 @@ import { getTournamentList } from '@/apis/getTournamentList';
 import { ChevronForwardIconFill } from '@/assets/icons';
 import TournamentCardSkeleton from '@/components/tournament-card/TournamentCardSkeleton';
 import { ROUTES } from '@/consts/route';
-import type { TournamentStatusT } from '@/types/tournament';
 import { getQueryClient } from '@/utils/queryClient';
 
 import TournamentListClient from './client';
-
-const TOURNAMENT_LIST_STATUS: TournamentStatusT[] = ['PENDING', 'IN_PROGRESS'];
 
 function TournamentList() {
   const queryClient = getQueryClient();
 
   queryClient.prefetchQuery({
-    queryKey: ['tournamentList', TOURNAMENT_LIST_STATUS],
-    queryFn: () => getTournamentList(TOURNAMENT_LIST_STATUS),
+    queryKey: ['tournamentList', [], 3],
+    queryFn: () => getTournamentList([], 3),
   });
 
   return (
@@ -40,7 +37,7 @@ function TournamentList() {
             </>
           }
         >
-          <TournamentListClient statuses={TOURNAMENT_LIST_STATUS} />
+          <TournamentListClient />
         </Suspense>
       </section>
     </HydrationBoundary>

--- a/apps/web/src/app/home/_components/tournament-list/index.tsx
+++ b/apps/web/src/app/home/_components/tournament-list/index.tsx
@@ -14,8 +14,8 @@ function TournamentList() {
   const queryClient = getQueryClient();
 
   queryClient.prefetchQuery({
-    queryKey: ['tournamentList', [], 3],
-    queryFn: () => getTournamentList([], 3),
+    queryKey: ['tournamentList', { limit: 3, ownedOnly: true }],
+    queryFn: () => getTournamentList({ limit: 3, ownedOnly: true }),
   });
 
   return (

--- a/apps/web/src/app/home/_components/tournament-list/index.tsx
+++ b/apps/web/src/app/home/_components/tournament-list/index.tsx
@@ -5,6 +5,7 @@ import { Suspense } from 'react';
 import { getTournamentList } from '@/apis/getTournamentList';
 import { ChevronForwardIconFill } from '@/assets/icons';
 import TournamentCardSkeleton from '@/components/tournament-card/TournamentCardSkeleton';
+import { QUERY_KEYS } from '@/consts/queryKeys';
 import { ROUTES } from '@/consts/route';
 import { getQueryClient } from '@/utils/queryClient';
 
@@ -14,7 +15,7 @@ function TournamentList() {
   const queryClient = getQueryClient();
 
   queryClient.prefetchQuery({
-    queryKey: ['tournamentList', { limit: 3, ownedOnly: true }],
+    queryKey: QUERY_KEYS.TOURNAMENT.LIST.BY_PARAMS({ limit: 3, ownedOnly: true }),
     queryFn: () => getTournamentList({ limit: 3, ownedOnly: true }),
   });
 

--- a/apps/web/src/consts/queryKeys.ts
+++ b/apps/web/src/consts/queryKeys.ts
@@ -1,0 +1,13 @@
+import type { GetTournamentListRequestT } from '@/types/tournament';
+
+export const QUERY_KEYS = {
+  /** 토너먼트 */
+  TOURNAMENT: {
+    /** 토너먼트 리스트 */
+    LIST: {
+      ALL: ['tournamentList'] as const,
+      BY_PARAMS: (params: GetTournamentListRequestT) =>
+        [...QUERY_KEYS.TOURNAMENT.LIST.ALL, params] as const,
+    },
+  },
+};

--- a/apps/web/src/hooks/useDeleteTournament.ts
+++ b/apps/web/src/hooks/useDeleteTournament.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 import { deleteTournament } from '@/apis/deleteTournament';
+import { QUERY_KEYS } from '@/consts/queryKeys';
 
 export const useDeleteTournament = (tournamentId: number) => {
   const queryClient = useQueryClient();
@@ -9,7 +10,7 @@ export const useDeleteTournament = (tournamentId: number) => {
   const { mutate: deleteTournamentMutation, isPending: isDeleteTournamentPending } = useMutation({
     mutationFn: () => deleteTournament(tournamentId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['tournamentList'] });
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.TOURNAMENT.LIST.ALL });
       queryClient.invalidateQueries({ queryKey: ['tournament', tournamentId] });
       toast.success('토너먼트를 삭제했어요.');
     },

--- a/apps/web/src/hooks/useGetTournamentList.ts
+++ b/apps/web/src/hooks/useGetTournamentList.ts
@@ -1,12 +1,12 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getTournamentList } from '@/apis/getTournamentList';
-import type { TournamentStatusT } from '@/types/tournament';
+import type { GetTournamentListRequestT } from '@/types/tournament';
 
-export const useGetTournamentList = (status: TournamentStatusT[] = [], limit?: number) => {
+export const useGetTournamentList = (params: GetTournamentListRequestT) => {
   const { data: tournamentListData } = useSuspenseQuery({
-    queryKey: ['tournamentList', status, limit],
-    queryFn: () => getTournamentList(status, limit),
+    queryKey: ['tournamentList', params],
+    queryFn: () => getTournamentList(params),
   });
 
   return { tournamentListData };

--- a/apps/web/src/hooks/useGetTournamentList.ts
+++ b/apps/web/src/hooks/useGetTournamentList.ts
@@ -1,11 +1,12 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getTournamentList } from '@/apis/getTournamentList';
+import { QUERY_KEYS } from '@/consts/queryKeys';
 import type { GetTournamentListRequestT } from '@/types/tournament';
 
 export const useGetTournamentList = (params: GetTournamentListRequestT) => {
   const { data: tournamentListData } = useSuspenseQuery({
-    queryKey: ['tournamentList', params],
+    queryKey: QUERY_KEYS.TOURNAMENT.LIST.BY_PARAMS(params),
     queryFn: () => getTournamentList(params),
   });
 

--- a/apps/web/src/hooks/usePostCreateTournament.ts
+++ b/apps/web/src/hooks/usePostCreateTournament.ts
@@ -3,6 +3,7 @@ import { useRouter } from 'next/navigation';
 
 import { postCreateTournament } from '@/apis/postCreateTournament';
 import { ANALYTICS_EVENT } from '@/consts/analytics';
+import { QUERY_KEYS } from '@/consts/queryKeys';
 import { ROUTES } from '@/consts/route';
 import { logAnalyticsEvent } from '@/utils/analytics';
 
@@ -16,7 +17,7 @@ export const usePostCreateTournament = () => {
       onSuccess: ({ tournamentId }) => {
         logAnalyticsEvent(ANALYTICS_EVENT.TOURNAMENT_CREATE, { tournament_id: tournamentId });
         // 홈의 진행 중인 토너먼트 리스트 갱신
-        queryClient.invalidateQueries({ queryKey: ['tournamentList'] });
+        queryClient.invalidateQueries({ queryKey: QUERY_KEYS.TOURNAMENT.LIST.ALL });
         router.push(ROUTES.TOURNAMENT_CREATE(tournamentId));
       },
     });

--- a/apps/web/src/types/tournament.ts
+++ b/apps/web/src/types/tournament.ts
@@ -24,6 +24,13 @@ export type TournamentRankingT = TournamentItemT & {
   rank: number;
 };
 
+export type GetTournamentListRequestT = {
+  status?: TournamentStatusT[];
+  limit?: number;
+  /** 내가 만든 토너먼트만 조회 */
+  ownedOnly?: boolean;
+};
+
 export type GetTournamentListResponseT = {
   tournamentId: number;
   name: string;


### PR DESCRIPTION
## 작업 요약

- 홈 토너먼트 리스트가 진행 상태와 무관하게 최근 3개를 보여주도록 바꾸고, 내 토너먼트 페이지 진입 시 같은 데이터를 두 번 요청하던 문제를 해결했습니다.

## 작업 내용

- 홈 토너먼트 리스트에서 `PENDING`/`IN_PROGRESS` 상태 필터를 제거하고 limit 3으로만 조회 — 서버 프리페치와 클라이언트 컴포넌트 양쪽에서 statuses prop을 걷어냄
- 내 토너먼트 페이지 프리페치 쿼리 키에 limit 자리(`null`)를 추가해 `useGetTournamentList`의 키(`['tournamentList', statuses, limit]`)와 일치시킴 — 키가 어긋나 SSR 프리페치 결과를 못 쓰고 클라이언트에서 재요청하던 동작 제거

## 스크린샷

<img width="479" height="794" alt="image" src="https://github.com/user-attachments/assets/d7bc4d10-5801-48ce-852b-31d4cb6340eb" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **변경 사항**
  * 홈 화면에 내가 생성한 토너먼트만 최대 3개까지 표시됩니다.
  * 토너먼트 목록과 보관된 토너먼트 목록의 상태 및 조회 조건이 일관되게 적용됩니다.
  * 토너먼트 목록 조회 조건에 상태, 표시 개수, 생성자 기준을 지정할 수 있도록 개선되었습니다.
  * 토너먼트 생성 또는 삭제 후 목록이 최신 상태로 갱신됩니다.
* **테스트**
  * 토너먼트 목록이 비어 있는 경우의 화면 테스트가 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->