### PR TITLE
fix: 친구 토너먼트 결과 상품 이미지를 이미지 프록시 경유로 로드

### DIFF
--- a/apps/web/src/app/tournament/[id]/result/group/_components/GroupResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/group/_components/GroupResultClient.tsx
@@ -215,7 +215,6 @@ function GroupProductCard({ item, highlight = false }: GroupProductCardProps) {
                 width={60}
                 height={60}
                 className="size-full object-cover"
-                unoptimized
               />
             ) : null}
           </div>


### PR DESCRIPTION
## 작업 내용

친구 토너먼트 결과 화면(`/tournament/[id]/result/group`)에서 상품 이미지가 403 으로 깨지던 문제를 수정했습니다.

`next/image` 의 `unoptimized` 때문에 Next 의 `/_next/image` 프록시를 건너뛰고 원본 URL 을 그대로 로드하고 있었습니다. 브라우저가 쇼핑몰 이미지 서버에 직접 요청하면서 `Referer` 가 붙어 핫링크 차단에 걸렸습니다.

```
Referer 없음            → 200
Referer: dev.piki.day   → 403
```

`unoptimized` 를 제거해 영수증 화면과 동일하게 이미지 프록시를 경유하도록 했습니다. Next 서버가 대신 받아오므로 Referer 가 없어 통과합니다.

## 연관 이슈

closes #555