### PR TITLE
fix: 부전승 안내 모달 사이즈 개선 및 참여자 화면 버튼 정리

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -10,19 +10,21 @@ import { QUERY_ACTION } from '@/consts/queryAction';
 import { useGetMe } from '@/hooks/useGetMe';
 import { useQueryAction } from '@/hooks/useQueryAction';
 import { useSSEFallback } from '@/hooks/useSSEFallback';
+import { hasSentInvite } from '@/utils/inviteSentSession';
 import { hasParsingItems } from '@/utils/item';
 
 import { useGetTournament } from '../../_common/_hooks/useGetTournament';
 import { PREV_ITEM_COUNT_KEY } from '../_consts/tournamentItemBasket';
 import { useCountdown } from '../_hooks/useCountdown';
 import { usePostTournamentStart } from '../_hooks/usePostTournamentStart';
-import { hasSentInvite } from '@/utils/inviteSentSession';
+import { needsByeWarning } from '../_utils/bye';
 import DepositClosedDialog from './deposit-closed-dialog/DepositClosedDialog';
 import OwnerStartedDialog from './owner-started-dialog/OwnerStartedDialog';
 import ParticipantPanel from './participant-panel/ParticipantPanel';
 import TournamentHeader from './tournament-header/TournamentHeader';
 import TournamentItemBasketStatus from './tournament-item-basket-status/TournamentItemBasketStatus';
 import TournamentItemBasketCarousel from './tournament-item-basket/TournamentItemBasketCarousel';
+import ByeWarningDialog from './tournament-start-button/ByeWarningDialog';
 import TournamentStartButton from './tournament-start-button/TournamentStartButton';
 import WelcomeJoinDialog from './welcome-join-dialog/WelcomeJoinDialog';
 
@@ -139,11 +141,25 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
     usePostTournamentStart(tournamentId);
   const itemCount = pending?.items.length ?? 0;
 
+  /**
+   * 시작 경로가 하단 버튼 외에 두 모달에도 있어 부전승 안내를 건너뛰고 있었다.
+   * 세 경로 모두 같은 기준으로 안내한 뒤 시작한다.
+   */
+  const [isByeWarningOpen, setIsByeWarningOpen] = useState(false);
+
+  const startWithByeCheck = () => {
+    if (needsByeWarning(itemCount)) {
+      setIsByeWarningOpen(true);
+      return;
+    }
+    postTournamentStartMutation();
+  };
+
   const handleStartFromDepositClosed = () => {
     if (isPostTournamentStartPending) return;
     setIsDepositClosedDialogOpen(false);
     setHasDismissedDepositClosed(true);
-    postTournamentStartMutation();
+    startWithByeCheck();
   };
 
   const handleDepositClosedOpenChange = (open: boolean) => {
@@ -169,7 +185,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
     if (isPostTournamentStartPending) return;
     setIsOwnerStartedDialogOpen(false);
     setHasDismissedOwnerStarted(true);
-    postTournamentStartMutation();
+    startWithByeCheck();
   };
 
   const handleOwnerStartedOpenChange = (open: boolean) => {
@@ -240,6 +256,17 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
         onStart={handleStartFromOwnerStarted}
         itemCount={itemCount}
         isPending={isPostTournamentStartPending}
+      />
+
+      <ByeWarningDialog
+        open={isByeWarningOpen}
+        onOpenChange={setIsByeWarningOpen}
+        onAddMore={() => setIsByeWarningOpen(false)}
+        onConfirm={() => {
+          setIsByeWarningOpen(false);
+          postTournamentStartMutation();
+        }}
+        isParticipant={isParticipant}
       />
 
       {isWelcomeOpen && (

--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -141,10 +141,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
     usePostTournamentStart(tournamentId);
   const itemCount = pending?.items.length ?? 0;
 
-  /**
-   * 시작 경로가 하단 버튼 외에 두 모달에도 있어 부전승 안내를 건너뛰고 있었다.
-   * 세 경로 모두 같은 기준으로 안내한 뒤 시작한다.
-   */
+  /** 하단 버튼 외에 두 모달에서도 시작할 수 있어 같은 기준으로 안내한다 */
   const [isByeWarningOpen, setIsByeWarningOpen] = useState(false);
 
   const startWithByeCheck = () => {

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/ByeWarningDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/ByeWarningDialog.tsx
@@ -7,18 +7,12 @@ import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/compone
 type ByeWarningDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** "상품 더 담기" — 모달 닫기만 (사용자가 후보를 더 추가하러 돌아감) */
   onAddMore: () => void;
-  /** 확인 — 부전승 포함된 채로 토너먼트 시작 진행 */
   onConfirm: () => void;
   /** 참여자는 후보를 더 담을 수 없어 확인 버튼 하나만 노출한다 */
   isParticipant?: boolean;
 };
 
-/**
- * 후보 개수가 2의 거듭제곱(2, 4, 8, 16, 32) 이 아닐 때 시작 직전에 노출되는 안내 모달.
- * 일부 후보가 자동으로 다음 라운드에 올라가는 부전승이 발생함을 사용자에게 알린다.
- */
 function ByeWarningDialog({
   open,
   onOpenChange,

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/ByeWarningDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/ByeWarningDialog.tsx
@@ -30,7 +30,7 @@ function ByeWarningDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent showCloseButton={false} className="max-w-83 flex-col items-center gap-5 p-4">
         <div className="flex flex-col items-center gap-3">
-          <AlertIconFill className="size-10 text-icon-neutral-secondary" aria-hidden />
+          <AlertIconFill className="size-10 text-icon-accent" aria-hidden />
 
           <div className="flex flex-col items-center gap-1">
             <DialogTitle className="text-center heading-2-semibold text-text-neutral-primary">

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/ByeWarningDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/ByeWarningDialog.tsx
@@ -9,39 +9,55 @@ type ByeWarningDialogProps = {
   onOpenChange: (open: boolean) => void;
   /** "상품 더 담기" — 모달 닫기만 (사용자가 후보를 더 추가하러 돌아감) */
   onAddMore: () => void;
-  /** "시작하기" — 부전승 포함된 채로 토너먼트 시작 진행 */
+  /** 확인 — 부전승 포함된 채로 토너먼트 시작 진행 */
   onConfirm: () => void;
+  /** 참여자는 후보를 더 담을 수 없어 확인 버튼 하나만 노출한다 */
+  isParticipant?: boolean;
 };
 
 /**
  * 후보 개수가 2의 거듭제곱(2, 4, 8, 16, 32) 이 아닐 때 시작 직전에 노출되는 안내 모달.
  * 일부 후보가 자동으로 다음 라운드에 올라가는 부전승이 발생함을 사용자에게 알린다.
  */
-function ByeWarningDialog({ open, onOpenChange, onAddMore, onConfirm }: ByeWarningDialogProps) {
+function ByeWarningDialog({
+  open,
+  onOpenChange,
+  onAddMore,
+  onConfirm,
+  isParticipant = false,
+}: ByeWarningDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent showCloseButton={false} className="flex flex-col items-center gap-3 p-5">
-        <AlertIconFill className="size-10 text-icon-accent" aria-hidden />
+      <DialogContent showCloseButton={false} className="max-w-83 flex-col items-center gap-5 p-4">
+        <div className="flex flex-col items-center gap-3">
+          <AlertIconFill className="size-10 text-icon-neutral-secondary" aria-hidden />
 
-        <div className="flex flex-col items-center gap-2">
-          <DialogTitle className="text-center heading-1-bold text-text-neutral-primary">
-            부전승이 포함돼요
-          </DialogTitle>
-          <DialogDescription className="text-center body-1-medium text-text-neutral-tertiary">
-            상품 수가 2, 4, 8, 16, 32개가 아니면
-            <br />
-            일부 상품은 자동으로 다음 라운드에 올라가요.
-          </DialogDescription>
+          <div className="flex flex-col items-center gap-1">
+            <DialogTitle className="text-center heading-2-semibold text-text-neutral-primary">
+              부전승이 포함돼요
+            </DialogTitle>
+            <DialogDescription className="text-center body-2-medium text-text-neutral-tertiary">
+              상품 수가 2, 4, 8, 16, 32개가 아니면
+              <br />
+              일부 상품은 자동으로 다음 라운드에 올라가요.
+            </DialogDescription>
+          </div>
         </div>
 
-        <div className="mt-1 flex w-full gap-2">
-          <Button variant="secondary" size="lg" onClick={onAddMore}>
-            상품 더 담기
+        {isParticipant ? (
+          <Button variant="primary" size="lg" className="w-full" onClick={onConfirm}>
+            확인하고 시작하기
           </Button>
-          <Button variant="primary" size="lg" onClick={onConfirm}>
-            시작하기
-          </Button>
-        </div>
+        ) : (
+          <div className="flex w-full gap-2.5">
+            <Button variant="secondary" size="lg" onClick={onAddMore}>
+              상품 더 담기
+            </Button>
+            <Button variant="primary" size="lg" onClick={onConfirm}>
+              시작하기
+            </Button>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/TournamentStartButton.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/TournamentStartButton.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import Button from '@/components/button';
 
 import { usePostTournamentStart } from '../../_hooks/usePostTournamentStart';
+import { needsByeWarning } from '../../_utils/bye';
 import ByeWarningDialog from './ByeWarningDialog';
 import ConfirmStartDialog from './ConfirmStartDialog';
 
@@ -14,8 +15,6 @@ const PARTICIPANT_TOOLTIP_DURATION_MS = 3_000;
  * count 가 2의 거듭제곱(2, 4, 8, 16, 32) 인지 검사.
  * 아니면 부전승이 발생하므로 사용자에게 안내 모달을 띄운다.
  */
-const isPowerOfTwo = (n: number) => n >= 2 && (n & (n - 1)) === 0;
-
 type TournamentStartButtonProps = {
   count: number;
   tournamentId: number;
@@ -73,7 +72,7 @@ function TournamentStartButton({
   const handleClick = () => {
     if (isWaitingForOwnerStart) return;
     // 후보 수가 2의 거듭제곱이 아니면 부전승 발생 — 먼저 안내 모달 노출.
-    if (!isPowerOfTwo(count)) {
+    if (needsByeWarning(count)) {
       setIsByeWarningOpen(true);
       return;
     }

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/TournamentStartButton.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/TournamentStartButton.tsx
@@ -131,6 +131,7 @@ function TournamentStartButton({
         onOpenChange={setIsByeWarningOpen}
         onAddMore={() => setIsByeWarningOpen(false)}
         onConfirm={handleByeWarningConfirm}
+        isParticipant={isParticipant}
       />
     </>
   );

--- a/apps/web/src/app/tournament/[id]/create/_utils/bye.ts
+++ b/apps/web/src/app/tournament/[id]/create/_utils/bye.ts
@@ -1,8 +1,4 @@
-/**
- * 후보 수가 2의 거듭제곱(2, 4, 8, 16, 32)이면 부전승 없이 진행된다.
- * 그 외에는 일부 후보가 자동으로 다음 라운드에 올라가므로 시작 전에 안내한다.
- */
-export const isPowerOfTwo = (n: number) => n >= 2 && (n & (n - 1)) === 0;
+const isPowerOfTwo = (n: number) => n >= 2 && (n & (n - 1)) === 0;
 
-/** 시작 전 부전승 안내가 필요한지 */
+/** 후보 수가 2의 거듭제곱이 아니면 일부가 자동으로 다음 라운드에 올라간다 */
 export const needsByeWarning = (itemCount: number) => !isPowerOfTwo(itemCount);

--- a/apps/web/src/app/tournament/[id]/create/_utils/bye.ts
+++ b/apps/web/src/app/tournament/[id]/create/_utils/bye.ts
@@ -1,0 +1,8 @@
+/**
+ * 후보 수가 2의 거듭제곱(2, 4, 8, 16, 32)이면 부전승 없이 진행된다.
+ * 그 외에는 일부 후보가 자동으로 다음 라운드에 올라가므로 시작 전에 안내한다.
+ */
+export const isPowerOfTwo = (n: number) => n >= 2 && (n & (n - 1)) === 0;
+
+/** 시작 전 부전승 안내가 필요한지 */
+export const needsByeWarning = (itemCount: number) => !isPowerOfTwo(itemCount);


### PR DESCRIPTION
## 작업 요약

- 부전승 안내 모달의 사이즈·타이포를 시안에 맞게 조정합니다.
- 참여자에게는 `확인하고 시작하기` 단일 버튼만 노출합니다.
- 모달 경로로 시작할 때 부전승 안내가 생략되던 문제를 함께 고칩니다.

## 작업 세부 내용

### 1. 사이즈·타이포 조정

| 항목 | 전 | 후 |
| --- | --- | --- |
| 모달 폭 | 최대 440 | **332** (`max-w-83`) |
| 패딩 | `p-5` (20) | **`p-4`** (16) |
| 타이틀 | `heading-1-bold` (20/28) | **`heading-2-semibold`** (18/26) |
| 본문 | `body-1-medium` (16/22) | **`body-2-medium`** (14/20) |
| 버튼 간격 | `gap-2` (8) | **`gap-2.5`** (10) |

### 2. 참여자 버튼 정리

참여자(CLONE)는 본인 후보를 더 담을 수 없어 `상품 더 담기` 가 동작할 여지가 없었습니다.

```
주최자   [상품 더 담기] [시작하기]
참여자   [  확인하고 시작하기  ]
```

호출부(`TournamentStartButton`)에 이미 `isParticipant` 가 있어 그대로 내려주는 것으로 끝났습니다.

### 3. 모달 경로에서 부전승 안내가 생략되던 문제

작업 중 발견했습니다. 시작 경로가 세 갈래인데 **부전승 검사가 하단 버튼에만** 있었습니다.

| 경로 | 전 | 후 |
| --- | --- | --- |
| 하단 `토너먼트 시작하기` | ✅ | ✅ |
| 주최자가 시작했어요 모달 | ❌ 바로 시작 | ✅ |
| 담기 마감 모달 | ❌ 바로 시작 | ✅ |

참여자는 주로 "주최자가 시작했어요" 모달로 시작하기 때문에, 2번에서 만든 참여자용 단일 버튼을 볼 기회 자체가 없었습니다. 함께 고치지 않으면 반쪽짜리 작업이 됩니다.

`isPowerOfTwo` 를 `_utils/bye.ts` 로 분리해 세 경로가 같은 기준을 쓰도록 했습니다.

```ts
const startWithByeCheck = () => {
  if (needsByeWarning(itemCount)) {
    setIsByeWarningOpen(true);
    return;
  }
  postTournamentStartMutation();
};
```

## 검증

타입·린트 통과했습니다.

`tournamentItemAdd.spec.ts` 는 5개 실패하지만 **dev 기준선과 동일**합니다(stash 후 대조 확인). 이번 변경으로 인한 회귀는 아닙니다.

실제 화면 확인은 하지 못했습니다. 특히 참여자 케이스는 주최자·참여자 두 계정이 필요하고, e2e 도 주최자 경로만 커버하고 있어 단일 버튼 분기는 수동 확인이 필요합니다.

## 스크린샷

<img width="671" height="668" alt="image" src="https://github.com/user-attachments/assets/9e3ed209-2b35-4b6a-a8aa-25e75506eca6" />

## 연관 이슈

closes #544


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 토너먼트 시작 전 참가자 수에 따른 부전승 안내를 제공합니다.
  * 부전승이 발생하는 경우 안내 확인 후 토너먼트를 시작할 수 있습니다.
  * 참가자는 안내 화면에서 바로 시작할 수 있으며, 주최자는 추가 상품을 담거나 시작할 수 있습니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->