### PR TITLE
fix: 토너먼트 시작 후 친구 초대 버튼 숨김

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -187,6 +187,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
             participants={participants}
             inviteCode={pending?.inviteCode ?? ''}
             inviteExpiresAt={pending?.inviteExpiresAt ?? ''}
+            ownerStarted={ownerStarted}
             {...(isCollaborative && !ownerStarted && !isDepositClosed && { depositDeadline })}
           />
         </div>

--- a/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantPanel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantPanel.tsx
@@ -34,6 +34,8 @@ type ParticipantPanelProps = {
   inviteExpiresAt?: string;
   /** 담기 마감 시각 — 있을 때만 타이머 노출 */
   depositDeadline?: string;
+  /** 주최자가 토너먼트를 시작했는지 — 시작 후에는 새 참여자를 받을 수 없다 */
+  ownerStarted?: boolean;
 };
 
 const PLACEHOLDER_AVATAR_COUNT = 2;
@@ -43,6 +45,7 @@ function ParticipantPanel({
   inviteCode,
   inviteExpiresAt,
   depositDeadline,
+  ownerStarted = false,
 }: ParticipantPanelProps) {
   const { id: tournamentId } = useParams<{ id: string }>();
   const { refetchTournament } = useGetTournament(Number(tournamentId));
@@ -104,14 +107,17 @@ function ParticipantPanel({
                 {participants.map(({ user, itemCount }) => (
                   <ParticipantChip key={user.id} user={user} itemCount={itemCount} />
                 ))}
-                <button
-                  type="button"
-                  onClick={handleOpenInvite}
-                  className="inline-flex size-9 cursor-pointer items-center justify-center rounded-full border border-border-neutral-muted bg-bg-layer-default"
-                  aria-label="친구 초대하기"
-                >
-                  <AddIconOutline className="size-4 text-icon-neutral-primary" />
-                </button>
+                {/* 시작 후에는 새 참여자를 받을 수 없어 초대 진입점을 숨긴다 */}
+                {!ownerStarted && (
+                  <button
+                    type="button"
+                    onClick={handleOpenInvite}
+                    className="inline-flex size-9 cursor-pointer items-center justify-center rounded-full border border-border-neutral-muted bg-bg-layer-default"
+                    aria-label="친구 초대하기"
+                  >
+                    <AddIconOutline className="size-4 text-icon-neutral-primary" />
+                  </button>
+                )}
               </div>
             </div>
           )}
@@ -144,8 +150,9 @@ function ParticipantPanel({
         </button>
       )}
 
+      {/* 시트를 열어둔 사이 주최자가 시작하면 초대가 무의미해지므로 함께 닫는다 */}
       <InviteFriendsDialog
-        open={isInviteDialogOpen}
+        open={isInviteDialogOpen && !ownerStarted}
         onOpenChange={setIsInviteDialogOpen}
         tournamentId={Number(tournamentId)}
         inviteUrl={inviteUrl}


### PR DESCRIPTION
## 작업 요약

- 토너먼트 시작 후 참여자 패널의 친구 초대 + 버튼을 숨깁니다.

## 작업 세부 내용

`+` 버튼에 노출 조건이 없어 항상 렌더되고 있었습니다. 시작 이후에는 새 참여자를 받을 수 없으므로 진입점 자체를 없앱니다.

`ParticipantPanel` 이 시작 여부를 판단할 정보를 받지 않아, 부모(`TournamentCreateClient`)가 이미 계산해 둔 `ownerStarted` 를 prop 으로 내려받도록 했습니다.

```tsx
{!ownerStarted && (
  <button onClick={handleOpenInvite} aria-label="친구 초대하기">
```

주최자·참여자 양쪽 모두 숨깁니다. 시작 후에는 서버도 초대를 받지 않습니다.

### 열려 있던 시트 처리

시트를 열어둔 사이 주최자가 시작하는 경우도 있습니다. SSE/폴링으로 `ownerStarted` 가 갱신되면 시트가 함께 닫히도록 했습니다.

```tsx
open={isInviteDialogOpen && !ownerStarted}
```

## 참고

`hasFriends` 가 false 일 때 나오는 "친구와 함께 담아보세요" 카드도 같은 `handleOpenInvite` 를 쓰지만, 혼자면 시작 시 매치 화면으로 이동해 이 카드를 볼 수 없어 범위에서 제외했습니다.

## 스크린샷

<img width="450" height="538" alt="스크린샷 2026-08-13 오전 2 37 19" src="https://github.com/user-attachments/assets/e06ae184-701d-4c43-b43c-7f323fbfec03" />

## 연관 이슈

closes #508
