### PR TITLE
style: 토너먼트 진행 화면 vs 카드 간격·라운드 칩 디자인 수정

### DIFF
--- a/apps/web/src/app/tournament/[id]/match/_components/RoundBadge.tsx
+++ b/apps/web/src/app/tournament/[id]/match/_components/RoundBadge.tsx
@@ -16,7 +16,7 @@ function RoundBadge({ label, isFinal = false }: RoundBadgeProps) {
   }
 
   return (
-    <div className="inline-flex items-center justify-center gap-2.5 rounded-[30px] bg-gray-100 px-5 py-4 body-1-bold text-text-neutral-primary">
+    <div className="inline-flex items-center justify-center gap-2.5 rounded-[30px] bg-gray-100 px-5 py-3 heading-2-semibold text-text-neutral-primary">
       {label}
     </div>
   );

--- a/apps/web/src/app/tournament/[id]/match/_components/TournamentClient.tsx
+++ b/apps/web/src/app/tournament/[id]/match/_components/TournamentClient.tsx
@@ -38,7 +38,7 @@ function TournamentClient({ tournamentId, tournamentName, inProgress }: Tourname
     <main
       className={`hide-scrollbar flex min-h-dvh flex-col items-center overflow-y-auto px-5 pt-padding-top pb-6 ${backgroundClassName}`}
     >
-      <div className="flex flex-col items-center gap-6">
+      <div className="mt-6 flex flex-col items-center gap-6">
         <div className="flex flex-col items-center gap-4">
           <RoundBadge label={roundLabel} isFinal={isFinalRound} />
           <TournamentQuestion isFinal={isFinalRound} />

--- a/apps/web/src/app/tournament/[id]/match/_components/TournamentClient.tsx
+++ b/apps/web/src/app/tournament/[id]/match/_components/TournamentClient.tsx
@@ -47,7 +47,7 @@ function TournamentClient({ tournamentId, tournamentName, inProgress }: Tourname
           <p className="heading-2-medium text-text-neutral-secondary">최종 선택을 해주세요</p>
         )}
       </div>
-      <div className={`w-full ${isFinalRound ? 'mt-29' : 'mt-8'}`}>
+      <div className={`-mx-5 ${isFinalRound ? 'mt-29' : 'mt-8'}`}>
         {/* 기록 대기 중에는 이전 화면을 유지해 스켈레톤 깜빡임을 방지한다. */}
         {!currentMatch ? (
           <MatchSkeleton isFinal={isFinalRound} />

--- a/apps/web/src/app/tournament/[id]/match/_components/VsSection.tsx
+++ b/apps/web/src/app/tournament/[id]/match/_components/VsSection.tsx
@@ -63,10 +63,10 @@ function VsSection({ left, right, isFinal = false, onSelect }: VsSectionProps) {
       )}
 
       {/* 카드 영역 */}
-      <div className="relative flex gap-3">
+      <div className="flex justify-center gap-1.5">
         {/* 왼쪽 */}
         <div
-          className={`flex min-w-0 flex-1 flex-col items-center ${transition}`}
+          className={`flex w-[148px] flex-col items-center ${transition}`}
           style={{
             transform: `translateY(${leftCardShift}px) scale(${leftCardStyle.scale})`,
             ...(leftCardStyle.blur > 0 && { filter: `blur(${leftCardStyle.blur}px)` }),
@@ -90,9 +90,21 @@ function VsSection({ left, right, isFinal = false, onSelect }: VsSectionProps) {
           />
         </div>
 
+        {/* VS 뱃지 */}
+        <div
+          className={`z-10 flex size-8 shrink-0 items-center justify-center rounded-full bg-bg-neutral-secondary text-[12.026px] leading-[17.18px] font-semibold tracking-[-0.515px] text-white ${transition}`}
+          style={{
+            marginTop: isFinal ? IMAGE_HEIGHT / 2 - 16 : HOOK_HEIGHT + IMAGE_HEIGHT - 16,
+            filter: selectedSide ? 'blur(2px)' : 'none',
+            ...duration,
+          }}
+        >
+          VS
+        </div>
+
         {/* 오른쪽 */}
         <div
-          className={`flex min-w-0 flex-1 flex-col items-center ${transition}`}
+          className={`flex w-[148px] flex-col items-center ${transition}`}
           style={{
             transform: `translateY(${rightCardShift}px) scale(${rightCardStyle.scale})`,
             ...(rightCardStyle.blur > 0 && { filter: `blur(${rightCardStyle.blur}px)` }),
@@ -114,18 +126,6 @@ function VsSection({ left, right, isFinal = false, onSelect }: VsSectionProps) {
             isPicked={selectedSide === 'right'}
             onClick={() => handleClick('right', right)}
           />
-        </div>
-
-        {/* VS 뱃지 */}
-        <div
-          className={`absolute left-1/2 z-10 flex size-8 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-bg-neutral-secondary text-[12.026px] leading-[17.18px] font-semibold tracking-[-0.515px] text-white ${transition}`}
-          style={{
-            top: isFinal ? IMAGE_HEIGHT / 2 : HOOK_HEIGHT + IMAGE_HEIGHT,
-            filter: selectedSide ? 'blur(2px)' : 'none',
-            ...duration,
-          }}
-        >
-          VS
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 작업 요약

- 토너먼트 플레이 화면(M-07) 디자인 수정

## 작업 세부 내용

- 라운드 칩 패딩 수정 (py-4 → py-3) 및 폰트 변경 (body-1-bold → heading-2-semibold)
- 헤더 영역 상단 간격 추가 (mt-6)
- VS 배지 레이아웃 변경: absolute 포지셔닝 → 인라인 배치, 카드↔VS 간격 6px 적용

## 스크린샷
<img width="325" height="705" alt="스크린샷 2026-08-24 오후 11 27 53" src="https://github.com/user-attachments/assets/ed584b4f-8e0b-4ff4-93a3-b8a4f009e35d" />


## 연관 이슈

closes #559


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 일반 라운드 배지의 간격과 세로 여백을 조정하고, 텍스트 강조 스타일을 개선했습니다.
  * 경기 카드와 VS 배지를 가로로 정렬해 대진 구성을 더 명확하게 표시합니다.
  * 경기 화면 상단 콘텐츠의 여백을 조정해 전체 레이아웃을 개선했습니다.
  * 결승전 배지의 동작과 표시 방식은 기존과 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->