### PR TITLE
fix: 토너먼트 시작 후 참여자 화면에 담기 버튼이 남던 문제

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -99,6 +99,8 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
   // ownerStarted 면 어차피 시작 흐름으로 넘어가야 하므로 마감 처리하지 않는다.
   // 협업 의도가 없는 토너먼트는 만료 자체를 무시한다.
   const isDepositClosed = !tournamentData.isOwner && !ownerStarted && isExpired && isCollaborative;
+  // 참여자는 주최자가 시작한 뒤로 담을 수 없다(서버 409). 만료 마감과 별개 사유라 따로 둔다.
+  const isAddItemBlocked = isDepositClosed || (!tournamentData.isOwner && ownerStarted);
 
   const participantImageMap = new Map(
     (pending?.participants ?? []).map(p => [p.userId, p.profileImage])
@@ -195,7 +197,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
           items={pending?.items}
           scrollToLast={scrollToLast}
           previousItemCount={previousItemCount}
-          isDepositClosed={isDepositClosed}
+          isAddItemBlocked={isAddItemBlocked}
           participantImageMap={participantImageMap}
         />
         <TournamentItemBasketStatus
@@ -218,7 +220,8 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
         />
       </div>
 
-      <Dialog open={isGetItemDialogOpen} onOpenChange={setIsGetItemDialogOpen}>
+      {/* 쿼리 파라미터로 직접 열 수 있어 + 버튼과 같은 조건으로 막는다 */}
+      <Dialog open={isGetItemDialogOpen && !isAddItemBlocked} onOpenChange={setIsGetItemDialogOpen}>
         <GetItemDialogContent type="tournament" />
       </Dialog>
 

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
@@ -18,7 +18,7 @@ type TournamentItemBasketProps = {
   basketIndex: number;
   items: TournamentPendingItemT[];
   maxHeight?: number;
-  isDepositClosed?: boolean;
+  isAddItemBlocked?: boolean;
   participantImageMap?: Map<string, string>;
 };
 
@@ -26,7 +26,7 @@ function TournamentItemBasket({
   basketIndex,
   items,
   maxHeight,
-  isDepositClosed = false,
+  isAddItemBlocked = false,
   participantImageMap,
 }: TournamentItemBasketProps) {
   const { id } = useParams<{ id: string }>();
@@ -41,7 +41,7 @@ function TournamentItemBasket({
   };
 
   const isFull = items.length >= ITEMS_PER_BASKET;
-  const showAddButton = !isDepositClosed && !isFull;
+  const showAddButton = !isAddItemBlocked && !isFull;
 
   const addSlot = showAddButton ? (
     <Dialog>

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
@@ -21,7 +21,7 @@ type TournamentItemBasketCarouselProps = {
   scrollToLast?: boolean;
   /** 위시 담기 등 재진입 시점의 기존 아이템 개수 */
   previousItemCount?: number | null;
-  isDepositClosed?: boolean;
+  isAddItemBlocked?: boolean;
   participantImageMap?: Map<string, string>;
 };
 
@@ -29,7 +29,7 @@ function TournamentItemBasketCarousel({
   items = [],
   scrollToLast = false,
   previousItemCount = null,
-  isDepositClosed = false,
+  isAddItemBlocked = false,
   participantImageMap,
 }: TournamentItemBasketCarouselProps) {
   const [carouselApi, setCarouselApi] = useState<CarouselApi>();
@@ -116,7 +116,7 @@ function TournamentItemBasketCarousel({
         <TournamentItemBasket
           basketIndex={0}
           items={items}
-          isDepositClosed={isDepositClosed}
+          isAddItemBlocked={isAddItemBlocked}
           maxHeight={basketMaxHeight}
           participantImageMap={participantImageMap}
         />
@@ -145,7 +145,7 @@ function TournamentItemBasketCarousel({
               <TournamentItemBasket
                 basketIndex={i}
                 items={items.slice(i * ITEMS_PER_BASKET, (i + 1) * ITEMS_PER_BASKET)}
-                isDepositClosed={isDepositClosed}
+                isAddItemBlocked={isAddItemBlocked}
                 maxHeight={basketMaxHeight}
                 participantImageMap={participantImageMap}
               />


### PR DESCRIPTION
## 작업 요약

- 주최자가 토너먼트를 시작한 뒤 참여자 화면에서 담기 + 버튼이 사라지도록 수정합니다.
- 쿼리 파라미터로 열리는 담기 다이얼로그도 동일하게 차단합니다.

## 작업 세부 내용

`+` 버튼 노출 조건이 `isDepositClosed` 만 보고 있었는데, 이 값은 `ownerStarted` 가 true 면 오히려 false 가 됩니다. 그래서 시작 이후에도 버튼이 남고, 누르면 409(시작 전에만 가능)만 돌아왔습니다.

### 원인 — 한 플래그가 두 의미를 겸함

```ts
const isDepositClosed = !isOwner && !ownerStarted && isExpired && isCollaborative;
```

`isDepositClosed` 는 "만료로 인한 마감" 개념이라 마감 안내 모달과 시작 버튼에서 쓰입니다. 여기서 `!ownerStarted` 는 의도된 조건입니다 — 시작했으면 마감 모달을 띄울 이유가 없기 때문입니다.

문제는 여기에 "담기 가능 여부" 판단까지 얹으면서 시작 이후 구멍이 생긴 점입니다.

### 담기 차단 플래그를 분리

기존 값을 건드리지 않고 담기 전용 플래그를 추가했습니다.

```ts
const isAddItemBlocked = isDepositClosed || (!tournamentData.isOwner && ownerStarted);
```

`isDepositClosed` 는 마감 모달·시작 버튼에서 그대로 쓰고, 바스켓 캐러셀에는 `isAddItemBlocked` 를 내려보냅니다.

### 다른 진입 경로 차단

이슈에서 확인 요청한 부분입니다. `TournamentCreateClient` 에 쿼리 파라미터(`OPEN_GET_ITEM_DIALOG`)로 열리는 담기 다이얼로그가 하나 더 있어, `+` 버튼만 숨기면 URL 로 우회됩니다. 같은 조건으로 막았습니다.

```tsx
open={isGetItemDialogOpen && !isAddItemBlocked}
```

## 스크린샷

<img width="570" height="731" alt="image" src="https://github.com/user-attachments/assets/539fb106-4936-4465-9623-1bdcc466920c" />

## 연관 이슈

closes #483