### PR TITLE
fix: 토너먼트 시작 후 CTA 상단 안내 토스트 제거

### DIFF
--- a/apps/web/src/app/tournament/[id]/_common/_types/tournamentResponse.ts
+++ b/apps/web/src/app/tournament/[id]/_common/_types/tournamentResponse.ts
@@ -34,7 +34,7 @@ export type TournamentPendingItemT = Partial<TournamentItemT> & {
 type TournamentPendingPayloadT = {
   /**
    * 주최자가 ROOT 토너먼트를 시작했는지 여부.
-   * - false (status=PENDING): "주최자가 시작해야..." 안내
+   * - false (status=PENDING): 참여자는 아직 시작할 수 없음
    * - true (status=IN_PROGRESS): 참여자도 본인 CLONE 시작 가능
    */
   ownerStarted: boolean;

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/TournamentStartButton.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/TournamentStartButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import Button from '@/components/button';
 
@@ -8,8 +8,6 @@ import { usePostTournamentStart } from '../../_hooks/usePostTournamentStart';
 import { needsByeWarning } from '../../_utils/bye';
 import ByeWarningDialog from './ByeWarningDialog';
 import ConfirmStartDialog from './ConfirmStartDialog';
-
-const PARTICIPANT_TOOLTIP_DURATION_MS = 3_000;
 
 /**
  * count 가 2의 거듭제곱(2, 4, 8, 16, 32) 인지 검사.
@@ -38,17 +36,6 @@ function TournamentStartButton({
   const [isByeWarningOpen, setIsByeWarningOpen] = useState(false);
   const { postTournamentStartMutation, isPostTournamentStartPending } =
     usePostTournamentStart(tournamentId);
-
-  const [isTooltipVisible, setIsTooltipVisible] = useState(isWaitingForOwnerStart);
-
-  useEffect(() => {
-    if (!isWaitingForOwnerStart) return;
-    const timeoutId = window.setTimeout(
-      () => setIsTooltipVisible(false),
-      PARTICIPANT_TOOLTIP_DURATION_MS
-    );
-    return () => window.clearTimeout(timeoutId);
-  }, [isWaitingForOwnerStart]);
 
   const startTournament = () => postTournamentStartMutation();
 
@@ -97,18 +84,6 @@ function TournamentStartButton({
 
   return (
     <>
-      {isTooltipVisible && (
-        <div className="flex justify-center">
-          <span className="relative inline-flex items-center rounded-md bg-gray-700 px-3 py-2 caption-1-regular text-text-neutral-inverse">
-            주최자가 시작해야 플레이 할 수 있어요
-            <span
-              aria-hidden
-              className="absolute -bottom-1 left-1/2 size-2 -translate-x-1/2 rotate-45 bg-gray-700"
-            />
-          </span>
-        </div>
-      )}
-
       <Button
         variant="primary"
         size="lg"


### PR DESCRIPTION
## 작업 내용

주최자가 토너먼트를 시작한 뒤에도 남아 있던 `주최자가 시작해야 플레이 할 수 있어요` 안내 토스트를 삭제했습니다.

주최자가 시작하면 `주최자가 토너먼트를 시작했어요!` 모달이 뜨므로 안내가 중복됩니다.

- CTA 상단 안내 토스트 UI 제거
- 토스트 노출용 state·타이머 제거
- 버튼 비활성화·클릭 차단 동작(`isWaitingForOwnerStart`)은 유지

## 스크린샷

<img width="453" height="869" alt="image" src="https://github.com/user-attachments/assets/81f75db6-9844-43f2-ae9b-ebde8093e813" />

## 연관 이슈

closes #552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 주최자 시작 전 참가자 제한 상태에 대한 설명을 명확히 했습니다.
  * 토너먼트 시작 버튼에서 참가자 안내 툴팁을 제거했습니다.
  * 토너먼트 시작, 부전승 경고, 확인 모달 및 버튼 동작은 기존과 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->