### PR TITLE
feat: 위시 아이템 INCOMPLETE 상태 대응

### DIFF
--- a/apps/web/e2e/specs/tournament/tournamentItemAdd.spec.ts
+++ b/apps/web/e2e/specs/tournament/tournamentItemAdd.spec.ts
@@ -64,7 +64,7 @@ test('위시에서 상품 4개를 가져오면 장바구니에 담긴다', async
   await expect(nextButton).toBeDisabled();
 
   for (const { item } of MOCK_WISHLIST_ENTRIES) {
-    await page.getByRole('button', { name: item.name }).click();
+    await page.getByRole('button', { name: item.name ?? '' }).click();
   }
 
   /** 담기 성공 후 재조회부터는 4개 담긴 응답 (뒤에 등록한 목이 우선 매칭) */

--- a/apps/web/src/app/archive/wish/[id]/_types/wish.ts
+++ b/apps/web/src/app/archive/wish/[id]/_types/wish.ts
@@ -20,7 +20,6 @@ type ItemT = {
       currency: null;
     }
   | {
-      /** 추출이 일부만 채운 상태 — 채운 필드만 값이 있다 */
       status: (typeof ITEM_STATUS)['INCOMPLETE'];
       name: string | null;
       imageUrl: string | null;

--- a/apps/web/src/app/archive/wish/[id]/_types/wish.ts
+++ b/apps/web/src/app/archive/wish/[id]/_types/wish.ts
@@ -20,6 +20,14 @@ type ItemT = {
       currency: null;
     }
   | {
+      /** 추출이 일부만 채운 상태 — 채운 필드만 값이 있다 */
+      status: (typeof ITEM_STATUS)['INCOMPLETE'];
+      name: string | null;
+      imageUrl: string | null;
+      price: number | null;
+      currency: string | null;
+    }
+  | {
       status: (typeof ITEM_STATUS)['READY'];
       name: string;
       imageUrl: string;

--- a/apps/web/src/app/archive/wish/_components/wish-grid/WishFailedCard.tsx
+++ b/apps/web/src/app/archive/wish/_components/wish-grid/WishFailedCard.tsx
@@ -1,13 +1,13 @@
 import { WarningIconFill } from '@/assets/icons';
 
-function WishFailedCard() {
+function WishFailedCard({ message }: { message: string }) {
   return (
     <div className="relative flex flex-col bg-black/5">
       <div className="aspect-[201/166] w-full" />
       <div className="h-[124px]" />
       <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 p-4">
         <WarningIconFill className="size-6 text-icon-neutral-secondary" />
-        <p className="body-2-semibold text-text-neutral-secondary">가져오는데 실패했어요</p>
+        <p className="body-2-semibold text-text-neutral-secondary">{message}</p>
         <p className="body-2-medium text-text-neutral-secondary underline underline-offset-[3px]">
           직접 입력하기
         </p>

--- a/apps/web/src/app/archive/wish/_components/wish-grid/index.tsx
+++ b/apps/web/src/app/archive/wish/_components/wish-grid/index.tsx
@@ -3,6 +3,7 @@ import type { MouseEvent } from 'react';
 
 import { CheckboxEmptyIconFill, CheckboxSelectedIconFill } from '@/assets/icons';
 import WishCard from '@/components/common/wish-card';
+import { ITEM_STATUS } from '@/consts/item';
 import { ROUTES } from '@/consts/route';
 import { Z_INDEX } from '@/consts/zIndex';
 import type { GetWishlistResponseT } from '@/types/wish';
@@ -29,7 +30,7 @@ function WishGrid({ items, isDeleteMode = false, selectedIds, onToggleSelect }: 
   return (
     <div className="grid grid-cols-2">
       {items.map(({ wish, item }, index) => {
-        if (item.status === 'FAILED' || item.status === 'INCOMPLETE')
+        if (item.status === ITEM_STATUS.FAILED || item.status === ITEM_STATUS.INCOMPLETE)
           return (
             <Link
               href={ROUTES.WISH_EDIT(wish.id)}
@@ -39,12 +40,14 @@ function WishGrid({ items, isDeleteMode = false, selectedIds, onToggleSelect }: 
             >
               <WishFailedCard
                 message={
-                  item.status === 'INCOMPLETE' ? '일부만 가져왔어요' : '가져오는데 실패했어요'
+                  item.status === ITEM_STATUS.INCOMPLETE
+                    ? '일부만 가져왔어요'
+                    : '가져오는데 실패했어요'
                 }
               />
             </Link>
           );
-        else if (item.status === 'PENDING' || item.status === 'PROCESSING')
+        else if (item.status === ITEM_STATUS.PENDING || item.status === ITEM_STATUS.PROCESSING)
           return <WishProcessingCard key={wish.id} />;
 
         if (isDeleteMode) {

--- a/apps/web/src/app/archive/wish/_components/wish-grid/index.tsx
+++ b/apps/web/src/app/archive/wish/_components/wish-grid/index.tsx
@@ -29,7 +29,7 @@ function WishGrid({ items, isDeleteMode = false, selectedIds, onToggleSelect }: 
   return (
     <div className="grid grid-cols-2">
       {items.map(({ wish, item }, index) => {
-        if (item.status === 'FAILED')
+        if (item.status === 'FAILED' || item.status === 'INCOMPLETE')
           return (
             <Link
               href={ROUTES.WISH_EDIT(wish.id)}
@@ -37,7 +37,11 @@ function WishGrid({ items, isDeleteMode = false, selectedIds, onToggleSelect }: 
               data-scroll-anchor-id={wish.id}
               onClick={event => handleCardClick(event, wish.id)}
             >
-              <WishFailedCard />
+              <WishFailedCard
+                message={
+                  item.status === 'INCOMPLETE' ? '일부만 가져왔어요' : '가져오는데 실패했어요'
+                }
+              />
             </Link>
           );
         else if (item.status === 'PENDING' || item.status === 'PROCESSING')

--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 
 import { Dialog } from '@/components/dialog';
 import GetItemDialogContent from '@/components/get-item-dialog';
+import { ITEM_STATUS } from '@/consts/item';
 import { QUERY_ACTION } from '@/consts/queryAction';
 import { useGetMe } from '@/hooks/useGetMe';
 import { useQueryAction } from '@/hooks/useQueryAction';
@@ -74,6 +75,10 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
   // 아이템 파싱 중이면 SSE 로 실시간 업데이트 (연결 실패 시 polling fallback).
   const hasPendingItem = hasParsingItems(pending?.items ?? []);
   useSSEFallback(['tournament', tournamentId], hasPendingItem);
+
+  const hasUnfinishedItem = (pending?.items ?? []).some(
+    item => item.status === ITEM_STATUS.FAILED || item.status === ITEM_STATUS.INCOMPLETE
+  );
 
   // 주최자가 ROOT 를 시작한 후(ownerStarted=true) 에는 초대 기간이 이미 종료된 상태라
   // inviteExpiresAt 이 null 이고 담기 마감 카운트다운도 의미 없다.
@@ -211,9 +216,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
         <TournamentStartButton
           count={pending?.items.length ?? 0}
           tournamentId={tournamentId}
-          hasUnreadyItem={
-            hasPendingItem || (pending?.items.some(item => item.status === 'FAILED') ?? false)
-          }
+          hasUnreadyItem={hasPendingItem || hasUnfinishedItem}
           hasFriends={hasFriends}
           isWaitingForOwnerStart={isWaitingForOwnerStart}
           isDepositClosed={isDepositClosed}

--- a/apps/web/src/app/tournament/[id]/create/_components/product-image/index.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/product-image/index.tsx
@@ -4,6 +4,7 @@ import type { ImageProps } from 'next/image';
 import type { ReactNode } from 'react';
 
 import BaseImage from '@/components/base-image';
+import { ITEM_STATUS } from '@/consts/item';
 import type { ItemStatusT } from '@/types/item';
 import { cn } from '@/utils/cn';
 
@@ -51,8 +52,11 @@ function ProductImage({
         className={containerClass}
         {...(!fill ? { style: { width: dimension, height: dimension } } : {})}
       >
-        {(parsingStatus === 'PENDING' || parsingStatus === 'PROCESSING') && <LoadingFallback />}
-        {parsingStatus === 'FAILED' &&
+        {(parsingStatus === ITEM_STATUS.PENDING || parsingStatus === ITEM_STATUS.PROCESSING) && (
+          <LoadingFallback />
+        )}
+        {/* INCOMPLETE 는 이미지를 못 건진 경우라 FAILED 와 같은 빈 이미지 자리를 쓴다 (디자인 확인 전 임시) */}
+        {(parsingStatus === ITEM_STATUS.FAILED || parsingStatus === ITEM_STATUS.INCOMPLETE) &&
           (size === 'lg' ? <LgErrorFallback radius={radius} /> : <SmErrorFallback />)}
       </div>
     );

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentBasketItem.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentBasketItem.tsx
@@ -28,7 +28,8 @@ function TournamentBasketItem({
     <div
       className={cn(
         'relative aspect-square w-full',
-        (item.status === 'READY' || item.status === 'FAILED') && 'cursor-pointer'
+        (item.status === 'READY' || item.status === 'FAILED' || item.status === 'INCOMPLETE') &&
+          'cursor-pointer'
       )}
       onClick={onClick}
     >

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentBasketItem.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentBasketItem.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 
 import ProductImage from '@/app/tournament/[id]/create/_components/product-image';
+import { ITEM_STATUS } from '@/consts/item';
 import { Z_INDEX } from '@/consts/zIndex';
 import { useGetMe } from '@/hooks/useGetMe';
 import { cn } from '@/utils/cn';
@@ -28,7 +29,9 @@ function TournamentBasketItem({
     <div
       className={cn(
         'relative aspect-square w-full',
-        (item.status === 'READY' || item.status === 'FAILED' || item.status === 'INCOMPLETE') &&
+        (item.status === ITEM_STATUS.READY ||
+          item.status === ITEM_STATUS.FAILED ||
+          item.status === ITEM_STATUS.INCOMPLETE) &&
           'cursor-pointer'
       )}
       onClick={onClick}

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import AddIcon from '@/assets/icons/fill/add.svg';
 import { Dialog, DialogTrigger } from '@/components/dialog';
 import GetItemDialogContent from '@/components/get-item-dialog';
+import { ITEM_STATUS } from '@/consts/item';
 import { ROUTES } from '@/consts/route';
 
 import type { TournamentPendingItemT } from '../../../_common/_types/tournamentResponse';
@@ -76,7 +77,7 @@ function TournamentItemBasket({
           <div className="grid w-[45%] grid-cols-2 gap-x-6 gap-y-5 pt-[20%]">
             {addSlot}
             {items.map((item, index) => {
-              if (item.status === 'READY') {
+              if (item.status === ITEM_STATUS.READY || item.status === ITEM_STATUS.INCOMPLETE) {
                 return (
                   <Link
                     key={item.tournamentItemId}

--- a/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
@@ -37,7 +37,11 @@ function ByWishContent({ tournamentId }: ByWishContentProps) {
   const existingItemIds = new Set(pending?.items.map(i => i.itemId) ?? []);
   const items = wishlistData.filter(
     ({ item }) =>
-      item.status !== 'FAILED' && item.status !== 'PROCESSING' && !existingItemIds.has(item.id)
+      item.status !== 'FAILED' &&
+      item.status !== 'PROCESSING' &&
+      /** 서버가 미완성 아이템의 토너먼트 출전을 막는다 */
+      item.status !== 'INCOMPLETE' &&
+      !existingItemIds.has(item.id)
   );
 
   const isWishlistLoaded = !hasNextPage && !isFetchingNextPage;

--- a/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_components/ByWishContent.tsx
@@ -7,6 +7,7 @@ import BottomCta from '@/components/bottom-cta';
 import Button from '@/components/button';
 import { Header, HeaderIcon } from '@/components/header';
 import TournamentErrorDialog from '@/components/tournament-error-dialog';
+import { ITEM_STATUS } from '@/consts/item';
 import { ROUTES } from '@/consts/route';
 import { useBackWithFallback } from '@/hooks/useBackWithFallback';
 import { useGetWishlist } from '@/hooks/useGetWishlist';
@@ -37,10 +38,9 @@ function ByWishContent({ tournamentId }: ByWishContentProps) {
   const existingItemIds = new Set(pending?.items.map(i => i.itemId) ?? []);
   const items = wishlistData.filter(
     ({ item }) =>
-      item.status !== 'FAILED' &&
-      item.status !== 'PROCESSING' &&
-      /** 서버가 미완성 아이템의 토너먼트 출전을 막는다 */
-      item.status !== 'INCOMPLETE' &&
+      item.status !== ITEM_STATUS.FAILED &&
+      item.status !== ITEM_STATUS.PROCESSING &&
+      item.status !== ITEM_STATUS.INCOMPLETE &&
       !existingItemIds.has(item.id)
   );
 

--- a/apps/web/src/app/tournament/[id]/create/by-wish/_components/WishSelectCard.tsx
+++ b/apps/web/src/app/tournament/[id]/create/by-wish/_components/WishSelectCard.tsx
@@ -2,8 +2,8 @@ import { CheckboxEmptyIconFill, CheckboxSelectedIconFill } from '@/assets/icons'
 import WishCard from '@/components/common/wish-card';
 
 type WishSelectCardProps = {
-  name: string;
-  price: number;
+  name: string | null;
+  price: number | null;
   imageUrl: string | null;
   sourcePlatform?: string | null;
   isSelected: boolean;

--- a/apps/web/src/app/tournament/[id]/item/[itemId]/_types/tournamentItem.ts
+++ b/apps/web/src/app/tournament/[id]/item/[itemId]/_types/tournamentItem.ts
@@ -19,6 +19,12 @@ export type GetTournamentItemResponseT = {
       price?: undefined;
     }
   | {
+      status: (typeof ITEM_STATUS)['INCOMPLETE'];
+      name?: string;
+      imageUrl?: string;
+      price?: number;
+    }
+  | {
       status: (typeof ITEM_STATUS)['READY'];
       name: string;
       imageUrl: string;

--- a/apps/web/src/components/common/wish-card/index.tsx
+++ b/apps/web/src/components/common/wish-card/index.tsx
@@ -4,8 +4,8 @@ import Skeleton from '@/components/skeleton';
 import formatPrice from '@/utils/formatPrice';
 
 type WishCardProps = {
-  name: string;
-  price: number;
+  name: string | null;
+  price: number | null;
   imageUrl: string | null;
   sourcePlatform?: string | null;
   preload?: boolean;
@@ -19,7 +19,7 @@ function WishCard({ name, price, imageUrl, sourcePlatform, preload = false }: Wi
         {imageUrl ? (
           <BaseImage
             src={imageUrl}
-            alt={name}
+            alt={name ?? ''}
             sizes="(max-width: 480px) calc(100vw - 40px - 8px), 216px"
             preload={preload}
             loadingFallback={<Skeleton className="absolute inset-0 rounded-none" />}
@@ -40,7 +40,9 @@ function WishCard({ name, price, imageUrl, sourcePlatform, preload = false }: Wi
       {/* 상품명 + 가격 + 커머스칩 */}
       <div className="flex h-[124px] flex-col items-start gap-2.5 self-stretch p-4">
         <div className="flex flex-col gap-1 self-stretch">
-          <p className="line-clamp-2 self-stretch body-2-medium text-text-neutral-primary">{name}</p>
+          <p className="line-clamp-2 self-stretch body-2-medium text-text-neutral-primary">
+            {name}
+          </p>
           <p className="body-2-semibold text-text-neutral-primary">{formatPrice(String(price))}</p>
         </div>
         {sourcePlatform && (

--- a/apps/web/src/consts/item.ts
+++ b/apps/web/src/consts/item.ts
@@ -2,5 +2,7 @@ export const ITEM_STATUS = {
   PENDING: 'PENDING',
   PROCESSING: 'PROCESSING',
   READY: 'READY',
+  /** 추출이 일부 필드만 채운 상태. 사용자가 나머지를 채우면 READY 가 된다 */
+  INCOMPLETE: 'INCOMPLETE',
   FAILED: 'FAILED',
 } as const;

--- a/apps/web/src/consts/item.ts
+++ b/apps/web/src/consts/item.ts
@@ -2,7 +2,6 @@ export const ITEM_STATUS = {
   PENDING: 'PENDING',
   PROCESSING: 'PROCESSING',
   READY: 'READY',
-  /** 추출이 일부 필드만 채운 상태. 사용자가 나머지를 채우면 READY 가 된다 */
   INCOMPLETE: 'INCOMPLETE',
   FAILED: 'FAILED',
 } as const;

--- a/apps/web/src/types/item.ts
+++ b/apps/web/src/types/item.ts
@@ -5,8 +5,9 @@ export type ItemTypeT = 'wish' | 'tournament';
 export type ItemT = {
   id: number;
   status: ItemStatusT;
-  name: string;
-  price: number;
+  /** INCOMPLETE 면 비어 있을 수 있다 */
+  name: string | null;
+  price: number | null;
   currency: string | null;
   imageUrl: string | null;
   sourceUrl: string | null;

--- a/apps/web/src/types/item.ts
+++ b/apps/web/src/types/item.ts
@@ -5,7 +5,6 @@ export type ItemTypeT = 'wish' | 'tournament';
 export type ItemT = {
   id: number;
   status: ItemStatusT;
-  /** INCOMPLETE 면 비어 있을 수 있다 */
   name: string | null;
   price: number | null;
   currency: string | null;


### PR DESCRIPTION
## 왜

서버가 추출 결과를 일부만 채웠을 때 `INCOMPLETE` 상태로 내려준다 (TeamPiKi/core#945). 클라는 이 값을 몰라서 `FAILED`/`PENDING`/`PROCESSING` 이 아니면 전부 정상 카드로 그렸다.

그래서 **이름과 가격이 빈 칸인 카드**가 보이고(`formatPrice` 가 숫자를 못 찾아 빈 문자열 반환), 사용자에게 채우라는 유도가 없다.

## 무엇을

| 화면 | 전 | 후 |
|---|---|---|
| 위시 그리드 | 값이 빈 정상 카드 | "일부만 가져왔어요" + 직접 입력하기 (편집 화면으로) |
| 토너먼트 담기 후보 | 선택 가능 (담으면 서버가 거절) | 후보에서 제외 |
| 토너먼트 바스켓 | 클릭 불가 | 클릭 가능 (값을 채워야 하므로) |

- `ITEM_STATUS` 에 `INCOMPLETE` 추가, `ItemT` 의 `name`·`price` 를 nullable 로
- 카드 컴포넌트도 nullable 을 받게 했다. `INCOMPLETE` 를 앞에서 걸러내므로 실제로 빈 값이 정상 카드에 들어가지는 않는다

문구만 다를 뿐 기존 실패 카드 흐름을 그대로 재사용해 변경을 최소화했다.

## 참고

알림 타입(`ITEM_PARSING_INCOMPLETE`)과 SSE status 대응은 #519 로 분리했다. 두 PR 은 파일이 겹치지 않아 독립적으로 머지할 수 있다.

---
## 연관 이슈

- close #518
