### PR TITLE
feat: 주최자 알림 토스트를 담기 화면에서만 노출

### DIFF
--- a/apps/web/src/hooks/useNotificationSSE.ts
+++ b/apps/web/src/hooks/useNotificationSSE.ts
@@ -2,12 +2,11 @@ import { fetchEventSource } from '@microsoft/fetch-event-source';
 import { WEBBRIDGE_MESSAGE_TYPE } from '@piki/core';
 import type { Query } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 
 import { ENDPOINTS } from '@/consts/api';
-import { QUERY_ACTION } from '@/consts/queryAction';
 import { QUERY_KEYS } from '@/consts/queryKeys';
 import { ROUTES } from '@/consts/route';
 import { CLIENT_TYPE } from '@/consts/webBridge';
@@ -27,38 +26,22 @@ const isWishQueryOfItem = (query: Query, itemId: number) =>
   query.queryKey[0] === 'wish' &&
   (query.state.data as { item?: { id: number } } | undefined)?.item?.id === itemId;
 
-const SCROLL_TO_LAST_QUERY = `${QUERY_ACTION.KEY}=${QUERY_ACTION.VALUE.SCROLL_TO_LAST}`;
-
 const buildToastMessage = (payload: NotificationSsePayloadT) =>
   payload.body ? `${payload.title} ${payload.body}` : payload.title;
 
-const resolveDeepLink = (payload: NotificationSsePayloadT): string | null => {
-  const { type, refId, kind, tournamentId } = payload;
-
-  switch (type) {
-    case 'TOURNAMENT_STARTED':
-      return ROUTES.TOURNAMENT_CREATE(refId);
-    case 'TOURNAMENT_JOINED':
-    case 'TOURNAMENT_ITEM_ADDED':
-      return `${ROUTES.TOURNAMENT_CREATE(refId)}?${SCROLL_TO_LAST_QUERY}`;
-    case 'ITEM_PARSING_COMPLETED':
-    case 'ITEM_PARSING_FAILED':
-      if (kind === 'TOURNAMENT' && tournamentId != null) {
-        return `${ROUTES.TOURNAMENT_CREATE(tournamentId)}?${SCROLL_TO_LAST_QUERY}`;
-      }
-      return ROUTES.WISHLIST;
-    default:
-      return null;
-  }
-};
-
 export const useNotificationSSE = (enabled: boolean) => {
-  const router = useRouter();
+  const pathname = usePathname();
   const queryClient = useQueryClient();
   const retryDelayRef = useRef(1_000);
   const abortRef = useRef<AbortController | null>(null);
   const hasConnectedRef = useRef(false);
   const authFailCountRef = useRef(0);
+
+  // 주최자 알림 토스트를 담기 화면에서만 노출하기 위해 최신 경로를 ref로 관리
+  const pathnameRef = useRef(pathname);
+  useEffect(() => {
+    pathnameRef.current = pathname;
+  }, [pathname]);
 
   useEffect(() => {
     if (!enabled) return;
@@ -169,10 +152,6 @@ export const useNotificationSSE = (enabled: boolean) => {
                 type: 'all',
               });
               const message = buildToastMessage(payload);
-              const deepLink = resolveDeepLink(payload);
-              const action = deepLink
-                ? { label: '바로가기', onClick: () => router.push(deepLink) }
-                : void 0;
 
               switch (payload.type) {
                 case 'ITEM_PARSING_COMPLETED':
@@ -199,17 +178,23 @@ export const useNotificationSSE = (enabled: boolean) => {
                       predicate: query => isWishQueryOfItem(query, payload.refId),
                     });
                   }
-                  toast.error(message, { action, duration: 5000 });
+                  toast.error(message, { duration: 5000 });
                   break;
                 case 'TOURNAMENT_STARTED':
+                  queryClient.invalidateQueries({ queryKey: ['tournament', payload.refId] });
+                  toast.info(message, { duration: 5000 });
+                  break;
                 case 'TOURNAMENT_JOINED':
                 case 'TOURNAMENT_ITEM_ADDED':
                 case 'TOURNAMENT_ITEM_DELETED':
                   queryClient.invalidateQueries({ queryKey: ['tournament', payload.refId] });
-                  toast.info(message, { action, duration: 5000 });
+
+                  if (pathnameRef.current === ROUTES.TOURNAMENT_CREATE(payload.refId)) {
+                    toast.info(message, { duration: 5000 });
+                  }
                   break;
                 default:
-                  toast.info(message, { action, duration: 5000 });
+                  toast.info(message, { duration: 5000 });
               }
             } catch {
               // malformed JSON — 무시
@@ -241,5 +226,5 @@ export const useNotificationSSE = (enabled: boolean) => {
       cancelled = true;
       abortRef.current?.abort();
     };
-  }, [enabled, router, queryClient]);
+  }, [enabled, queryClient]);
 };


### PR DESCRIPTION

## 작업 요약

- 주최자 알림 토스트를 담기 화면에서만 노출
- 토스트 바로가기 딥링크 제거 

## 작업 세부 내용

SSE 알림 토스트가 타입과 무관하게 어느 페이지에서든 노출되던 것을, 알림 성격에 맞게 범위를 조정했습니다.

### 1. 주최자가 받는 참여자 활동 알림을 담기 화면 한정으로

| 알림 | 받는 사람 | 노출 범위 |
| --- | --- | --- |
| `TOURNAMENT_JOINED` (참여자 입장) | 주최자 | 해당 토너먼트 담기 화면에서만 |
| `TOURNAMENT_ITEM_ADDED` (참여자가 후보 담음) | 주최자 | 해당 토너먼트 담기 화면에서만 |
| `TOURNAMENT_ITEM_DELETED` (참여자가 후보 뺌) | 주최자 | 해당 토너먼트 담기 화면에서만 |
| `TOURNAMENT_STARTED` (주최자가 시작) | 참여자 | 어디서든 (기존 유지) |
| 파싱 완료·실패, 그 외 전체 | - | 기존 유지 |

주최자가 받는 참여자 활동 알림은 담기 화면을 보고 있을 때만 의미가 있습니다. 다른 화면에서는 지금 하는 일과 무관해 방해가 됩니다.

- 캐시 무효화(`invalidateQueries`)는 **토스트 노출 여부와 무관하게 항상 실행**됩니다. 다른 화면에 있다가 담기 화면으로 돌아와도 목록은 최신입니다.
- 경로 비교에 `payload.refId`를 사용해 **해당 토너먼트의 담기 화면인지**까지 확인합니다. A 토너먼트를 보는 중에 B 토너먼트 알림이 뜨는 것을 막습니다.
- `TOURNAMENT_STARTED`는 놓치면 참여 기회를 잃는 알림이라 별도 case로 분리해 전역 노출을 유지했습니다.

### 2. 토스트의 `바로가기` 버튼 전면 제거

담기 화면 한정 알림은 이미 그 페이지에 있는 사용자에게 같은 페이지로 가는 버튼을 주는 셈이라 무의미해졌습니다. 이에 맞춰 전체 토스트에서 제거했습니다.

- `resolveDeepLink` 함수 삭제
- 미사용이 된 `useRouter`, `QUERY_ACTION` import 정리
- effect deps 에서 `router` 제거 → **SSE 재연결 유발 요인이 하나 줄었습니다**
- `SCROLL_TO_LAST_QUERY` 는 이 파일에서 딥링크 URL 조립에만 쓰이던 지역 상수라 함께 삭제했습니다. 원본 `QUERY_ACTION.VALUE.SCROLL_TO_LAST` 는 위시 담기 플로우에서 계속 사용하므로 유지됩니다.

## `pathname` 을 deps 대신 ref 로 참조한 이유

```ts
const pathnameRef = useRef(pathname);
useEffect(() => {
  pathnameRef.current = pathname;
}, [pathname]);
```

`pathname` 을 SSE effect 의 deps 에 넣으면 값은 최신이 되지만, **페이지 이동마다 연결이 끊겼다 재연결됩니다.**

- 이동할 때마다 서버에 새 스트림 연결
- `onopen` 의 재연결 복구 로직이 매번 실행되어 `invalidateQueries` 3개(`notifications`·`tournament`·`wishlists`)가 불필요하게 반복
- 재연결 사이 공백에 도착한 이벤트 유실 가능

`onmessage` 는 연결 시점에 한 번만 생성되는 클로저라, `pathname` 을 직접 참조하면 연결 당시 값에 고정됩니다(stale closure). 연결은 유지한 채 최신 값만 읽어야 해서 ref 를 경유합니다.



## 스크린샷
### 변경 전

https://github.com/user-attachments/assets/5fcd89bf-98b4-4f72-a107-b45b35d100c3

### 변경 후

https://github.com/user-attachments/assets/d9aad043-95fe-4e41-8e9f-ecb8999d6e8d
## 연관 이슈

closes #478


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 알림 수신 시 현재 화면에 맞춰 토스트 표시 여부가 조정됩니다.
  * 토너먼트 관련 알림이 도착하면 최신 정보가 자동으로 갱신됩니다.
  * 토너먼트 상세 화면에서 참가, 아이템 추가·삭제 알림을 확인할 수 있습니다.
  * 파싱 성공·실패 알림의 화면 이동 동작이 제거되었습니다.
  * 알림 연결 성공 후 데이터 재조회와 자동 재연결 기능은 계속 지원됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->