### PR TITLE
feat: 헤더 알림 뱃지를 개수 표시로 변경

### DIFF
--- a/apps/web/src/components/header/AlarmHeaderIcon.tsx
+++ b/apps/web/src/components/header/AlarmHeaderIcon.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 
 import { useGetNotifications } from '@/app/notification/_hooks/useGetNotifications';
-import { NotificationBadgeIconFill, NotificationIconFill } from '@/assets/icons/fill';
+import { NotificationIconFill } from '@/assets/icons/fill';
 import { ROUTES } from '@/consts/route';
 import { cn } from '@/utils/cn';
 
@@ -12,20 +12,34 @@ type AlarmHeaderIconProps = {
   onClick?: () => void;
 };
 
+const MAX_DISPLAY_COUNT = 99;
+
 function AlarmHeaderIcon({ className, onClick }: AlarmHeaderIconProps) {
   const { unreadCount } = useGetNotifications();
+
+  const hasUnread = unreadCount > 0;
+  const isOverflow = unreadCount > MAX_DISPLAY_COUNT;
+  const displayCount = isOverflow ? `${MAX_DISPLAY_COUNT}+` : unreadCount;
 
   return (
     <Link
       href={ROUTES.NOTIFICATION}
-      aria-label="알림"
-      className={cn('cursor-pointer p-[3px]', className)}
+      aria-label={hasUnread ? `알림 ${unreadCount}개 안 읽음` : '알림'}
+      className={cn('relative cursor-pointer p-[3px]', className)}
       onClick={onClick}
     >
-      {unreadCount > 0 ? (
-        <NotificationBadgeIconFill className="size-6 text-icon-neutral-secondary" />
-      ) : (
-        <NotificationIconFill className="size-6 text-icon-neutral-secondary" />
+      <NotificationIconFill className="size-6 text-icon-neutral-secondary" />
+
+      {hasUnread && (
+        <span
+          aria-hidden
+          className={cn(
+            'absolute bottom-4 flex h-4.5 min-w-4.5 items-center justify-center rounded-full bg-red-500 px-1.25 text-[12px] leading-none text-white',
+            isOverflow ? 'left-[calc(50%+5px)] -translate-x-1/2' : 'left-3'
+          )}
+        >
+          {displayCount}
+        </span>
       )}
     </Link>
   );


### PR DESCRIPTION
## 작업 요약

안 읽은 알림이 있으면 빨간 점만 뜨던 것을 실제 개수 뱃지로 표시하도록 변경

## 작업 세부 내용

기존에는 안 읽은 알림이 1개든 50개든 동일한 빨간 점 하나로만 표시되어 사용자가 얼마나 밀렸는지 알 수 없었음
개수를 노출해 알림함 진입 동기를 높이고, 앱 아이콘 뱃지(이미 개수로 표시 중)와 일치시킴


### 뱃지 개수 표시
안 읽은 알림 개수를 뱃지로 표시

  | 개수 | 표시 |
  |------|------|
  | 0 | 뱃지 미노출 (기존 동작 유지) |
  | 1~99 | 숫자 그대로 |
  | 100 이상 | `99+` |

### 렌더 방식 변경
- 안 읽음 여부에 따라 아이콘을 갈아끼우던 방식 → 종 아이콘 위에 뱃지를 얹는 방식으로 변경
- 자릿수에 따라 뱃지 폭이 늘어나도(1자리 → 3자리) 아이콘 정렬이 깨지지 않도록 처리

### 접근성
- `aria-label`에 안 읽은 개수를 포함해 스크린리더에 실제 개수 전달 (예: `알림 3개 안 읽음`)

## 참고
- 개수는 이미 `useGetNotifications`의 `unreadCount`로 내려오고 있어 API 변경 없음
  (기존에는 `> 0` 여부만 사용하고 값을 버리던 상태)
- 앱 아이콘 네이티브 뱃지는 OS 자체 규칙으로 표시되므로 웹의 `99+` 규칙과 별개로 유지
## 스크린샷
| 1~99개 알림 | 100개 이상 알림 |
| :---: | :---: |
| <img width="515" alt="0~9개 알림 뱃지" src="https://github.com/user-attachments/assets/f42207e1-83df-494e-8a34-d298560268d3" /> | <img width="515" alt="10~99개 알림 뱃지" src="https://github.com/user-attachments/assets/e175955d-c696-4e3c-a84b-f1e3ea5b7613" /> |


## 연관 이슈

closes #452 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 알림 아이콘에 읽지 않은 알림 수를 숫자 배지로 표시합니다.
  * 읽지 않은 알림이 없으면 배지가 표시되지 않습니다.
  * 알림 수가 99개를 초과하면 `99+`로 표시됩니다.
  * 접근성 라벨에 읽지 않은 알림 개수가 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->