### PR TITLE
style: 인스타 랜딩 CTA 위계 변경 + 스플래시 로고 116px 정합

### DIFF
--- a/apps/app/app.json
+++ b/apps/app/app.json
@@ -101,7 +101,7 @@
         "expo-splash-screen",
         {
           "image": "./assets/images/splash-icon.png",
-          "imageWidth": 200,
+          "imageWidth": 116,
           "resizeMode": "contain",
           "backgroundColor": "#FAFAFA",
           "dark": {
@@ -109,7 +109,7 @@
           },
           "android": {
             "image": "./assets/images/splash-android-blank.png",
-            "imageWidth": 200,
+            "imageWidth": 116,
             "resizeMode": "contain",
             "backgroundColor": "#FAFAFA",
             "dark": {

--- a/apps/app/components/SplashOverlay.tsx
+++ b/apps/app/components/SplashOverlay.tsx
@@ -2,7 +2,7 @@ import { Image, StyleSheet, View } from 'react-native';
 
 /** app.json expo-splash-screen 설정과 동일하게 유지 (backgroundColor / imageWidth) */
 const SPLASH_BACKGROUND_COLOR = '#FAFAFA';
-const SPLASH_LOGO_WIDTH = 200;
+const SPLASH_LOGO_WIDTH = 116;
 
 /**
  * 네이티브 스플래시를 이어받는 RN 스플래시 오버레이.

--- a/apps/web/src/app/_components/SplashClient.tsx
+++ b/apps/web/src/app/_components/SplashClient.tsx
@@ -17,10 +17,10 @@ type LogoTransformT = {
 /** 로그인 페이지 PikiLogo 원본 너비(px) */
 const LOGIN_LOGO_WIDTH = 146;
 /** 스플래시에서 보여줄 로고 너비(px) */
-const SPLASH_LOGO_WIDTH = 200;
+const SPLASH_LOGO_WIDTH = 116;
 /**
- * SVG width attribute로 키우면 viewBox만 커지고 path는 그대로라 왼쪽 위로 치우쳐 보임.
- * 원본 크기(146px)로 렌더한 뒤 transform scale로 통째로 확대한다.
+ * SVG width attribute로 바꾸면 viewBox만 변하고 path는 그대로라 왼쪽 위로 치우쳐 보임.
+ * 원본 크기(146px)로 렌더한 뒤 transform scale로 통째로 조정한다.
  */
 const SPLASH_SCALE = SPLASH_LOGO_WIDTH / LOGIN_LOGO_WIDTH;
 

--- a/apps/web/src/app/open-app/_components/AppStoreRedirect.tsx
+++ b/apps/web/src/app/open-app/_components/AppStoreRedirect.tsx
@@ -59,11 +59,11 @@ function AppStoreRedirect({ storeUrl, target }: AppStoreRedirectProps) {
 
       {hasAttemptedStore && (
         <BottomCta className="flex-col items-stretch gap-2 bg-transparent pb-10">
-          <Button size="lg" onClick={handleWebContinueClick}>
-            웹으로 계속 보기
-          </Button>
-          <Button variant="secondary" size="lg" onClick={handleStoreRetryClick}>
+          <Button size="lg" onClick={handleStoreRetryClick}>
             앱 설치하러 가기
+          </Button>
+          <Button variant="secondary" size="lg" onClick={handleWebContinueClick}>
+            웹으로 계속 보기
           </Button>
         </BottomCta>
       )}

--- a/apps/web/src/app/open-app/_components/AppStoreRedirect.tsx
+++ b/apps/web/src/app/open-app/_components/AppStoreRedirect.tsx
@@ -15,8 +15,8 @@ type AppStoreRedirectProps = {
   target: string;
 };
 
-/** 루트 스플래시와 같은 로고 크기 — 원본 146px 을 200px 로 키운 비율 */
-const SPLASH_LOGO_SCALE = 200 / 146;
+/** 루트 스플래시와 같은 로고 크기 — 원본 146px 을 116px 로 줄인 비율 */
+const SPLASH_LOGO_SCALE = 116 / 146;
 
 function AppStoreRedirect({ storeUrl, target }: AppStoreRedirectProps) {
   /** 스토어 전환을 취소하고 남은 유저에게만 CTA 를 보여준다 — 전환 전에는 로고만 */

--- a/apps/web/src/app/open/_components/OpenLanding.tsx
+++ b/apps/web/src/app/open/_components/OpenLanding.tsx
@@ -20,8 +20,8 @@ type OpenLandingProps = {
   source: string | null;
 };
 
-/** 루트 스플래시와 같은 로고 크기 — 원본 146px 을 200px 로 키운 비율 */
-const SPLASH_LOGO_SCALE = 200 / 146;
+/** 루트 스플래시와 같은 로고 크기 — 원본 146px 을 116px 로 줄인 비율 */
+const SPLASH_LOGO_SCALE = 116 / 146;
 
 /** 앱을 여는 URL — 설치 여부 판정은 전부 OS 에 맡긴다 (웹에는 감지 수단이 없다) */
 const getAppOpenUrl = ({ landingEnv, target, serviceOrigin, source }: OpenLandingProps) => {


### PR DESCRIPTION
## 작업 요약

- 루트 스플래시·인스타 랜딩(/open, /open-app)의 로고 표시 너비를 200px 에서 116px 로 줄입니다
- 앱 네이티브 스플래시(iOS)도 같은 크기로 보이도록 imageWidth 를 116 으로 맞춥니다
- /open-app 랜딩 CTA 위계를 바꿔 앱 설치가 primary, 웹으로 계속 보기가 secondary 가 되게 합니다

## 작업 세부 내용

### 1. 웹 로고 3곳 — scale 기준 너비 200 → 116

세 곳 모두 146px 원본 SVG 를 transform scale 로 조정하는 기존 구조를 그대로 두고, 기준 너비만 바꿨습니다. 비율(146:106)은 자동으로 유지됩니다.

- `app/_components/SplashClient.tsx` — `SPLASH_LOGO_WIDTH` 200 → 116
- `app/open/_components/OpenLanding.tsx` — `SPLASH_LOGO_SCALE` 200/146 → 116/146
- `app/open-app/_components/AppStoreRedirect.tsx` — 동일

### 2. 앱 스플래시 — `app.json` `imageWidth` + `SplashOverlay` 200 → 116

- expo-splash-screen 의 `imageWidth` 는 원본(1024px)을 지정 너비로 축소 렌더링하는 값이라 에셋 교체 없이 숫자만 변경했습니다. iOS 의 dp 는 웹 CSS px 과 1:1 대응이라 네이티브 스플래시 → 웹 스플래시 전환 시 로고 크기가 이어집니다
- 네이티브 스플래시를 이어받는 RN `SplashOverlay` 의 `SPLASH_LOGO_WIDTH` 도 같이 116 으로 맞췄습니다 (주석 규약대로 app.json 과 동기화)
- 반영 경로가 둘로 갈립니다:
  - `SplashOverlay` — JS 라 **EAS Update(OTA)로 즉시 반영 가능**. Android 는 네이티브 스플래시가 blank 이미지라 유저가 보는 첫 로고가 이 오버레이 → OTA 만으로 완전 반영
  - `app.json` — 네이티브 빌드에 구워지는 값이라 **스토어 릴리즈부터 반영**. iOS 구버전 빌드는 네이티브 스플래시(200) → 오버레이(116) 전환 시 로고가 살짝 줄어드는 점프가 남고, 새 빌드부터 해소됩니다

### 3. open-app 랜딩 CTA 위계 변경 — `AppStoreRedirect.tsx`

- 버튼 순서와 variant 를 스왑해 `앱 설치하러 가기` 가 위·primary, `웹으로 계속 보기` 가 아래·secondary 가 되게 했습니다

### 참고

- 로그인 페이지 로고(146px)는 변경하지 않았습니다. 루트 스플래시의 축소 애니메이션은 로그인 로고 자리에 착지하는 연출인데, 시작 크기(116)가 착지 크기(146)보다 작아져서 이동하며 살짝 커지는 모션이 됩니다. 로그인 쪽도 116 으로 맞출지는 디자인 확인이 필요합니다

## 스크린샷

<img width="804" height="1744" alt="image" src="https://github.com/user-attachments/assets/452ca4ae-8ff5-4801-aadd-32ad9dc99063" />

<img width="533" height="898" alt="image" src="https://github.com/user-attachments/assets/40778a75-afe9-4f77-8c29-eb22615243fb" />


## 연관 이슈

closes #492


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * iOS, Android 및 웹의 스플래시 화면 로고 크기를 116px로 조정했습니다.
  * 앱 열기 및 초기 로딩 화면에서 로고가 더 작게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->