### PR TITLE
fix: 담기 마감 시각 기본값을 시트 여는 시점 기준으로 재계산

### DIFF
--- a/apps/web/src/app/tournament/[id]/_common/_hooks/useGetTournament.ts
+++ b/apps/web/src/app/tournament/[id]/_common/_hooks/useGetTournament.ts
@@ -3,10 +3,10 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { getTournament } from '../_apis/getTournament';
 
 export const useGetTournament = (tournamentId: number) => {
-  const { data: tournamentData } = useSuspenseQuery({
+  const { data: tournamentData, refetch: refetchTournament } = useSuspenseQuery({
     queryKey: ['tournament', tournamentId],
     queryFn: () => getTournament(tournamentId),
   });
 
-  return { tournamentData };
+  return { tournamentData, refetchTournament };
 };

--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteExpiresPicker.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteExpiresPicker.tsx
@@ -44,14 +44,19 @@ const from24Hour = (hour24: number): { hour12: number; meridiem: MeridiemT } => 
   return { hour12, meridiem };
 };
 
+/** 기본 마감 — 값이 없거나 이미 지났을 때 쓰는 "지금부터 30분 후" */
+const DEFAULT_EXPIRES_OFFSET_MS = 30 * 60 * 1000;
+const getDefaultExpires = () => new Date(Date.now() + DEFAULT_EXPIRES_OFFSET_MS);
+
 /** ISO 시각을 picker 의 초기 hour12/minute/meridiem 인덱스로 변환 */
 const parseInitial = (
   initialExpiresAt: string | undefined
 ): { hourIndex: number; minuteIndex: number; meridiemIndex: number } => {
   const base = (() => {
-    if (!initialExpiresAt) return new Date(Date.now() + 30 * 60 * 1000); // 기본 30분 후
+    if (!initialExpiresAt) return getDefaultExpires();
     const d = parseServerLocalDateTime(initialExpiresAt);
-    return Number.isNaN(d.getTime()) ? new Date(Date.now() + 30 * 60 * 1000) : d;
+    if (Number.isNaN(d.getTime())) return getDefaultExpires();
+    return d.getTime() <= Date.now() ? getDefaultExpires() : d;
   })();
   const { hour12, meridiem } = from24Hour(base.getHours());
   return {

--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 import { CheckIconFill, StopwatchIconFill } from '@/assets/icons/fill';
@@ -30,13 +30,13 @@ const isSameDay = (a: Date, b: Date) =>
   a.getMonth() === b.getMonth() &&
   a.getDate() === b.getDate();
 
-const formatExpiresInfo = (expiresAt: string | undefined) => {
+const formatExpiresInfo = (expiresAt: string | undefined, nowMs: number) => {
   if (!expiresAt) return null;
   const expires = parseServerLocalDateTime(expiresAt);
   if (Number.isNaN(expires.getTime())) return null;
 
-  const now = new Date();
-  const remainingMs = expires.getTime() - now.getTime();
+  const now = new Date(nowMs);
+  const remainingMs = expires.getTime() - nowMs;
   if (remainingMs <= 0) return { remainingLabel: '마감', absoluteLabel: '만료됨' };
 
   const totalMinutes = Math.floor(remainingMs / 60_000);
@@ -69,8 +69,22 @@ function InviteFriendsDialog({
   inviteUrl,
   inviteExpiresAt,
 }: InviteFriendsDialogProps) {
-  const expiresInfo = useMemo(() => formatExpiresInfo(inviteExpiresAt), [inviteExpiresAt]);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
+  // 남은 시간 라벨은 시간이 흐르면 스스로 낡는다. 열려 있는 동안만 분 단위로 기준 시각을 갱신한다.
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!open) return;
+
+    const timerId = setInterval(() => setNow(Date.now()), 60_000);
+
+    return () => clearInterval(timerId);
+  }, [open]);
+
+  const expiresInfo = useMemo(
+    () => formatExpiresInfo(inviteExpiresAt, now),
+    [inviteExpiresAt, now]
+  );
   const { patchInviteExpiryMutation, isPatchInviteExpiryPending } =
     usePatchInviteExpiry(tournamentId);
 

--- a/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantPanel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantPanel.tsx
@@ -9,6 +9,7 @@ import type { UserT } from '@/components/user-profile-group/userProfile.const';
 import { ROUTES } from '@/consts/route';
 import { cn } from '@/utils/cn';
 
+import { useGetTournament } from '../../../_common/_hooks/useGetTournament';
 import DepositCountdown from '../deposit-countdown/DepositCountdown';
 import InviteFriendsDialog from '../invite-friends/InviteFriendsDialog';
 import ParticipantChip from './ParticipantChip';
@@ -44,6 +45,7 @@ function ParticipantPanel({
   depositDeadline,
 }: ParticipantPanelProps) {
   const { id: tournamentId } = useParams<{ id: string }>();
+  const { refetchTournament } = useGetTournament(Number(tournamentId));
   const [isExpanded, setIsExpanded] = useState(false);
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
 
@@ -54,7 +56,12 @@ function ParticipantPanel({
   const inviteUrl = inviteCode ? buildInviteUrl(tournamentId, inviteCode) : '';
 
   const handleToggleExpand = () => setIsExpanded(prev => !prev);
-  const handleOpenInvite = () => setIsInviteDialogOpen(true);
+
+  const handleOpenInvite = () => {
+    // 화면을 오래 열어두면 inviteExpiresAt 이 낡아 시트가 만료된 시각을 보여준다.
+    void refetchTournament();
+    setIsInviteDialogOpen(true);
+  };
 
   return (
     <>


### PR DESCRIPTION
## 작업 요약

- 담기 마감 시각 기본값을 시트 여는 시점 기준으로 재계산합니다.
- 초대 시트를 열 때 토너먼트를 재조회해 최신 마감 시각을 반영합니다.
- 남은 시간 라벨이 시간 경과에 따라 갱신되도록 수정합니다.

## 작업 세부 내용

토너먼트를 오래 열어두면 생성 시각 기준으로 잡힌 `inviteExpiresAt` 이 낡아, 시트를 열자마자 `마감` / `만료됨` 으로 표시되던 문제입니다.

원인이 세 겹이라 각각 처리했습니다.

### 1. 시트 열 때 토너먼트 재조회

`useSuspenseQuery` 가 오래 열어둔 화면에서 stale 해져 `inviteExpiresAt` 이 과거 값이었습니다. `useGetTournament` 에서 `refetchTournament` 를 노출하고, 초대 시트를 여는 시점에 호출합니다.

```ts
const handleOpenInvite = () => {
  void refetchTournament();
  setIsInviteDialogOpen(true);
};
```

`await` 하지 않습니다. 재조회를 기다리면 느린 망에서 버튼을 눌러도 시트가 안 열리는 것처럼 보여서, 시트는 즉시 띄우고 최신 값은 뒤따라 반영되게 했습니다.

> `ParticipantPanel` 이 부모(`TournamentCreateClient`)와 같은 queryKey 를 쓰므로, 추가 네트워크 요청 없이 캐시를 공유합니다.

### 2. picker 초기값 보정

`initialExpiresAt` 이 이미 지난 값이어도 그대로 초기값으로 쓰고 있었습니다. 지난 값이면 여는 시점 +30분으로 다시 잡습니다.

```ts
return d.getTime() <= Date.now() ? getDefaultExpires() : d;
```

재조회가 늦거나 실패해도 picker 가 만료된 시각을 가리키지 않게 하는 방어선입니다.

### 3. 남은 시간 라벨 실시간 갱신

`useMemo` 의존성이 `inviteExpiresAt` 뿐이라 시간이 흘러도 라벨이 멈춰 있었습니다. 기준 시각을 상태로 분리하고, 시트가 열려 있는 동안만 1분 간격으로 갱신합니다. 닫히면 타이머를 정리합니다.

처음엔 tick 카운터로 구현했는데 린트가 이펙트 내 동기 `setState`(연쇄 렌더링)와 `useMemo` 의 불필요한 의존성을 지적했습니다. 시각 자체를 상태로 두니 둘 다 해소되고 `formatExpiresInfo` 도 순수 함수가 되어 그대로 갔습니다.

## 연관 이슈

closes #480
