### PR TITLE
fix: 시작·삭제된 토너먼트 액션이 안내 없이 실패하던 문제 정리

### DIFF
--- a/apps/web/src/apis/postTournamentItemLink.ts
+++ b/apps/web/src/apis/postTournamentItemLink.ts
@@ -1,8 +1,8 @@
-import { clientApi } from '@/apis/client';
 import { ENDPOINTS } from '@/consts/api';
 import type { ApiResponseT } from '@/types/api';
+import type { PostTournamentItemLinkResponseT } from '@/types/tournament';
 
-import type { PostTournamentItemLinkResponseT } from '../_types/tournament';
+import { clientApi } from './client';
 
 export const postTournamentItemLink = async (tournamentId: number, url: string) => {
   const { data } = await clientApi.post<ApiResponseT<PostTournamentItemLinkResponseT>>(

--- a/apps/web/src/app/tournament/[id]/_common/_hooks/useDeleteTournamentItem.ts
+++ b/apps/web/src/app/tournament/[id]/_common/_hooks/useDeleteTournamentItem.ts
@@ -36,6 +36,7 @@ export const useDeleteTournamentItem = (tournamentId: number, tournamentItemId: 
 
         /** 토너먼트가 시작된 경우 */
         if (code === ERROR_CODE.TOURNAMENT_NOT_PENDING) {
+          toast.error(getApiErrorMessage(error));
           queryClient.invalidateQueries({ queryKey: ['tournament', tournamentId] });
           if (pathname !== ROUTES.TOURNAMENT_CREATE(tournamentId))
             router.replace(ROUTES.TOURNAMENT_CREATE(tournamentId));

--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ERROR_CODE, ERROR_MESSAGE_MAP } from '@piki/core';
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -105,7 +106,7 @@ function InviteFriendsDialog({
   const handleSendInviteLink = async () => {
     /** 이미 시작된 토너먼트인 경우 */
     if (!inviteUrl) {
-      toast.error('이미 시작된 토너먼트에는 친구를 초대할 수 없어요.');
+      toast.error(ERROR_MESSAGE_MAP[ERROR_CODE.TOURNAMENT_NOT_PENDING]);
       return;
     }
 

--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
@@ -103,7 +103,11 @@ function InviteFriendsDialog({
   };
 
   const handleSendInviteLink = async () => {
-    if (!inviteUrl) return;
+    /** 이미 시작된 토너먼트인 경우 */
+    if (!inviteUrl) {
+      toast.error('이미 시작된 토너먼트에는 친구를 초대할 수 없어요.');
+      return;
+    }
 
     const result = await share({
       title: 'piki 토너먼트 초대',

--- a/apps/web/src/app/tournament/[id]/create/_hooks/usePatchInviteExpiry.ts
+++ b/apps/web/src/app/tournament/[id]/create/_hooks/usePatchInviteExpiry.ts
@@ -31,6 +31,7 @@ export const usePatchInviteExpiry = (tournamentId: number) => {
 
       /** 토너먼트가 시작된 경우 */
       if (code === ERROR_CODE.TOURNAMENT_NOT_PENDING) {
+        toast.error(getApiErrorMessage(error));
         queryClient.invalidateQueries({ queryKey: ['tournament', tournamentId] });
         return;
       }

--- a/apps/web/src/app/tournament/[id]/create/_types/tournament.ts
+++ b/apps/web/src/app/tournament/[id]/create/_types/tournament.ts
@@ -1,3 +1,0 @@
-export type PostTournamentItemLinkResponseT = {
-  tournamentItemId: number;
-};

--- a/apps/web/src/app/tournament/[id]/create/by-wish/_hooks/usePostTournamentItemsByWish.ts
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_hooks/usePostTournamentItemsByWish.ts
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
 import { PREV_ITEM_COUNT_KEY } from '@/app/tournament/[id]/create/_consts/tournamentItemBasket';
+import { QUERY_ACTION } from '@/consts/queryAction';
 import { ROUTES } from '@/consts/route';
 import { useBackWithFallback } from '@/hooks/useBackWithFallback';
 import { getApiErrorCode, isGlobalNetError } from '@/utils/apiError';
@@ -33,11 +34,19 @@ export const usePostTournamentItemsByWish = (tournamentId: number, previousItemC
 
       const code = getApiErrorCode(error);
 
-      /** 토너먼트가 시작됐거나 삭제, 존재하지 않는 경우 */
-      if (code === ERROR_CODE.TOURNAMENT_NOT_PENDING || code === ERROR_CODE.TOURNAMENT_NOT_FOUND) {
+      /** 토너먼트가 시작된 경우 */
+      if (code === ERROR_CODE.TOURNAMENT_NOT_PENDING) {
         toast.error(getApiErrorMessage(error));
         queryClient.invalidateQueries({ queryKey: ['tournament', tournamentId] });
         router.replace(ROUTES.TOURNAMENT_CREATE(tournamentId));
+        return;
+      }
+
+      /** 토너먼트가 삭제된 경우 */
+      if (code === ERROR_CODE.TOURNAMENT_NOT_FOUND) {
+        router.replace(
+          `${ROUTES.HOME}?${QUERY_ACTION.KEY}=${QUERY_ACTION.VALUE.TOURNAMENT_NOT_FOUND}`
+        );
         return;
       }
 

--- a/apps/web/src/app/tournament/[id]/create/by-wish/_hooks/usePostTournamentItemsByWish.ts
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_hooks/usePostTournamentItemsByWish.ts
@@ -35,6 +35,7 @@ export const usePostTournamentItemsByWish = (tournamentId: number, previousItemC
 
       /** 토너먼트가 시작됐거나 삭제, 존재하지 않는 경우 */
       if (code === ERROR_CODE.TOURNAMENT_NOT_PENDING || code === ERROR_CODE.TOURNAMENT_NOT_FOUND) {
+        toast.error(getApiErrorMessage(error));
         queryClient.invalidateQueries({ queryKey: ['tournament', tournamentId] });
         router.replace(ROUTES.TOURNAMENT_CREATE(tournamentId));
         return;

--- a/apps/web/src/app/tournament/[id]/item/[itemId]/_hooks/usePatchTournamentItem.ts
+++ b/apps/web/src/app/tournament/[id]/item/[itemId]/_hooks/usePatchTournamentItem.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
+import { QUERY_ACTION } from '@/consts/queryAction';
 import { ROUTES } from '@/consts/route';
 import { useBackWithFallback } from '@/hooks/useBackWithFallback';
 import type { PatchItemRequestT } from '@/types/item';
@@ -37,13 +38,18 @@ export const usePatchTournamentItem = (tournamentId: number, tournamentItemId: n
 
         const code = getApiErrorCode(error);
 
-        /** 토너먼트가 시작됐거나 삭제, 존재하지 않는 경우 */
-        if (
-          code === ERROR_CODE.TOURNAMENT_NOT_PENDING ||
-          code === ERROR_CODE.TOURNAMENT_NOT_FOUND
-        ) {
+        /** 토너먼트가 시작된 경우 */
+        if (code === ERROR_CODE.TOURNAMENT_NOT_PENDING) {
           queryClient.invalidateQueries({ queryKey: ['tournament', tournamentId] });
           router.replace(ROUTES.TOURNAMENT_CREATE(tournamentId));
+          return;
+        }
+
+        /** 토너먼트가 삭제된 경우 */
+        if (code === ERROR_CODE.TOURNAMENT_NOT_FOUND) {
+          router.replace(
+            `${ROUTES.HOME}?${QUERY_ACTION.KEY}=${QUERY_ACTION.VALUE.TOURNAMENT_NOT_FOUND}`
+          );
           return;
         }
 

--- a/apps/web/src/app/tournament/[id]/item/[itemId]/_hooks/usePatchTournamentItem.ts
+++ b/apps/web/src/app/tournament/[id]/item/[itemId]/_hooks/usePatchTournamentItem.ts
@@ -40,6 +40,7 @@ export const usePatchTournamentItem = (tournamentId: number, tournamentItemId: n
 
         /** 토너먼트가 시작된 경우 */
         if (code === ERROR_CODE.TOURNAMENT_NOT_PENDING) {
+          toast.error(getApiErrorMessage(error));
           queryClient.invalidateQueries({ queryKey: ['tournament', tournamentId] });
           router.replace(ROUTES.TOURNAMENT_CREATE(tournamentId));
           return;

--- a/apps/web/src/components/get-item-dialog/ByLinkDialog.tsx
+++ b/apps/web/src/components/get-item-dialog/ByLinkDialog.tsx
@@ -3,11 +3,11 @@
 import { useParams } from 'next/navigation';
 import { useState } from 'react';
 
-import { usePostTournamentItemLink } from '@/app/tournament/[id]/create/_hooks/usePostTournamentItemLink';
 import { LinkIconFill } from '@/assets/icons';
 import Button from '@/components/button';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/dialog';
 import Input from '@/components/input';
+import { usePostTournamentItemLink } from '@/hooks/usePostTournamentItemLink';
 import { usePostWishLink } from '@/hooks/usePostWishLink';
 import type { ItemTypeT } from '@/types/item';
 import { isGlobalNetError } from '@/utils/apiError';

--- a/apps/web/src/hooks/usePostTournamentItemLink.ts
+++ b/apps/web/src/hooks/usePostTournamentItemLink.ts
@@ -3,12 +3,11 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
+import { postTournamentItemLink } from '@/apis/postTournamentItemLink';
 import { QUERY_ACTION } from '@/consts/queryAction';
 import { ROUTES } from '@/consts/route';
 import { getApiErrorCode, getApiErrorStatus, isGlobalNetError } from '@/utils/apiError';
 import { getApiErrorMessage } from '@/utils/getApiErrorMessage';
-
-import { postTournamentItemLink } from '../_apis/postTournamentItemLink';
 
 type UsePostTournamentItemLinkOptionsT = {
   /** 입력 폼처럼 에러를 화면 안에서 안내하는 경우 false — 4xx 토스트를 끈다 */

--- a/apps/web/src/hooks/usePostTournamentItemLink.ts
+++ b/apps/web/src/hooks/usePostTournamentItemLink.ts
@@ -34,6 +34,7 @@ export const usePostTournamentItemLink = (
 
         /** 토너먼트가 시작된 경우 */
         if (code === ERROR_CODE.TOURNAMENT_NOT_PENDING) {
+          if (showErrorToast) toast.error(getApiErrorMessage(error));
           queryClient.invalidateQueries({ queryKey: ['tournament', tournamentId] });
           return;
         }

--- a/apps/web/src/hooks/usePostTournamentOCR.ts
+++ b/apps/web/src/hooks/usePostTournamentOCR.ts
@@ -29,6 +29,7 @@ export const usePostTournamentOCR = (tournamentId: number) => {
 
       /** 토너먼트가 시작된 경우 */
       if (code === ERROR_CODE.TOURNAMENT_NOT_PENDING) {
+        toast.error(getApiErrorMessage(error));
         queryClient.invalidateQueries({ queryKey: ['tournament', tournamentId] });
         return;
       }

--- a/apps/web/src/types/tournament.ts
+++ b/apps/web/src/types/tournament.ts
@@ -56,6 +56,10 @@ export type PostCreateTournamentResponseT = {
   tournamentId: number;
 };
 
+export type PostTournamentItemLinkResponseT = {
+  tournamentItemId: number;
+};
+
 /** 초대 코드 / 토너먼트 미리보기 응답 */
 export type GetInvitePreviewResponseT = {
   tournamentId: number;


### PR DESCRIPTION
## 작업 요약

- 시작된 토너먼트에 이미지로 담기·위시에서 가져오기 시 안내 토스트를 추가합니다
- 아이템 수정·삭제, 초대 마감 변경, 링크 담기의 침묵 분기에도 같은 안내를 추가합니다
- 삭제된 토너먼트에 액션 시 홈 폴백 + 안내 토스트로 동선을 통일합니다
- 공유 다이얼로그가 쓰는 usePostTournamentItemLink 훅·API를 src/hooks·src/apis로 레벨업합니다
- 초대 링크가 없는 상태에서 공유 버튼이 무반응이던 것에 안전망 토스트를 추가합니다

## 작업 세부 내용

### 1. 시작된 토너먼트 담기 안내 (#488 본편)

토너먼트가 시작된 뒤 담기를 시도하면 서버는 409(`TOURNAMENT-005`)를 내려주는데, `usePostTournamentOCR`(이미지로 담기)·`usePostTournamentItemsByWish`(위시에서 가져오기)의 `TOURNAMENT_NOT_PENDING` 분기가 **토스트 없이 early return** 하고 있었습니다. 에러 처리 정책(4xx는 빠짐없이 안내, invalidate·redirect는 그 위에 얹기)대로 분기 맨 앞에 `toast.error(getApiErrorMessage(error))`를 추가했습니다.

링크로 담기만 정상이었던 이유: `ByLinkDialog`가 `showErrorToast: false` + per-mutate `onError`로 인라인 문구를 직접 그려서 훅의 침묵 분기를 우회하고 있었습니다.

### 2. 남은 NOT_PENDING 침묵 분기 정리

같은 침묵 패턴이 있던 4곳에 안내를 추가했습니다.

- `usePostTournamentItemLink` — `showErrorToast` 옵션을 존중해 `if (showErrorToast) toast.error(...)`. 유일한 소비처(ByLinkDialog)는 인라인 안내라 이중 안내 없음
- `usePatchTournamentItem` / `useDeleteTournamentItem` / `usePatchInviteExpiry` — 토스트 추가 (기존 invalidate·redirect 동작 유지)

join 경로(`usePostJoin`·join 페이지·홈 초대 다이얼로그)는 `ALREADY_STARTED` 전용 다이얼로그로 이미 안내되고 있어 제외했습니다.

### 3. 삭제된 토너먼트 NOT_FOUND 동선 통일

`usePostTournamentItemsByWish`·`usePatchTournamentItem`은 `TOURNAMENT_NOT_FOUND`를 `NOT_PENDING`과 한 분기로 묶어 create 화면으로만 replace 했는데, create로의 소프트 네비게이션은 404 → 홈 폴백을 담당하는 `tournament/[id]/layout.tsx`(RSC)를 다시 실행시키지 않아 **삭제된 토너먼트의 stale 화면에 안내 없이 머무는** 문제가 있었습니다. 링크·이미지·삭제 훅과 동일하게 홈 replace + `?action=tournament-not-found`(루트 `QueryActionToast`가 안내 표시)로 통일하고 분기를 분리했습니다.

### 4. usePostTournamentItemLink 레벨업

`components/get-item-dialog`(홈·위시 보관함·토너먼트 create 3개 top-level 라우트 공유)가 라우트 private 훅 `app/tournament/[id]/create/_hooks/usePostTournamentItemLink`를 import하고 있어 콜로케이션 규칙에 어긋났습니다. 훅은 `src/hooks/`, API 함수는 `src/apis/`, 응답 타입은 `src/types/tournament.ts`로 이동했습니다 (OCR 훅과 동일한 배치).

### 5. 공유 버튼 안전망

`InviteFriendsDialog`의 "초대 링크 보내기"가 `inviteUrl`이 빈 값이면 침묵 early return 했습니다. 진입점 숨김·시트 자동 닫기는 #509에서 해결됐고, 여기서는 예상 못 한 경로로 시트가 열린 경우를 위한 안전망 토스트만 추가합니다.

## 스크린샷

<img width="465" height="122" alt="이미 시작한 토너먼트 - 초대 버튼 비활성화" src="https://github.com/user-attachments/assets/30242ca9-f164-43ea-ba8d-bd35af3d9ae8" />

https://github.com/user-attachments/assets/3f6c7a86-2ff9-45c8-8602-2cd50f7e4856

https://github.com/user-attachments/assets/cf06bb73-5c19-4bc7-8ab8-dd79843178cf


https://github.com/user-attachments/assets/bd2bbe4d-87f4-45e2-9571-cc4b8fc1a77e


## 연관 이슈

closes #488


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 이미 시작된 토너먼트에서 초대 링크 전송, 초대 마감 시간 변경, 아이템 추가·수정·OCR 요청이 실패할 때 오류 메시지가 토스트로 표시됩니다.
  - 삭제된 토너먼트 접근 시 상황에 맞는 안내와 함께 홈 화면으로 이동합니다.
  - 토너먼트가 아직 시작되지 않은 경우 안내 후 생성 화면으로 이동하고 관련 정보가 갱신됩니다.
  - 초대 링크가 없는 경우에도 초대할 수 없는 사유를 안내합니다.

- **개선**
  - 토너먼트 관련 오류 상황별 화면 이동과 안내가 더욱 일관되게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->