### PR TITLE
feat: 정보 수집 실패한 위시에 삭제 버튼 노출 + 위시 정보 화면 스페이싱 정합

### DIFF
--- a/apps/web/src/components/common/item-info-screen/ItemEditForm.tsx
+++ b/apps/web/src/components/common/item-info-screen/ItemEditForm.tsx
@@ -64,7 +64,7 @@ function ItemEditForm({ item, onSave, isSavePending = false }: ItemEditFormProps
       <ItemImagePicker
         imageUrl={item.imageUrl}
         onImageSelect={setSelectedImage}
-        className={item.status === ITEM_STATUS.FAILED ? 'mt-2' : 'mt-5'}
+        className={item.status === ITEM_STATUS.FAILED ? 'mt-4' : 'mt-5'}
       />
 
       <Spacing size={16} />

--- a/apps/web/src/components/common/item-info-screen/index.tsx
+++ b/apps/web/src/components/common/item-info-screen/index.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { TrashIconOutline } from '@/assets/icons';
 import ConfirmDialog from '@/components/common/confirm-dialog';
 import { Header, HeaderIcon } from '@/components/header';
+import { ITEM_STATUS } from '@/consts/item';
 import type { ItemTypeT, PatchItemRequestT } from '@/types/item';
 import { cn } from '@/utils/cn';
 
@@ -62,9 +63,9 @@ function ItemInfoScreen({
         left={<HeaderIcon name="BACK" {...(isEditing && { onClick: () => setIsEditing(false) })} />}
         center={isDetailMode ? viewTitle : '위시 정보 수정'}
         centerClassName="heading-1-bold"
-        /** 삭제는 조회 화면에서만 */
+        /** 삭제는 조회 화면과 FAILED 수집 실패 화면에서 노출 */
         right={
-          isDetailMode && (
+          (isDetailMode || item.status === ITEM_STATUS.FAILED) && (
             <button
               type="button"
               aria-label="삭제하기"


### PR DESCRIPTION
## 작업 요약

- 정보 수집 실패한 위시에 삭제 버튼을 노출하고, 위시 정보 수정 화면의 스페이싱을 정합합니다

## 작업 세부 내용

- `ItemInfoScreen`: 헤더 우측 삭제 버튼을 `isDetailMode`(조회 화면) 외에 `item.status === FAILED`일 때도 노출
- `ItemEditForm`: 경고 배너 → 이미지 피커 간격 8px → 16px (Spacing -x4) 정합

## 스크린샷
<img width="487" height="802" alt="스크린샷 2026-08-16 오후 8 16 28" src="https://github.com/user-attachments/assets/45d2e777-3b67-41f5-9498-c271f2f51eac" />


## 연관 이슈

closes #473


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 실패 상태의 상품에서도 삭제 버튼을 사용할 수 있도록 개선했습니다.
  * 실패 상태에서 이미지 선택 영역의 상단 여백을 조정해 화면 표시를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->