### PR TITLE
fix: 홈 최근 토너먼트를 전체 조회로 변경 및 empty state 문구 수정

### DIFF
--- a/apps/web/src/app/home/_components/tournament-list/client.tsx
+++ b/apps/web/src/app/home/_components/tournament-list/client.tsx
@@ -5,7 +5,7 @@ import TournamentCard from '@/components/tournament-card';
 import { useGetTournamentList } from '@/hooks/useGetTournamentList';
 
 function TournamentListClient() {
-  const { tournamentListData } = useGetTournamentList({ limit: 3, ownedOnly: true });
+  const { tournamentListData } = useGetTournamentList({ limit: 3 });
 
   if (tournamentListData.length === 0)
     return (

--- a/apps/web/src/app/home/_components/tournament-list/index.tsx
+++ b/apps/web/src/app/home/_components/tournament-list/index.tsx
@@ -15,8 +15,8 @@ function TournamentList() {
   const queryClient = getQueryClient();
 
   queryClient.prefetchQuery({
-    queryKey: QUERY_KEYS.TOURNAMENT.LIST.BY_PARAMS({ limit: 3, ownedOnly: true }),
-    queryFn: () => getTournamentList({ limit: 3, ownedOnly: true }),
+    queryKey: QUERY_KEYS.TOURNAMENT.LIST.BY_PARAMS({ limit: 3 }),
+    queryFn: () => getTournamentList({ limit: 3 }),
   });
 
   return (

--- a/apps/web/src/components/common/tournament-empty-state/index.tsx
+++ b/apps/web/src/components/common/tournament-empty-state/index.tsx
@@ -15,10 +15,8 @@ function TournamentEmptyState({ variant }: TournamentEmptyStateProps) {
     <div className={tournamentEmptyStateStyles({ variant })} role="status">
       <BasketEmptyIcon className={tournamentEmptyStateIconStyles({ variant })} aria-hidden />
       <div className={tournamentEmptyStateTextGroupStyles({ variant })}>
-        <p className={tournamentEmptyStateTitleStyles({ variant })}>
-          최근 생성한 토너먼트가 없어요
-        </p>
-        <p className="body-1-medium text-center text-text-neutral-tertiary">
+        <p className={tournamentEmptyStateTitleStyles({ variant })}>최근 토너먼트가 없어요</p>
+        <p className="text-center body-1-medium text-text-neutral-tertiary">
           새 토너먼트를 만들거나
           <br />
           초대를 받아 시작해보세요.

--- a/apps/web/src/types/tournament.ts
+++ b/apps/web/src/types/tournament.ts
@@ -31,8 +31,6 @@ export type GetTournamentListRequestT = {
   /** 플레이 유형 필터 (SOLO · SOCIAL). 생략 시 전체이며 status 와 AND 로 걸린다. */
   playType?: TournamentPlayTypeT;
   limit?: number;
-  /** 내가 만든 토너먼트만 조회 */
-  ownedOnly?: boolean;
 };
 
 export type GetTournamentListResponseT = {


### PR DESCRIPTION
## 작업 요약

- 홈의 최근 토너먼트 목록이 내가 만든 것만 보여주던 제약을 없애고, 초대받아 참여한 토너먼트까지 모두 보이도록 바꿨습니다.

## 작업 내용

- 홈 토너먼트 리스트 조회에서 `ownedOnly` 파라미터를 제거 — 서버 프리페치(쿼리 키·쿼리 함수)와 클라이언트 컴포넌트 양쪽에서 걷어내고, 더 쓰이는 곳이 없어 `GetTournamentListRequestT` 타입에서도 필드를 삭제
- 토너먼트 empty state 문구를 `최근 생성한 토너먼트가 없어요` → `최근 토너먼트가 없어요` 로 수정 — 생성 여부와 무관한 목록이 되었으므로 '생성한' 한정을 제거
- 참고: `TournamentEmptyState` 는 공통 컴포넌트라 문구 변경이 토너먼트 히스토리(`/archive/tournament`)에도 함께 반영됩니다.

## 스크린샷

<img width="484" height="791" alt="image" src="https://github.com/user-attachments/assets/983f955b-b80d-4caf-9494-4adc07e55936" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - 홈 화면에서 소유 여부와 관계없이 최근 토너먼트 최대 3개를 표시합니다.
  - 토너먼트가 없을 때 안내 문구가 “최근 토너먼트가 없어요”로 간결하게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->