### PR TITLE
fix: 즉시 시작 확인 모달 사이즈·라이팅을 시안대로 조정

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/ConfirmStartDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/ConfirmStartDialog.tsx
@@ -16,26 +16,28 @@ function ConfirmStartDialog({ open, onOpenChange, onConfirm }: ConfirmStartDialo
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent showCloseButton={false} className="flex flex-col items-center gap-5 p-6">
-        <ConfirmStartFace className="size-7.75" aria-hidden />
+      <DialogContent showCloseButton={false} className="max-w-83 flex-col items-center gap-5 p-4">
+        <div className="flex flex-col items-center gap-3">
+          <ConfirmStartFace className="size-7.5" aria-hidden />
 
-        <div className="flex flex-col items-center gap-1">
-          <DialogTitle className="text-center heading-1-bold text-text-neutral-primary">
-            토너먼트를 정말 바로 시작할까요?
-          </DialogTitle>
-          <DialogDescription className="text-center body-2-medium text-text-neutral-tertiary">
-            바로 시작하면 담지 못한 친구가
-            <br />
-            있을 수 있어요.
-          </DialogDescription>
+          <div className="flex flex-col items-center gap-1">
+            <DialogTitle className="text-center heading-2-semibold text-text-neutral-primary">
+              토너먼트를 바로 시작할까요?
+            </DialogTitle>
+            <DialogDescription className="text-center body-2-medium text-text-neutral-tertiary">
+              바로 시작하면 담지 못한 친구가
+              <br />
+              있을 수 있어요.
+            </DialogDescription>
+          </div>
         </div>
 
-        <div className="flex w-full gap-2">
+        <div className="flex w-full gap-2.5">
           <Button variant="secondary" size="lg" onClick={handleCancel}>
             돌아가기
           </Button>
           <Button variant="primary" size="lg" onClick={onConfirm}>
-            바로 시작할래요
+            바로 시작하기
           </Button>
         </div>
       </DialogContent>


### PR DESCRIPTION
## 작업 내용

즉시 시작 확인 모달을 시안 기준으로 정리했습니다.

**라이팅**
- `토너먼트를 정말 바로 시작할까요?` → `토너먼트를 바로 시작할까요?`
- `바로 시작할래요` → `바로 시작하기`

**모달 사이즈**
- 폭 332px, padding 16px 적용
- 제목 타이포 heading-1-bold → heading-2-semibold
- 아이콘과 텍스트를 한 그룹(gap 12px)으로 묶고, 그룹과 버튼 사이 간격 20px
- 버튼 간격 8px → 10px

## 스크린샷

<img width="394" height="786" alt="image" src="https://github.com/user-attachments/assets/b3bd3faf-0a42-49fe-8eae-2626855d0387" />

## 연관 이슈

closes #550