### PR TITLE
refactor: 아이템·토너먼트 status 비교를 상수로 통일

### DIFF
--- a/apps/web/src/app/archive/tournament/_consts/tournamentTab.ts
+++ b/apps/web/src/app/archive/tournament/_consts/tournamentTab.ts
@@ -1,3 +1,4 @@
+import { TOURNAMENT_STATUS } from '@/consts/tournament';
 import type { TournamentStatusT } from '@/types/tournament';
 
 export type TournamentStatusTabT = 'ongoing' | 'completed';
@@ -8,6 +9,6 @@ export type TournamentStatusTabT = 'ongoing' | 'completed';
  * - 완료(completed) 탭: 완료된 토너먼트
  */
 export const STATUS_BY_TAB: Record<TournamentStatusTabT, TournamentStatusT[]> = {
-  ongoing: ['PENDING', 'IN_PROGRESS'],
-  completed: ['COMPLETED'],
+  ongoing: [TOURNAMENT_STATUS.PENDING, TOURNAMENT_STATUS.IN_PROGRESS],
+  completed: [TOURNAMENT_STATUS.COMPLETED],
 };

--- a/apps/web/src/app/archive/wish/[id]/layout.tsx
+++ b/apps/web/src/app/archive/wish/[id]/layout.tsx
@@ -2,6 +2,7 @@ import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { notFound, redirect } from 'next/navigation';
 
+import { ITEM_STATUS } from '@/consts/item';
 import { ROUTES } from '@/consts/route';
 import type { ApiErrorResponseT } from '@/types/api';
 import { parseIdParam } from '@/utils/parseIdParam';
@@ -27,7 +28,10 @@ async function WishEditLayout({ children, params }: WishEditLayoutProps) {
     queryClient.setQueryData(['wish', wishId], wishData);
 
     /** 아직 PROCESSING 상태인 경우에는 접근 불가 */
-    if (wishData.item.status === 'PROCESSING' || wishData.item.status === 'PENDING')
+    if (
+      wishData.item.status === ITEM_STATUS.PROCESSING ||
+      wishData.item.status === ITEM_STATUS.PENDING
+    )
       redirect(ROUTES.WISHLIST);
   } catch (error) {
     if (!isAxiosError<ApiErrorResponseT>(error)) throw error;

--- a/apps/web/src/app/archive/wish/_components/WishContent.tsx
+++ b/apps/web/src/app/archive/wish/_components/WishContent.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import CheckboxSelectedIconFill from '@/assets/icons/fill/checkbox-selected.svg';
 import TrashIconFill from '@/assets/icons/fill/trash.svg';
 import ConfirmDialog from '@/components/common/confirm-dialog';
+import { ITEM_STATUS } from '@/consts/item';
 import { useGetWishlist } from '@/hooks/useGetWishlist';
 
 import { useDeleteWishes } from '../_hooks/useDeleteWishes';
@@ -39,7 +40,9 @@ function WishContent() {
   const selectableIds = wishlistData
     .filter(
       ({ item }) =>
-        item.status !== 'FAILED' && item.status !== 'PENDING' && item.status !== 'PROCESSING'
+        item.status !== ITEM_STATUS.FAILED &&
+        item.status !== ITEM_STATUS.PENDING &&
+        item.status !== ITEM_STATUS.PROCESSING
     )
     .map(({ wish }) => wish.id);
   const isAllSelected = selectableIds.length > 0 && selectableIds.every(id => selectedIds.has(id));

--- a/apps/web/src/app/play/[id]/_components/PlayClient.tsx
+++ b/apps/web/src/app/play/[id]/_components/PlayClient.tsx
@@ -12,6 +12,7 @@ import ButtonLink from '@/components/button/ButtonLink';
 import Spinner from '@/components/spinner';
 import { ANALYTICS_EVENT } from '@/consts/analytics';
 import { ROUTES } from '@/consts/route';
+import { TOURNAMENT_STATUS } from '@/consts/tournament';
 import { logAnalyticsEvent } from '@/utils/analytics';
 import { isServerOrNetworkError } from '@/utils/apiError';
 
@@ -42,11 +43,11 @@ function PlayClient({ sourceTournamentId }: PlayClientProps) {
     // - COMPLETED: 이미 끝낸 토너먼트 (재진입) → result 로 결과 다시 보기
     const goToTournament = async (id: number) => {
       const data = await getTournament(id);
-      if (data.status === 'COMPLETED') {
+      if (data.status === TOURNAMENT_STATUS.COMPLETED) {
         router.replace(ROUTES.TOURNAMENT_RESULT(id));
         return;
       }
-      if (data.status === 'IN_PROGRESS' && !data.pending) {
+      if (data.status === TOURNAMENT_STATUS.IN_PROGRESS && !data.pending) {
         router.replace(ROUTES.TOURNAMENT_MATCH(id));
         return;
       }

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
@@ -38,7 +38,7 @@ function TournamentItemBasket({
   const [failedItem, setFailedItem] = useState<TournamentPendingItemT | null>(null);
 
   const handleItemClick = (item: TournamentItemBasketProps['items'][number]) => {
-    if (item.status === 'FAILED') setFailedItem(item);
+    if (item.status === ITEM_STATUS.FAILED) setFailedItem(item);
   };
 
   const isFull = items.length >= ITEMS_PER_BASKET;

--- a/apps/web/src/app/tournament/[id]/item/[itemId]/layout.tsx
+++ b/apps/web/src/app/tournament/[id]/item/[itemId]/layout.tsx
@@ -2,6 +2,7 @@ import { ERROR_CODE } from '@piki/core';
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 import { notFound, redirect } from 'next/navigation';
 
+import { ITEM_STATUS } from '@/consts/item';
 import { QUERY_ACTION } from '@/consts/queryAction';
 import { ROUTES } from '@/consts/route';
 import { getApiErrorCode, getApiErrorStatus, isGlobalNetError } from '@/utils/apiError';
@@ -34,7 +35,10 @@ async function TournamentItemLayout({ children, params }: TournamentItemLayoutPr
     );
 
     /** 아직 PROCESSING 상태인 경우에는 접근 불가 */
-    if (tournamentItemData.status === 'PROCESSING' || tournamentItemData.status === 'PENDING')
+    if (
+      tournamentItemData.status === ITEM_STATUS.PROCESSING ||
+      tournamentItemData.status === ITEM_STATUS.PENDING
+    )
       redirect(ROUTES.TOURNAMENT_CREATE(tournamentId));
   } catch (error) {
     if (isGlobalNetError(error)) throw error;

--- a/apps/web/src/app/tournament/[id]/match/_hooks/useTournament.ts
+++ b/apps/web/src/app/tournament/[id]/match/_hooks/useTournament.ts
@@ -7,6 +7,7 @@ import { useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import { ROUTES } from '@/consts/route';
+import { TOURNAMENT_STATUS } from '@/consts/tournament';
 import type { ApiErrorResponseT } from '@/types/api';
 import type { TournamentItemT } from '@/types/tournament';
 
@@ -60,7 +61,7 @@ const useTournament = ({ tournamentId, inProgress }: UseTournamentArgs) => {
         isOwner: previous.isOwner,
         isRoot: previous.isRoot,
         ...(sourceTournamentId ? { sourceTournamentId } : {}),
-        status: 'COMPLETED',
+        status: TOURNAMENT_STATUS.COMPLETED,
         completed: {
           result: completed.result,
           hasGroupResult: completed.hasGroupResult,
@@ -102,12 +103,12 @@ const useTournament = ({ tournamentId, inProgress }: UseTournamentArgs) => {
     const next = await getTournament(tournamentId);
     queryClient.setQueryData(['tournament', tournamentId], next);
 
-    if (next.status === 'COMPLETED') {
+    if (next.status === TOURNAMENT_STATUS.COMPLETED) {
       setIsNavigatingToResult(true);
       router.replace(ROUTES.TOURNAMENT_RESULT(tournamentId));
       return;
     }
-    if (next.status !== 'IN_PROGRESS' || !next.inProgress) return;
+    if (next.status !== TOURNAMENT_STATUS.IN_PROGRESS || !next.inProgress) return;
 
     const nextInProgress = next.inProgress;
 

--- a/apps/web/src/app/tournament/[id]/match/page.tsx
+++ b/apps/web/src/app/tournament/[id]/match/page.tsx
@@ -3,6 +3,7 @@ import { isAxiosError } from 'axios';
 import { redirect } from 'next/navigation';
 
 import { ROUTES } from '@/consts/route';
+import { TOURNAMENT_STATUS } from '@/consts/tournament';
 import { getQueryClient } from '@/utils/queryClient';
 
 import { getTournament } from '../_common/_apis/getTournament';
@@ -20,20 +21,20 @@ async function TournamentPage({ params }: TournamentPageProps) {
 
   const tournamentData = await getTournament(tournamentId);
 
-  if (tournamentData.status === 'COMPLETED') {
+  if (tournamentData.status === TOURNAMENT_STATUS.COMPLETED) {
     redirect(ROUTES.TOURNAMENT_RESULT(tournamentId));
   }
 
   // 참여자가 본인 매치를 시작하기 전 (IN_PROGRESS + pending 페이로드)
   // — 아직 진행할 게 없으므로 create(대기) 화면으로 돌려보낸다.
-  if (tournamentData.status === 'IN_PROGRESS' && tournamentData.pending) {
+  if (tournamentData.status === TOURNAMENT_STATUS.IN_PROGRESS && tournamentData.pending) {
     redirect(ROUTES.TOURNAMENT_CREATE(tournamentId));
   }
 
   let hydratedTournament: GetTournamentInProgressResponseT;
   let playTournamentId = tournamentId;
 
-  if (tournamentData.status === 'PENDING') {
+  if (tournamentData.status === TOURNAMENT_STATUS.PENDING) {
     try {
       // 응답 tournamentId 활용:
       // - 주최자(ROOT): 요청 tournamentId 와 동일
@@ -50,10 +51,10 @@ async function TournamentPage({ params }: TournamentPageProps) {
       playTournamentId = nextTournamentId;
       const started = await getTournament(nextTournamentId);
 
-      if (started.status === 'COMPLETED') {
+      if (started.status === TOURNAMENT_STATUS.COMPLETED) {
         redirect(ROUTES.TOURNAMENT_RESULT(nextTournamentId));
       }
-      if (started.status !== 'IN_PROGRESS' || started.pending) {
+      if (started.status !== TOURNAMENT_STATUS.IN_PROGRESS || started.pending) {
         // start 직후인데 진행 상태가 아님 — 예상 밖이라 대기 화면으로 돌려보낸다
         redirect(ROUTES.TOURNAMENT_CREATE(nextTournamentId));
       }
@@ -64,17 +65,17 @@ async function TournamentPage({ params }: TournamentPageProps) {
       if (!isAxiosError(error) || error.response?.status !== 409) throw error;
 
       const latest = await getTournament(tournamentId);
-      if (latest.status === 'COMPLETED') {
+      if (latest.status === TOURNAMENT_STATUS.COMPLETED) {
         redirect(ROUTES.TOURNAMENT_RESULT(tournamentId));
       }
-      if (latest.status === 'PENDING' || latest.pending) {
+      if (latest.status === TOURNAMENT_STATUS.PENDING || latest.pending) {
         // 409이면서 여전히 PENDING 또는 멤버 대기 상태 — 예상 밖, 그대로 던짐
         throw error;
       }
       hydratedTournament = latest;
     }
   } else {
-    // tournamentData.status === 'IN_PROGRESS' && !tournamentData.pending — 매치 진행 중
+    // tournamentData.status === TOURNAMENT_STATUS.IN_PROGRESS && !tournamentData.pending — 매치 진행 중
     hydratedTournament = tournamentData;
   }
 

--- a/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
@@ -10,6 +10,7 @@ import Button from '@/components/button';
 import { Header } from '@/components/header';
 import { ANALYTICS_EVENT } from '@/consts/analytics';
 import { ROUTES } from '@/consts/route';
+import { TOURNAMENT_STATUS } from '@/consts/tournament';
 import { logAnalyticsEvent } from '@/utils/analytics';
 import { cn } from '@/utils/cn';
 
@@ -36,7 +37,7 @@ function ResultClient({ tournamentId, isGuest = false, isApp = false }: ResultCl
 
   // RSC에서 status 검사를 하지만, 클라에서 status가 바뀐 경우 방어
   useEffect(() => {
-    if (tournamentData.status === 'COMPLETED') return;
+    if (tournamentData.status === TOURNAMENT_STATUS.COMPLETED) return;
     router.replace(ROUTES.TOURNAMENT_MATCH(tournamentId));
   }, [tournamentData.status, router, tournamentId]);
 
@@ -44,13 +45,13 @@ function ResultClient({ tournamentId, isGuest = false, isApp = false }: ResultCl
   // 같은 인스턴스가 다른 tournamentId 로 재사용되더라도 ID 별로 정확히 1회만 로깅한다.
   const loggedCompleteForRef = useRef<number | null>(null);
   useEffect(() => {
-    if (tournamentData.status !== 'COMPLETED') return;
+    if (tournamentData.status !== TOURNAMENT_STATUS.COMPLETED) return;
     if (loggedCompleteForRef.current === tournamentId) return;
     loggedCompleteForRef.current = tournamentId;
     logAnalyticsEvent(ANALYTICS_EVENT.RESULT_VIEW, { tournament_id: tournamentId });
   }, [tournamentData.status, tournamentId]);
 
-  if (tournamentData.status !== 'COMPLETED') {
+  if (tournamentData.status !== TOURNAMENT_STATUS.COMPLETED) {
     return (
       <main className="flex min-h-dvh items-center justify-center bg-bg-layer-basement pt-padding-top">
         <p className="body-1-medium text-text-neutral-tertiary">결과를 불러오는 중...</p>

--- a/apps/web/src/app/tournament/[id]/result/page.tsx
+++ b/apps/web/src/app/tournament/[id]/result/page.tsx
@@ -2,6 +2,7 @@ import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 import { redirect } from 'next/navigation';
 
 import { ROUTES } from '@/consts/route';
+import { TOURNAMENT_STATUS } from '@/consts/tournament';
 import { getIsApp } from '@/utils/getIsApp';
 import { getIsGuest } from '@/utils/getIsGuest';
 import { getQueryClient } from '@/utils/queryClient';
@@ -28,7 +29,7 @@ async function ResultContent({ tournamentId }: { tournamentId: number }) {
     queryFn: () => getTournament(tournamentId),
   });
 
-  if (tournamentData.status !== 'COMPLETED') {
+  if (tournamentData.status !== TOURNAMENT_STATUS.COMPLETED) {
     redirect(ROUTES.TOURNAMENT_MATCH(tournamentId));
   }
 

--- a/apps/web/src/types/notification.ts
+++ b/apps/web/src/types/notification.ts
@@ -1,3 +1,5 @@
+import type { ITEM_STATUS } from '@/consts/item';
+
 export type NotificationTypeT =
   | 'TOURNAMENT_JOINED'
   | 'TOURNAMENT_ITEM_ADDED'
@@ -41,7 +43,10 @@ export type SilentSyncSsePayloadT =
       type: 'TOURNAMENT_ITEM_PARSED';
       tournamentId: number;
       tournamentItemId: number;
-      status: 'READY' | 'INCOMPLETE' | 'FAILED';
+      status:
+        | (typeof ITEM_STATUS)['READY']
+        | (typeof ITEM_STATUS)['INCOMPLETE']
+        | (typeof ITEM_STATUS)['FAILED'];
     }
   | {
       type: 'UNREAD_COUNT_CHANGED';

--- a/apps/web/src/utils/item.ts
+++ b/apps/web/src/utils/item.ts
@@ -1,4 +1,5 @@
+import { ITEM_STATUS } from '@/consts/item';
 import type { ItemStatusT } from '@/types/item';
 
 export const hasParsingItems = (items: { status?: ItemStatusT }[]) =>
-  items.some(item => item.status === 'PENDING' || item.status === 'PROCESSING');
+  items.some(item => item.status === ITEM_STATUS.PENDING || item.status === ITEM_STATUS.PROCESSING);


### PR DESCRIPTION
## 작업 요약
- 아이템·토너먼트 status 비교를 상수로 통일
## 작업 상세 내용

`ITEM_STATUS` / `TOURNAMENT_STATUS` 상수가 이미 있는데도 status 비교가 문자열 리터럴과 상수로 혼재되어 있어, 상수 쪽으로 통일했습니다.


### 1. 아이템 status → `ITEM_STATUS` 

- `utils/item.ts` — PENDING, PROCESSING
- `archive/wish/_components/WishContent.tsx` — FAILED, PENDING, PROCESSING
- `archive/wish/[id]/layout.tsx` — PROCESSING, PENDING
- `tournament/[id]/item/[itemId]/layout.tsx` — PROCESSING, PENDING
- `tournament/[id]/create/.../TournamentItemBasket.tsx` — FAILED
- `types/notification.ts` — `SilentSyncSsePayloadT` 의 status 유니온을 다른 타입 파일(`_types/wish.ts`, `_types/tournamentItem.ts`)과 동일하게 `(typeof ITEM_STATUS)[...]` 파생 형태로 변경

### 2. 토너먼트 status → `TOURNAMENT_STATUS`

- `tournament/[id]/match/page.tsx` — 7곳 (+ 주석 1)
- `tournament/[id]/result/_components/ResultClient.tsx` — 3곳
- `tournament/[id]/match/_hooks/useTournament.ts` — 비교 2곳 +`setQueryData` 낙관적 업데이트의 값 할당 1곳
- `play/[id]/_components/PlayClient.tsx` — 2곳
- `tournament/[id]/result/page.tsx` — 1곳
- `archive/tournament/_consts/tournamentTab.ts` — 탭별 상태 매핑 배열

## 참고

- **동작 변경 없음.** 상수 값 자체는 서버 계약이라 그대로 두고, 참조 방식만 바꿨습니다
- **타입 좁히기 유지 확인.** `match/page.tsx` 는 `status` 로 discriminated union 을 좁혀 `pending` 필드에 접근하는데, `as const` 라 값 타입이 리터럴로 유지되어 narrowing 이 그대로 동작합니다. `check-types` 통과 확인했습니다


### 이번에 안 건드린 곳

`tournament/[id]/_common/_types/tournamentResponse.ts` 의 `Extract<TournamentStatusT, 'PENDING'>` 4곳은 파일 내에서 일관돼 있어 그대로 뒀습니다.

## 스크린샷

UI 변경 없음

## 연관 이슈

closes #525
