### PR TITLE
feat: 초대 시트에 초대 코드 복사 기능 추가

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
@@ -147,10 +147,10 @@ function InviteFriendsDialog({
       <DrawerContent>
         <div className="flex flex-col items-center gap-6">
           <div className="flex flex-col items-center gap-1">
-            <DrawerTitle className="heading-1-bold text-text-neutral-primary">
+            <DrawerTitle className="heading-2-semibold text-text-neutral-primary">
               친구 초대하기
             </DrawerTitle>
-            <DrawerDescription className="body-1-medium text-text-neutral-tertiary">
+            <DrawerDescription className="body-2-regular text-text-neutral-secondary">
               초대 링크를 보내 친구와 함께 담을 수 있어요.
             </DrawerDescription>
           </div>

--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
@@ -4,7 +4,7 @@ import { ERROR_CODE, ERROR_MESSAGE_MAP } from '@piki/core';
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
-import { CheckIconFill, StopwatchIconFill } from '@/assets/icons/fill';
+import { CheckIconFill, TimerIconFill } from '@/assets/icons/fill';
 import Button from '@/components/button';
 import { Drawer, DrawerContent, DrawerDescription, DrawerTitle } from '@/components/drawer';
 import { ANALYTICS_EVENT } from '@/consts/analytics';
@@ -162,7 +162,7 @@ function InviteFriendsDialog({
                 <div className="flex w-full items-center justify-between rounded-xl border border-gray-75 p-4">
                   <div className="flex items-center gap-3">
                     <div className="flex size-11 items-center justify-center rounded-full bg-sky-blue-50">
-                      <StopwatchIconFill className="size-6 text-text-accent" />
+                      <TimerIconFill className="size-6 text-sky-blue-300" />
                     </div>
                     <div className="flex flex-col gap-0.5">
                       <p className="caption-1-semibold text-sky-blue-500">

--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
@@ -151,7 +151,7 @@ function InviteFriendsDialog({
               친구 초대하기
             </DrawerTitle>
             <DrawerDescription className="body-2-regular text-text-neutral-secondary">
-              초대 링크를 보내 친구와 함께 담을 수 있어요.
+              링크를 보내 친구와 함께 담을 수 있어요.
             </DrawerDescription>
           </div>
 

--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
@@ -10,10 +10,10 @@ import { Drawer, DrawerContent, DrawerDescription, DrawerTitle } from '@/compone
 import { ANALYTICS_EVENT } from '@/consts/analytics';
 import { logAnalyticsEvent } from '@/utils/analytics';
 import { parseServerLocalDateTime } from '@/utils/formatDate';
-import { share } from '@/utils/share';
+import { markInviteSent } from '@/utils/inviteSentSession';
+import { copyToClipboard, share } from '@/utils/share';
 
 import { usePatchInviteExpiry } from '../../_hooks/usePatchInviteExpiry';
-import { markInviteSent } from '@/utils/inviteSentSession';
 import InviteExpiresPicker from './InviteExpiresPicker';
 
 type InviteFriendsDialogProps = {
@@ -22,6 +22,8 @@ type InviteFriendsDialogProps = {
   /** 마감 시각 변경 API 호출용 */
   tournamentId: number;
   inviteUrl?: string;
+  /** 초대 코드 — 링크 대신 코드로 참여할 때 쓴다 */
+  inviteCode?: string;
   /** ISO 8601 — 초대 코드 만료 시각 */
   inviteExpiresAt?: string;
 };
@@ -68,6 +70,7 @@ function InviteFriendsDialog({
   onOpenChange,
   tournamentId,
   inviteUrl,
+  inviteCode,
   inviteExpiresAt,
 }: InviteFriendsDialogProps) {
   const [isPickerOpen, setIsPickerOpen] = useState(false);
@@ -90,6 +93,17 @@ function InviteFriendsDialog({
     usePatchInviteExpiry(tournamentId);
 
   const handleOpenPicker = () => setIsPickerOpen(true);
+
+  const handleCopyInviteCode = async () => {
+    if (!inviteCode) return;
+
+    try {
+      await copyToClipboard(inviteCode);
+      toast.success('초대 코드를 복사했어요.');
+    } catch {
+      toast.warning('이 환경에서는 복사를 지원하지 않아요.');
+    }
+  };
 
   const handleConfirmExpires = (newExpiresAt: string) => {
     patchInviteExpiryMutation(
@@ -141,41 +155,64 @@ function InviteFriendsDialog({
             </DrawerDescription>
           </div>
 
-          {expiresInfo && (
-            <div className="flex w-full items-center justify-between rounded-xl border border-border-neutral-muted bg-bg-layer-default px-4 py-5">
-              <div className="flex items-center gap-4">
-                <div className="flex size-11 items-center justify-center rounded-3xl bg-sky-blue-50">
-                  <StopwatchIconFill className="size-6 text-text-accent" />
-                </div>
-                <div className="flex flex-col gap-0.5">
-                  <p className="body-2-semibold text-text-accent">{expiresInfo.remainingLabel}</p>
-                  <p className="heading-1-bold text-text-neutral-primary">
-                    {expiresInfo.absoluteLabel}
-                  </p>
+          <div className="flex w-full flex-col gap-5">
+            {expiresInfo && (
+              <div className="flex flex-col gap-1">
+                <p className="body-2-medium text-text-neutral-primary">담기 기한</p>
+                <div className="flex w-full items-center justify-between rounded-xl border border-gray-75 p-4">
+                  <div className="flex items-center gap-3">
+                    <div className="flex size-11 items-center justify-center rounded-full bg-sky-blue-50">
+                      <StopwatchIconFill className="size-6 text-text-accent" />
+                    </div>
+                    <div className="flex flex-col gap-0.5">
+                      <p className="caption-1-semibold text-sky-blue-500">
+                        {expiresInfo.remainingLabel}
+                      </p>
+                      <p className="heading-2-semibold text-text-neutral-primary">
+                        {expiresInfo.absoluteLabel}
+                      </p>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    className="cursor-pointer body-2-medium text-text-neutral-tertiary"
+                    onClick={handleOpenPicker}
+                  >
+                    변경
+                  </button>
                 </div>
               </div>
-              <button
-                type="button"
-                className="cursor-pointer body-2-medium text-text-neutral-tertiary underline"
-                onClick={handleOpenPicker}
-              >
-                변경
-              </button>
-            </div>
-          )}
+            )}
 
-          <div className="flex w-full flex-col gap-2 rounded-xl bg-gray-50 p-4">
-            <div className="flex items-center gap-2">
-              <CheckIconFill className="size-4.5 text-text-neutral-secondary" />
-              <p className="body-2-medium text-text-neutral-secondary">
-                최대 7명까지 초대할 수 있어요.
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
-              <CheckIconFill className="size-4.5 text-text-neutral-secondary" />
-              <p className="body-2-medium text-text-neutral-secondary">
-                설정한 기한이 지나면 후보를 담을 수 없어요.
-              </p>
+            {inviteCode && (
+              <div className="flex flex-col gap-2">
+                <p className="body-2-medium text-text-neutral-primary">초대 코드</p>
+                <div className="flex w-full items-center justify-between rounded-xl border border-gray-75 p-4">
+                  <p className="heading-2-semibold text-text-neutral-primary">{inviteCode}</p>
+                  <button
+                    type="button"
+                    className="cursor-pointer body-2-medium text-text-neutral-tertiary"
+                    onClick={handleCopyInviteCode}
+                  >
+                    복사
+                  </button>
+                </div>
+              </div>
+            )}
+
+            <div className="flex w-full flex-col gap-1 rounded-xl bg-gray-50 px-4 py-3">
+              <div className="flex items-center gap-1">
+                <CheckIconFill className="size-4.5 text-text-neutral-secondary" />
+                <p className="caption-1-regular text-text-neutral-secondary">
+                  최대 7명까지 초대할 수 있어요.
+                </p>
+              </div>
+              <div className="flex items-center gap-1">
+                <CheckIconFill className="size-4.5 text-text-neutral-secondary" />
+                <p className="caption-1-regular text-text-neutral-secondary">
+                  설정한 기한이 지나면 후보를 담을 수 없어요.
+                </p>
+              </div>
             </div>
           </div>
 

--- a/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/invite-friends/InviteFriendsDialog.tsx
@@ -202,13 +202,13 @@ function InviteFriendsDialog({
 
             <div className="flex w-full flex-col gap-1 rounded-xl bg-gray-50 px-4 py-3">
               <div className="flex items-center gap-1">
-                <CheckIconFill className="size-4.5 text-text-neutral-secondary" />
+                <CheckIconFill className="size-4.5 text-icon-neutral-secondary" />
                 <p className="caption-1-regular text-text-neutral-secondary">
                   최대 7명까지 초대할 수 있어요.
                 </p>
               </div>
               <div className="flex items-center gap-1">
-                <CheckIconFill className="size-4.5 text-text-neutral-secondary" />
+                <CheckIconFill className="size-4.5 text-icon-neutral-secondary" />
                 <p className="caption-1-regular text-text-neutral-secondary">
                   설정한 기한이 지나면 후보를 담을 수 없어요.
                 </p>

--- a/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantPanel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantPanel.tsx
@@ -158,6 +158,7 @@ function ParticipantPanel({
         onOpenChange={setIsInviteDialogOpen}
         tournamentId={Number(tournamentId)}
         inviteUrl={inviteUrl}
+        inviteCode={inviteCode}
         inviteExpiresAt={inviteExpiresAt}
       />
     </>

--- a/apps/web/src/utils/share.ts
+++ b/apps/web/src/utils/share.ts
@@ -11,7 +11,7 @@ const canUseWebShare = (data: ShareDataT) => {
   return true;
 };
 
-const copyToClipboard = async (text: string) => {
+export const copyToClipboard = async (text: string) => {
   if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
     await navigator.clipboard.writeText(text);
     return;


### PR DESCRIPTION
## 작업 요약

- 친구 초대 시트에 초대 코드 카드와 복사 버튼을 추가합니다.
- 시안에 맞춰 라벨·타이포·아이콘을 정리합니다.

## 작업 세부 내용

### 1. 초대 코드 복사

링크 공유만 가능해 코드로 참여하려는 친구에게 코드를 알려줄 방법이 없었습니다.

```
초대 코드
┌──────────────────────────┐
│ ABC123              복사 │
└──────────────────────────┘
```

`utils/share.ts` 의 `copyToClipboard` 가 내부 함수로 묶여 있어 export 해서 재사용했습니다. 복사 성공 시 토스트, 미지원 환경에서는 안내가 나갑니다.

`inviteCode` 는 `ParticipantPanel` 이 이미 갖고 있어(`buildInviteUrl` 에 쓰임) 시트로 내려주는 것으로 끝났습니다.

### 2. 시안 반영

| 항목 | 전 | 후 |
| --- | --- | --- |
| 섹션 라벨 | 없음 | `담기 기한` · `초대 코드` |
| 기한 카드 타이포 | `body-2-semibold` / `heading-1-bold` | `caption-1-semibold` / `heading-2-semibold` |
| 남은 시간 색 | `text-accent` | `sky-blue-500` |
| 기한 아이콘 | `StopwatchIconFill` (점선 원형) | **`TimerIconFill`** (fill) |
| 기한 아이콘 색 | `text-accent` | `sky-blue-300` (#76cefd) |
| 체크 아이콘 색 | `text-neutral-secondary` | `icon-neutral-secondary` (#adb1bb) |
| 카드 테두리 | `border-neutral-muted` | `gray-75` |
| 안내 문구 | `body-2-medium` | `caption-1-regular` |
| `변경` 버튼 | 밑줄 | 밑줄 없음 |

아이콘은 시안 SVG 를 받아 path 를 대조했습니다. 기존 `stopwatch` 는 점선 원형 테두리라 다른 모양이었고, 프로젝트에 이미 있던 `fill/timer.svg` 가 시안과 동일했습니다.

색상 값도 시안과 정확히 일치하는 토큰을 골랐습니다(`#76cefd` = `sky-blue-300`, `#adb1bb` = `icon-neutral-secondary`).

## 검증

타입·린트 통과했습니다. 사용한 토큰(`caption-1-regular`, `heading-2-semibold`, `sky-blue-300/500`, `gray-75`)이 모두 존재하는지 확인했습니다.

이 시트를 다루는 e2e 는 없습니다. 실제 화면과 복사 동작은 확인하지 못했습니다.

## 스크린샷

<img width="396" height="792" alt="image" src="https://github.com/user-attachments/assets/f9de4d64-2f3d-4647-9840-01facfc7fbf9" />

## 연관 이슈

closes #548
