### PR TITLE
fix: 친구 목록 모달의 딤 클릭·조회 실패 처리

### DIFF
--- a/apps/web/src/components/tournament-card/FriendListDialog.tsx
+++ b/apps/web/src/components/tournament-card/FriendListDialog.tsx
@@ -41,9 +41,10 @@ const toUser = (friend: FriendListItemT): UserT => ({
 
 function FriendListDialog({ open, onOpenChange, tournamentId }: FriendListDialogProps) {
   // 모달이 열렸을 때만 group-result fetch.
-  const { groupResultData, isGroupResultPending } = useGetGroupResult(tournamentId, {
-    enabled: open,
-  });
+  const { groupResultData, isGroupResultPending, isGroupResultError } = useGetGroupResult(
+    tournamentId,
+    { enabled: open }
+  );
   const { userData } = useGetMe();
   const myUserId = userData.id;
 
@@ -78,7 +79,11 @@ function FriendListDialog({ open, onOpenChange, tournamentId }: FriendListDialog
           이 토너먼트에 참여한 친구 목록입니다.
         </DialogDescription>
 
-        <FriendListBody isPending={isGroupResultPending} friends={friends} />
+        <FriendListBody
+          isPending={isGroupResultPending}
+          isError={isGroupResultError}
+          friends={friends}
+        />
       </DialogContent>
     </Dialog>
   );
@@ -86,15 +91,25 @@ function FriendListDialog({ open, onOpenChange, tournamentId }: FriendListDialog
 
 type FriendListBodyProps = {
   isPending: boolean;
+  isError: boolean;
   friends: FriendListItemT[];
 };
 
-function FriendListBody({ isPending, friends }: FriendListBodyProps) {
+function FriendListBody({ isPending, isError, friends }: FriendListBodyProps) {
   if (isPending) {
     return (
       <div className="flex h-50 items-center justify-center">
         <Spinner size={24} />
       </div>
+    );
+  }
+
+  /** 조회 실패를 빈 목록으로 뭉뚱그리면 "친구 없음" 으로 잘못 안내된다 */
+  if (isError) {
+    return (
+      <p className="py-10 text-center body-1-medium text-text-neutral-tertiary">
+        친구 목록을 불러오지 못했어요.
+      </p>
     );
   }
 

--- a/apps/web/src/components/tournament-card/MorePopover.tsx
+++ b/apps/web/src/components/tournament-card/MorePopover.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { type ComponentType, type SVGProps, useState } from 'react';
+import { type ComponentType, type MouseEvent, type SVGProps, useState } from 'react';
 
 import {
   GroupIconFill,
@@ -57,76 +57,81 @@ function MorePopover({ status, tournamentId, participantCount = 0 }: MorePopover
     router.push(ROUTES.TOURNAMENT_RESULT(tournamentId));
   };
 
+  /** 카드 전체가 Link 라 더보기 조작이 페이지 이동으로 이어지지 않게 막는다 */
+  const handleStopCardNavigation = (event: MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
   return (
-    <div
-      className="contents"
-      onClick={event => {
-        event.preventDefault();
-        event.stopPropagation();
-      }}
-    >
-      <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
-        <PopoverTrigger asChild>
-          <button type="button" aria-label="더보기" className="cursor-pointer">
-            <ThreeDotVerticalIconFill className="size-6 text-icon-neutral-secondary" />
-          </button>
-        </PopoverTrigger>
-        <PopoverContent className="p-2" align="end" alignOffset={-24}>
-          <PopoverTitle className="sr-only">더보기</PopoverTitle>
+    <>
+      {/*
+        Dialog 는 이 래퍼 밖에 둔다 — 안에 두면 딤 클릭이 stopPropagation 에 막혀 닫히지 않는다.
+      */}
+      <div className="contents" onClick={handleStopCardNavigation}>
+        <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
+          <PopoverTrigger asChild>
+            <button type="button" aria-label="더보기" className="cursor-pointer">
+              <ThreeDotVerticalIconFill className="size-6 text-icon-neutral-secondary" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="p-2" align="end" alignOffset={-24}>
+            <PopoverTitle className="sr-only">더보기</PopoverTitle>
 
-          {status === TOURNAMENT_STATUS.PENDING && (
-            <>
-              <OptionButton
-                Icon={HeartIconFill}
-                label="위시 추가하기"
-                onClick={handleAddTournamentItem}
-              />
-              <OptionButton
-                Icon={TrashIconFill}
-                label="삭제하기"
-                onClick={handleDeleteTournament}
-              />
-            </>
-          )}
+            {status === TOURNAMENT_STATUS.PENDING && (
+              <>
+                <OptionButton
+                  Icon={HeartIconFill}
+                  label="위시 추가하기"
+                  onClick={handleAddTournamentItem}
+                />
+                <OptionButton
+                  Icon={TrashIconFill}
+                  label="삭제하기"
+                  onClick={handleDeleteTournament}
+                />
+              </>
+            )}
 
-          {status === TOURNAMENT_STATUS.IN_PROGRESS && (
-            <>
-              {/*
+            {status === TOURNAMENT_STATUS.IN_PROGRESS && (
+              <>
+                {/*
                 TODO: IN_PROGRESS 참여자 API 가 추가되면 친구 목록 보기 노출.
                 현재는 group-result(COMPLETED 전용) 만 사용 가능해 데이터를 못 받으므로 미노출.
               */}
-              <OptionButton
-                disabled
-                Icon={TrashIconFill}
-                label="삭제하기"
-                onClick={handleDeleteTournament}
-              />
-            </>
-          )}
-
-          {status === TOURNAMENT_STATUS.COMPLETED && (
-            <>
-              {hasInvitedFriends && (
                 <OptionButton
-                  Icon={GroupIconFill}
-                  label="친구 목록 보기"
-                  onClick={handleViewFriendList}
+                  disabled
+                  Icon={TrashIconFill}
+                  label="삭제하기"
+                  onClick={handleDeleteTournament}
                 />
-              )}
-              <OptionButton
-                Icon={ReceiptIconFill}
-                label="결과 확인하기"
-                onClick={handleViewTournamentResult}
-              />
-              <OptionButton
-                Icon={TrashIconFill}
-                label="삭제하기"
-                onClick={handleDeleteTournament}
-              />
-            </>
-          )}
-        </PopoverContent>
-      </Popover>
+              </>
+            )}
+
+            {status === TOURNAMENT_STATUS.COMPLETED && (
+              <>
+                {hasInvitedFriends && (
+                  <OptionButton
+                    Icon={GroupIconFill}
+                    label="친구 목록 보기"
+                    onClick={handleViewFriendList}
+                  />
+                )}
+                <OptionButton
+                  Icon={ReceiptIconFill}
+                  label="결과 확인하기"
+                  onClick={handleViewTournamentResult}
+                />
+                <OptionButton
+                  Icon={TrashIconFill}
+                  label="삭제하기"
+                  onClick={handleDeleteTournament}
+                />
+              </>
+            )}
+          </PopoverContent>
+        </Popover>
+      </div>
 
       <TournamentDeleteDialog
         open={isDeleteDialogOpen}
@@ -139,7 +144,7 @@ function MorePopover({ status, tournamentId, participantCount = 0 }: MorePopover
         onOpenChange={setIsFriendListOpen}
         tournamentId={tournamentId}
       />
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## 작업 요약

- 친구 목록 모달이 딤 클릭으로 닫히도록 수정합니다.
- 조회 실패를 "친구 없음" 과 구분해 안내합니다.

## 작업 세부 내용

### 1. 딤 클릭이 차단되던 문제

`MorePopover` 의 루트 `div` 가 하위 클릭을 전부 막고 있었습니다. 카드 전체가 `<Link>` 라 더보기 조작이 페이지 이동으로 이어지지 않게 하려는 처리인데, `Dialog` 도 이 안에 있어 딤 클릭 이벤트가 함께 죽었습니다.

`Dialog` 를 래퍼 밖으로 옮겼습니다. 카드 이동 차단은 Popover 영역에만 적용됩니다.

```tsx
<>
  <div className="contents" onClick={handleStopCardNavigation}>
    <Popover>...</Popover>
  </div>

  <TournamentDeleteDialog ... />
  <FriendListDialog ... />
</>
```

`TournamentDeleteDialog` 도 같은 문제였어서 함께 옮겼습니다.

### 2. 조회 실패가 "친구 없음" 으로 표시되던 문제

`useGetGroupResult` 가 `isGroupResultError` 를 반환하는데 모달이 구독하지 않았습니다. 에러 시 `groupResultData` 가 `undefined` → 빈 배열 → "참여한 친구가 없어요" 로 떨어졌습니다.

실패 상태를 별도 문구로 분리했습니다.

```
실패 → "친구 목록을 불러오지 못했어요."
빈값 → "참여한 친구가 없어요."
```

문구는 의도적으로 일반적인 표현을 썼습니다. 실패 사유가 401·403·404·409·네트워크로 여러 갈래라 특정 사유로 단정할 수 없고, 특히 409 는 서버 응답과 실제 사유가 어긋나 있어(#504 참고) 그 위에 구체적 안내를 얹기 어렵습니다.


## 연관 이슈

closes #506
