### PR TITLE
feat: 친구 토너먼트 결과에도 영수증 출력기 GUI 적용

### DIFF
--- a/apps/web/src/app/tournament/[id]/result/_components/ReceiptDrawMachine.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ReceiptDrawMachine.tsx
@@ -2,12 +2,9 @@
 
 import { gsap } from 'gsap';
 import Image from 'next/image';
-import { useLayoutEffect, useRef, useState } from 'react';
+import { type ReactNode, useLayoutEffect, useRef, useState } from 'react';
 
 import ReceiptPrinterImg from '@/assets/images/tournament/result/receipt-printer.png';
-
-import type { RankedProductT } from '../../_common/_types/tournament';
-import ReceiptPaper from './ReceiptPaper';
 
 /** 프린터 래퍼 aspect ratio (디자인 박스) */
 const PRINTER_ASPECT_NUMERATOR = 267;
@@ -25,18 +22,11 @@ const RECEIPT_TOP_PER_PRINTER_HEIGHT =
   RECEIPT_TOP_AT_MAX_PRINTER_WIDTH_PX / REFERENCE_PRINTER_FRAME_HEIGHT_PX;
 
 type ReceiptDrawMachineProps = {
-  tournamentId: number;
-  tournamentName: string;
-  result: RankedProductT[];
-  date: Date;
+  /** 슬롯에서 빠져나오는 영수증 본문 */
+  children: ReactNode;
 };
 
-function ReceiptDrawMachine({
-  tournamentId,
-  tournamentName,
-  result,
-  date,
-}: ReceiptDrawMachineProps) {
+function ReceiptDrawMachine({ children }: ReceiptDrawMachineProps) {
   const animationScopeRef = useRef<HTMLDivElement | null>(null);
   const printerFrameRef = useRef<HTMLDivElement | null>(null);
   const receiptPaperRef = useRef<HTMLDivElement | null>(null);
@@ -149,12 +139,7 @@ function ReceiptDrawMachine({
 
       {/* 영수증 종이 영역 공간 확보 (layout reserved) */}
       <div className="invisible mx-auto w-[74%]" aria-hidden>
-        <ReceiptPaper
-          tournamentId={tournamentId}
-          tournamentName={tournamentName}
-          result={result}
-          date={date}
-        />
+        {children}
       </div>
 
       {/* 영수증 마스크 — 슬롯 위치(top)부터 컨테이너 끝(bottom-0)까지, 프린터 위로(z-40) 덮음.
@@ -167,12 +152,7 @@ function ReceiptDrawMachine({
           ref={receiptPaperRef}
           className="pointer-events-auto mx-auto h-fit w-[74%] will-change-transform"
         >
-          <ReceiptPaper
-            tournamentId={tournamentId}
-            tournamentName={tournamentName}
-            result={result}
-            date={date}
-          />
+          {children}
         </div>
       </div>
     </div>

--- a/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
@@ -16,6 +16,7 @@ import { cn } from '@/utils/cn';
 
 import { useGetTournament } from '../../_common/_hooks/useGetTournament';
 import ReceiptDrawMachine from './ReceiptDrawMachine';
+import ReceiptPaper from './ReceiptPaper';
 import ResultGuestBanner from './ResultGuestBanner';
 import GroupResultEntryCard from './group-result-entry-card/GroupResultEntryCard';
 import PlateShareDialog from './plate-share-dialog/PlateShareDialog';
@@ -83,12 +84,14 @@ function ResultClient({ tournamentId, isGuest = false, isApp = false }: ResultCl
       <Header center="토너먼트 결과" centerClassName="heading-1-bold" />
 
       <div className="mx-auto mt-4 flex min-h-0 w-full max-w-120 flex-1 flex-col gap-3">
-        <ReceiptDrawMachine
-          tournamentId={tournamentId}
-          tournamentName={tournamentName}
-          result={result}
-          date={date}
-        />
+        <ReceiptDrawMachine>
+          <ReceiptPaper
+            tournamentId={tournamentId}
+            tournamentName={tournamentName}
+            result={result}
+            date={date}
+          />
+        </ReceiptDrawMachine>
 
         {isGuest && (
           <div className="mx-5 mt-[49px]">

--- a/apps/web/src/app/tournament/[id]/result/group/_components/GroupResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/group/_components/GroupResultClient.tsx
@@ -17,6 +17,7 @@ import { useBackWithFallback } from '@/hooks/useBackWithFallback';
 import { cn } from '@/utils/cn';
 
 import { useGetTournament } from '../../../_common/_hooks/useGetTournament';
+import ReceiptDrawMachine from '../../_components/ReceiptDrawMachine';
 import { useGetGroupResult } from '../../_hooks/useGetGroupResult';
 import type { GroupResultItemT } from '../../_types/groupResult';
 import { formatDate, formatTime } from '../../_utils/formatReceipt';
@@ -109,78 +110,80 @@ function GroupResultClient({ tournamentId }: GroupResultClientProps) {
       </header>
 
       <div className="mx-auto mt-5 flex w-full max-w-105 flex-1 flex-col px-5">
-        <div className="relative flex w-full flex-col gap-2 bg-bg-layer-default pt-6 pb-6.25 filter-[drop-shadow(0px_2px_4px_rgba(0,0,0,0.12))]">
-          {/* PiKi 로고 + 헤드라인 */}
-          <div className="relative flex flex-col items-center gap-2">
-            <PikiLogo aria-label="PiKi" className="h-14 w-19.25 shrink-0 text-gray-800" />
-            <p
-              className={cn(
-                kodeMono.className,
-                'text-center text-[12px] leading-4 font-semibold tracking-[-0.4px] text-text-neutral-secondary'
-              )}
-            >
-              FROM WISH TO PICK
-            </p>
-          </div>
-
-          <div className="flex flex-col">
-            {/* 날짜 / 시간 */}
-            <div className={cn(kodeMono.className, 'flex items-center justify-between px-5')}>
-              <span className="caption-1-semibold text-text-neutral-secondary">
-                {formatDate(date)}
-              </span>
-              <span className="caption-1-semibold text-text-neutral-secondary">
-                {formatTime(date)}
-              </span>
+        <ReceiptDrawMachine>
+          <div className="relative flex w-full flex-col gap-2 bg-bg-layer-default pt-6 pb-6.25 filter-[drop-shadow(0px_2px_4px_rgba(0,0,0,0.12))]">
+            {/* PiKi 로고 + 헤드라인 */}
+            <div className="relative flex flex-col items-center gap-2">
+              <PikiLogo aria-label="PiKi" className="h-14 w-19.25 shrink-0 text-gray-800" />
+              <p
+                className={cn(
+                  kodeMono.className,
+                  'text-center text-[12px] leading-4 font-semibold tracking-[-0.4px] text-text-neutral-secondary'
+                )}
+              >
+                FROM WISH TO PICK
+              </p>
             </div>
 
-            <SectionDivider />
+            <div className="flex flex-col">
+              {/* 날짜 / 시간 */}
+              <div className={cn(kodeMono.className, 'flex items-center justify-between px-5')}>
+                <span className="caption-1-semibold text-text-neutral-secondary">
+                  {formatDate(date)}
+                </span>
+                <span className="caption-1-semibold text-text-neutral-secondary">
+                  {formatTime(date)}
+                </span>
+              </div>
 
-            {/* 토너먼트 이름 */}
-            <div className="flex flex-col px-5 py-2">
-              <p className="body-2-semibold text-text-neutral-primary">{tournamentName}</p>
+              <SectionDivider />
+
+              {/* 토너먼트 이름 */}
+              <div className="flex flex-col px-5 py-2">
+                <p className="body-2-semibold text-text-neutral-primary">{tournamentName}</p>
+              </div>
+
+              {/* 1st Place — 트로피 */}
+              {firstItem && (
+                <div className="flex flex-col gap-3 py-3">
+                  <PlaceLabel label="1st Place" />
+                  <GroupProductCard item={firstItem} highlight />
+                </div>
+              )}
+
+              {/* Others — 상품 카드 리스트 */}
+              {otherItems.length > 0 && (
+                <div className="flex flex-col gap-3 py-3">
+                  <PlaceLabel label="Others" />
+                  <ul className="flex flex-col gap-3">
+                    {otherItems.map(item => (
+                      <li key={`${item.rank}-${item.itemId}`}>
+                        <GroupProductCard item={item} />
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <SectionDivider />
+
+              <p
+                className={cn(
+                  kodeMono.className,
+                  'px-5 py-2 text-center caption-1-semibold text-text-neutral-secondary'
+                )}
+              >
+                @piki.day
+              </p>
             </div>
 
-            {/* 1st Place — 트로피 */}
-            {firstItem && (
-              <div className="flex flex-col gap-3 py-3">
-                <PlaceLabel label="1st Place" />
-                <GroupProductCard item={firstItem} highlight />
-              </div>
-            )}
-
-            {/* Others — 상품 카드 리스트 */}
-            {otherItems.length > 0 && (
-              <div className="flex flex-col gap-3 py-3">
-                <PlaceLabel label="Others" />
-                <ul className="flex flex-col gap-3">
-                  {otherItems.map(item => (
-                    <li key={`${item.rank}-${item.itemId}`}>
-                      <GroupProductCard item={item} />
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-
-            <SectionDivider />
-
-            <p
-              className={cn(
-                kodeMono.className,
-                'px-5 py-2 text-center caption-1-semibold text-text-neutral-secondary'
-              )}
-            >
-              @piki.day
-            </p>
+            <ReceiptZigzag
+              aria-hidden
+              preserveAspectRatio="none"
+              className="pointer-events-none absolute top-full left-0 block h-4.5 w-full"
+            />
           </div>
-
-          <ReceiptZigzag
-            aria-hidden
-            preserveAspectRatio="none"
-            className="pointer-events-none absolute top-full left-0 block h-4.5 w-full"
-          />
-        </div>
+        </ReceiptDrawMachine>
       </div>
     </main>
   );


### PR DESCRIPTION
## 작업 요약

- 친구 토너먼트 결과 화면에도 영수증 출력기 GUI·애니메이션을 적용합니다.

## 작업 세부 내용

개인 결과에만 있던 출력기가 친구 결과에는 없어 같은 영수증인데 화면마다 표현이 달랐습니다.

### `ReceiptDrawMachine` 일반화

기존에는 `ReceiptPaper` 를 직접 렌더하고 있어 재사용할 수 없었습니다. 친구 결과는 참여자 칩·펼치기 등 내용 구조가 달라 같은 props 로는 그릴 수 없기 때문입니다.

영수증 본문을 `children` 으로 받도록 바꿨습니다.

```tsx
// 전 — 개인 결과 전용
<ReceiptDrawMachine tournamentId={...} result={...} date={...} />

// 후 — 내용을 주입
<ReceiptDrawMachine>
  <ReceiptPaper ... />           {/* 개인 결과 */}
</ReceiptDrawMachine>

<ReceiptDrawMachine>
  <div>...친구 결과 영수증...</div>
</ReceiptDrawMachine>
```

프린터 프레임·슬롯 애니메이션·마스킹 로직을 두 화면이 공유합니다. 중복이 사라져 `-95 / +81` 로 줄었습니다.

## 검증

타입·린트 통과했습니다.

`tournamentResult.spec.ts` 는 4개 실패하지만 **dev 기준선과 동일**합니다(stash 후 대조 확인). 이번 변경으로 인한 회귀는 아닙니다.

## 확인 필요

친구 결과 영수증은 참여자 칩이 펼쳐지면 개인 결과보다 길어집니다. 긴 영수증에서 출력기 애니메이션이 자연스러운지는 실제 화면 확인이 필요합니다.

## 스크린샷

<img width="396" height="790" alt="스크린샷 2026-08-23 오후 9 23 29" src="https://github.com/user-attachments/assets/e4286616-ae19-49fb-b98b-c652fd500d20" />

## 연관 이슈

closes #546