### PR TITLE
fix: 참여자·게스트도 전체 결과 보기를 볼 수 있도록 수정

### DIFF
--- a/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
@@ -67,8 +67,7 @@ function ResultClient({ tournamentId, isGuest = false }: ResultClientProps) {
     setIsShareDialogOpen(true);
   };
 
-  // 비회원 솔로(isRoot=false): 배너가 스크롤 마지막 — 버튼과 13px 간격
-  // 나머지: pb-40 (160px) → GroupResultEntryCard 또는 ReceiptDrawMachine과 BottomCta 버튼 사이 ~28px
+  /** 비회원 솔로는 배너가 스크롤 마지막이라 하단 여백을 줄인다 */
   const mainPb = isGuest && !tournamentData.isRoot ? 'pb-[145px]' : 'pb-40';
 
   return (
@@ -88,10 +87,6 @@ function ResultClient({ tournamentId, isGuest = false }: ResultClientProps) {
           date={date}
         />
 
-        {/*
-          비회원 유도 배너 — 게스트일 때만 노출.
-          영수증과 61px 간격: gap-3(12px) + mt-[49px](49px) = 61px.
-        */}
         {isGuest && (
           <div className="mx-5 mt-[49px]">
             <ResultGuestBanner />
@@ -99,14 +94,8 @@ function ResultClient({ tournamentId, isGuest = false }: ResultClientProps) {
         )}
 
         {/*
-          친구 토너먼트 결과보기 카드 노출 + 라우팅.
-          - 주최자·참여자·플레이 링크 게스트 모두에게 노출한다.
-            참여자와 게스트는 시작 시 본인 CLONE 이 생겨 isRoot=false 라, 이 값으로 거르면
-            주최자에게만 보인다. 전원이 전체 결과를 볼 수 있어야 하므로 조건에서 뺀다.
-          - 그룹 결과는 원본(ROOT) 단위로 집계되므로 CLONE 이면 sourceTournamentId 로 조회한다.
-          - hasGroupResult 는 완료한 CLONE 이 있는지를 뜻한다. 혼자 끝낸 토너먼트에서 누르면
-            서버가 409(TOURNAMENT-028) 를 주므로 회원·게스트 가리지 않고 이 값으로 막는다.
-          - 앱 화면이 낮게 크롭될 때도 CTA 는 항상 고정돼야 해서 스크롤 영역에 둔다.
+          전체 결과 보기 — 주최자·참여자·게스트 모두에게 노출한다.
+          hasGroupResult 가 false 면(완료한 CLONE 없음) 눌러도 서버가 409 를 주므로 숨긴다.
         */}
         {tournamentData.completed.hasGroupResult && (
           <div className="mx-5">
@@ -115,9 +104,7 @@ function ResultClient({ tournamentId, isGuest = false }: ResultClientProps) {
         )}
       </div>
 
-      {/* 하단 CTA — 저장/공유 버튼 → 홈으로 가기 순 위계, 항상 화면 하단 고정 */}
       <BottomCta hasGradient className="flex-col items-stretch gap-6.5 pb-[30px]">
-        {/* 영수증 공유 (모든 사용자) + 토너먼트 공유 (ROOT 소유자만, 플레이 링크 공유) */}
         <div className="flex gap-3">
           <Button
             variant="secondary"

--- a/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
@@ -60,6 +60,8 @@ function ResultClient({ tournamentId, isGuest = false }: ResultClientProps) {
   const result = tournamentData.completed.result;
   // 플레이 링크 공유는 ROOT 의 소유자만 가능 — CLONE 소유자(친구 초대 → CLONE 생성한 사람) 제외
   const canSharePlayLink = tournamentData.isRoot && tournamentData.isOwner;
+  // 그룹 결과는 원본(ROOT) 단위로 집계된다. CLONE 에서 보고 있으면 원본 id 로 조회해야 한다.
+  const groupResultTournamentId = tournamentData.sourceTournamentId ?? tournamentId;
 
   const handleSharePlayLink = () => {
     setIsShareDialogOpen(true);
@@ -70,7 +72,12 @@ function ResultClient({ tournamentId, isGuest = false }: ResultClientProps) {
   const mainPb = isGuest && !tournamentData.isRoot ? 'pb-[145px]' : 'pb-40';
 
   return (
-    <main className={cn('flex min-h-dvh flex-col overflow-x-hidden bg-bg-layer-basement pt-padding-top', mainPb)}>
+    <main
+      className={cn(
+        'flex min-h-dvh flex-col overflow-x-hidden bg-bg-layer-basement pt-padding-top',
+        mainPb
+      )}
+    >
       <Header center="토너먼트 결과" centerClassName="heading-1-bold" />
 
       <div className="mx-auto mt-4 flex min-h-0 w-full max-w-120 flex-1 flex-col gap-3">
@@ -93,14 +100,16 @@ function ResultClient({ tournamentId, isGuest = false }: ResultClientProps) {
 
         {/*
           친구 토너먼트 결과보기 카드 노출 + 라우팅.
-          - ROOT 사용자(주최자 / 친구 초대 멤버) 에게만 노출.
-          - CLONE 사용자(플레이 링크 게스트)는 숨긴다.
+          - 주최자·참여자·플레이 링크 게스트 모두에게 노출한다.
+            참여자와 게스트는 시작 시 본인 CLONE 이 생겨 isRoot=false 라, 이 값으로 거르면
+            주최자에게만 보인다. 전원이 전체 결과를 볼 수 있어야 하므로 조건에서 뺀다.
+          - 그룹 결과는 원본(ROOT) 단위로 집계되므로 CLONE 이면 sourceTournamentId 로 조회한다.
           - 친구 유무는 클릭 시 group-result API 응답으로 판단한다 (캐시 의존 X).
           - 앱 화면이 낮게 크롭될 때도 CTA 는 항상 고정돼야 해서 스크롤 영역에 둔다.
         */}
-        {tournamentData.isRoot && (!isGuest || tournamentData.completed.hasGroupResult) && (
+        {(!isGuest || tournamentData.completed.hasGroupResult) && (
           <div className="mx-5">
-            <GroupResultEntryCard tournamentId={tournamentId} />
+            <GroupResultEntryCard tournamentId={groupResultTournamentId} />
           </div>
         )}
       </div>

--- a/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
@@ -104,10 +104,11 @@ function ResultClient({ tournamentId, isGuest = false }: ResultClientProps) {
             참여자와 게스트는 시작 시 본인 CLONE 이 생겨 isRoot=false 라, 이 값으로 거르면
             주최자에게만 보인다. 전원이 전체 결과를 볼 수 있어야 하므로 조건에서 뺀다.
           - 그룹 결과는 원본(ROOT) 단위로 집계되므로 CLONE 이면 sourceTournamentId 로 조회한다.
-          - 친구 유무는 클릭 시 group-result API 응답으로 판단한다 (캐시 의존 X).
+          - hasGroupResult 는 완료한 CLONE 이 있는지를 뜻한다. 혼자 끝낸 토너먼트에서 누르면
+            서버가 409(TOURNAMENT-028) 를 주므로 회원·게스트 가리지 않고 이 값으로 막는다.
           - 앱 화면이 낮게 크롭될 때도 CTA 는 항상 고정돼야 해서 스크롤 영역에 둔다.
         */}
-        {(!isGuest || tournamentData.completed.hasGroupResult) && (
+        {tournamentData.completed.hasGroupResult && (
           <div className="mx-5">
             <GroupResultEntryCard tournamentId={groupResultTournamentId} />
           </div>


### PR DESCRIPTION
## 작업 요약

- 전체 결과 보기 카드를 참여자·플레이 링크 게스트에게도 노출합니다.
- CLONE 에서 진입할 때 원본 토너먼트 id 로 그룹 결과를 조회합니다.
- 혼자 끝낸 토너먼트에서는 카드를 숨깁니다.

## 작업 세부 내용

### 1. 참여자·게스트에게 노출

카드 노출 조건이 `isRoot` 를 요구해 주최자에게만 보였습니다.

참여자와 게스트는 담기 화면에서 "시작" 을 누르는 순간 **본인 CLONE 이 생성**되고 그 인스턴스로 진행합니다. 결과 화면에 도달할 때는 CLONE 이라 `isRoot=false` 가 되어 항상 걸러졌습니다.

**수정 전**

```
주최자   ROOT 에서 진행 → 결과도 ROOT   → isRoot=true   ✅ 노출
참여자   CLONE 생성 → 결과는 CLONE      → isRoot=false  ❌ 숨김
게스트   CLONE 생성 → 결과는 CLONE      → isRoot=false  ❌ 숨김
```

**수정 후** — 조건에서 `isRoot` 를 제거해 전원 노출

```
주최자   isRoot=true    ✅ 노출
참여자   isRoot=false   ✅ 노출
게스트   isRoot=false   ✅ 노출
```

### 2. 조회 대상 id 보정

그룹 결과는 원본(ROOT) 단위로 집계되므로 CLONE 에서는 원본 id 로 조회해야 합니다.

```ts
const groupResultTournamentId = tournamentData.sourceTournamentId ?? tournamentId;
```

**dev 서버로 실측 확인했습니다.** CLONE id 로 호출하면 403 이 납니다.

| id | isRoot | source | group-result |
| --- | --- | --- | --- |
| 88 | false | 84 | **403** |
| 49 | false | 46 | **403** |

보정 없이는 참여자가 카드를 눌러도 403 만 나옵니다.

### 3. 혼자 끝낸 토너먼트는 숨김

`hasGroupResult` 검사가 게스트에게만 걸려 있어, 회원은 완료한 CLONE 이 없어도 카드가 보였습니다. 누르면 서버가 409 를 줍니다.

실측 결과 혼자 끝낸 토너먼트 11건 모두 `hasGroupResult=false` + group-result 409 였고, CLONE 이 있는 2건만 `true` 였습니다. 회원·게스트 구분 없이 이 값으로 막도록 바꿨습니다.

## 연관 이슈

closes #504
