### PR TITLE
fix: 플레이링크 게스트 전체 결과 보기 진입 시 403 홈 리다이렉트 수정

### DIFF
--- a/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
@@ -63,8 +63,6 @@ function ResultClient({ tournamentId, isGuest = false, isApp = false }: ResultCl
   const result = tournamentData.completed.result;
   // 플레이 링크 공유는 ROOT 의 소유자만 가능 — CLONE 소유자(친구 초대 → CLONE 생성한 사람) 제외
   const canSharePlayLink = tournamentData.isRoot && tournamentData.isOwner;
-  // 그룹 결과는 원본(ROOT) 단위로 집계된다. CLONE 에서 보고 있으면 원본 id 로 조회해야 한다.
-  const groupResultTournamentId = tournamentData.sourceTournamentId ?? tournamentId;
 
   const handleSharePlayLink = () => {
     setIsShareDialogOpen(true);
@@ -92,9 +90,10 @@ function ResultClient({ tournamentId, isGuest = false, isApp = false }: ResultCl
         )}
 
         {/* 전체 결과 보기 — 소셜 토너먼트면 주최자·참여자·게스트 모두에게 항상 노출 */}
+        {/* URL은 현재 토너먼트 ID로 설정 - sourceTournament 이동은 그룹 결과 페이지 내부에서 처리 */}
         {tournamentData.completed.isGroupTournament && (
           <div className="mx-5">
-            <GroupResultEntryCard tournamentId={groupResultTournamentId} />
+            <GroupResultEntryCard tournamentId={tournamentId} />
           </div>
         )}
       </div>

--- a/apps/web/src/app/tournament/[id]/result/group/_components/GroupResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/group/_components/GroupResultClient.tsx
@@ -2,6 +2,7 @@
 
 import { Kode_Mono } from 'next/font/google';
 import Image from 'next/image';
+import type { ReactNode } from 'react';
 import { useState } from 'react';
 
 import {
@@ -12,6 +13,7 @@ import {
 import PikiLogo from '@/assets/images/piki-logo-cart.svg';
 import ReceiptZigzag from '@/assets/images/tournament/result/receipt-zigzag.svg';
 import TrophyBadge from '@/assets/images/tournament/result/trophy-badge.svg';
+import Spinner from '@/components/spinner';
 import { ROUTES } from '@/consts/route';
 import { useBackWithFallback } from '@/hooks/useBackWithFallback';
 import { cn } from '@/utils/cn';
@@ -29,6 +31,25 @@ type GroupResultClientProps = {
 };
 
 const SectionDivider = () => <div className="h-px w-full border-t border-dashed border-gray-100" />;
+
+const GroupResultShell = ({ onBack, children }: { onBack: () => void; children: ReactNode }) => (
+  <main className="flex min-h-dvh flex-col bg-bg-layer-basement pt-padding-top pb-8">
+    <header className="relative flex h-7.5 w-full shrink-0 items-center px-5">
+      <button
+        type="button"
+        aria-label="뒤로가기"
+        onClick={onBack}
+        className="cursor-pointer p-0.75"
+      >
+        <ChevronBackwardIconFill className="size-6 text-icon-neutral-secondary" />
+      </button>
+      <h1 className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 heading-1-bold text-text-neutral-primary">
+        친구 토너먼트 결과
+      </h1>
+    </header>
+    {children}
+  </main>
+);
 
 /**
  * 영수증 구분선 라벨. 라벨 길이에 상관없이 항상 영수증 전체 폭을 채우도록
@@ -64,24 +85,21 @@ function GroupResultClient({ tournamentId }: GroupResultClientProps) {
 
   const date = new Date();
   const tournamentName = tournamentData.name;
+  const handleBack = () => backWithFallback(ROUTES.TOURNAMENT_RESULT(tournamentId));
 
-  // 친구가 아직 본인 매치를 시작 안 했거나, 권한 없음 등으로 데이터를 받지 못한 경우.
-  if (isGroupResultPending || isGroupResultError || !groupResultData) {
+  if (isGroupResultPending) {
     return (
-      <main className="flex min-h-dvh flex-col bg-bg-layer-basement pt-padding-top pb-8">
-        <header className="relative flex h-7.5 w-full shrink-0 items-center px-5">
-          <button
-            type="button"
-            aria-label="뒤로가기"
-            onClick={() => backWithFallback(ROUTES.TOURNAMENT_RESULT(tournamentId))}
-            className="cursor-pointer p-0.75"
-          >
-            <ChevronBackwardIconFill className="size-6 text-icon-neutral-secondary" />
-          </button>
-          <h1 className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 heading-1-bold text-text-neutral-primary">
-            친구 토너먼트 결과
-          </h1>
-        </header>
+      <GroupResultShell onBack={handleBack}>
+        <div className="flex flex-1 items-center justify-center px-5">
+          <Spinner size={32} />
+        </div>
+      </GroupResultShell>
+    );
+  }
+
+  if (isGroupResultError || !groupResultData) {
+    return (
+      <GroupResultShell onBack={handleBack}>
         <div className="flex flex-1 flex-col items-center justify-center gap-2 px-5">
           <p className="heading-1-bold text-text-neutral-primary">아직 친구 결과가 없어요</p>
           <p className="text-center body-1-medium text-text-neutral-tertiary">
@@ -90,7 +108,7 @@ function GroupResultClient({ tournamentId }: GroupResultClientProps) {
             결과를 비교해볼 수 있어요.
           </p>
         </div>
-      </main>
+      </GroupResultShell>
     );
   }
 
@@ -99,21 +117,7 @@ function GroupResultClient({ tournamentId }: GroupResultClientProps) {
   const otherItems = sortedItems.filter(item => item.rank !== 1);
 
   return (
-    <main className="flex min-h-dvh flex-col bg-bg-layer-basement pt-padding-top pb-8">
-      <header className="relative flex h-7.5 w-full shrink-0 items-center px-5">
-        <button
-          type="button"
-          aria-label="뒤로가기"
-          onClick={() => backWithFallback(ROUTES.TOURNAMENT_RESULT(tournamentId))}
-          className="cursor-pointer p-0.75"
-        >
-          <ChevronBackwardIconFill className="size-6 text-icon-neutral-secondary" />
-        </button>
-        <h1 className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 heading-1-bold text-text-neutral-primary">
-          친구 토너먼트 결과
-        </h1>
-      </header>
-
+    <GroupResultShell onBack={handleBack}>
       <div className="mx-auto mt-5 flex w-full max-w-105 flex-1 flex-col px-5">
         <ReceiptDrawMachine>
           <div className="relative flex w-full flex-col gap-2 bg-bg-layer-default pt-6 pb-6.25 filter-[drop-shadow(0px_2px_4px_rgba(0,0,0,0.12))]">
@@ -190,7 +194,7 @@ function GroupResultClient({ tournamentId }: GroupResultClientProps) {
           </div>
         </ReceiptDrawMachine>
       </div>
-    </main>
+    </GroupResultShell>
   );
 }
 

--- a/apps/web/src/app/tournament/[id]/result/group/_components/GroupResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/group/_components/GroupResultClient.tsx
@@ -54,8 +54,13 @@ const PlaceLabel = ({ label }: { label: string }) => (
 function GroupResultClient({ tournamentId }: GroupResultClientProps) {
   const backWithFallback = useBackWithFallback();
   const { tournamentData } = useGetTournament(tournamentId);
+  // 그룹 결과는 원본(ROOT) 단위로 집계된다. CLONE 에서 진입하면 원본 id 로 조회한다.
+  const groupResultTournamentId =
+    'sourceTournamentId' in tournamentData && tournamentData.sourceTournamentId
+      ? tournamentData.sourceTournamentId
+      : tournamentId;
   const { groupResultData, isGroupResultPending, isGroupResultError } =
-    useGetGroupResult(tournamentId);
+    useGetGroupResult(groupResultTournamentId);
 
   const date = new Date();
   const tournamentName = tournamentData.name;

--- a/apps/web/src/app/tournament/[id]/result/group/page.tsx
+++ b/apps/web/src/app/tournament/[id]/result/group/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { parseIdParam } from '@/utils/parseIdParam';
 import { getQueryClient } from '@/utils/queryClient';
 
+import { getTournament } from '../../_common/_apis/getTournament';
 import { getGroupResult } from '../_apis/getGroupResult';
 import GroupResultClient from './_components/GroupResultClient';
 
@@ -18,9 +19,21 @@ async function GroupResultPage({ params }: GroupResultPageProps) {
   if (tournamentId === null) notFound();
 
   const queryClient = getQueryClient();
+
+  // 그룹 결과는 원본(ROOT) 단위로 집계된다. CLONE 진입이면 원본 id 로 조회해야 해서 토너먼트를 먼저 확인한다.
+  // (layout 과 병렬 렌더라 캐시 히트가 보장되지 않아 ensureQueryData 로 조회)
+  const tournamentData = await queryClient.ensureQueryData({
+    queryKey: ['tournament', tournamentId],
+    queryFn: () => getTournament(tournamentId),
+  });
+  const groupResultTournamentId =
+    'sourceTournamentId' in tournamentData && tournamentData.sourceTournamentId
+      ? tournamentData.sourceTournamentId
+      : tournamentId;
+
   queryClient.prefetchQuery({
-    queryKey: ['groupResult', tournamentId],
-    queryFn: () => getGroupResult(tournamentId),
+    queryKey: ['groupResult', groupResultTournamentId],
+    queryFn: () => getGroupResult(groupResultTournamentId),
   });
 
   return (


### PR DESCRIPTION
## 작업 요약

- 플레이링크 게스트가 전체 결과 보기를 누르면 403 으로 홈에 튕기던 문제를 수정합니다 (그룹 결과 페이지를 자기 토너먼트 id URL 로 진입시키고, 그룹 결과 API 만 원본 id 로 호출)
- 그룹 결과 로딩 중에 빈 상태 문구("아직 친구 결과가 없어요")가 노출되던 것을 스피너로 분리합니다

## 작업 세부 내용

### 배경

전체 결과 보기 링크가 페이지 URL 자체를 원본(ROOT) id 로 옮기는 구조였습니다 (`/tournament/{rootId}/result/group`). `tournament/[id]/layout.tsx` 가 진입 게이트로 원본 단건 조회(`GET /tournaments/{rootId}`)를 하는데, 플레이링크 게스트는 ROOT 의 참여자가 아니라 403(`TOURNAMENT-001`)을 받고 홈으로 리다이렉트됐습니다. 정작 그룹 결과 API 는 플레이링크 게스트에게 허용돼 있어서(api-docs: "플레이 링크로 복제된 모든 토너먼트의 결과를 비교") 데이터는 볼 수 있는 사람인데 URL 구조 때문에 문 앞에서 튕기는 상황이었습니다.

서버에 ROOT 단건 조회 권한을 열어달라는 방향은 참여자 목록·초대코드 등 불필요한 정보까지 노출하는 과한 권한이라 배제하고, 프론트 라우팅을 수정했습니다.

### 그룹 결과 진입 URL 을 자기 토너먼트 id 로 변경 (403 수정)

- `result/_components/ResultClient.tsx` — 전체 결과 보기 링크를 원본 id 대신 현재 페이지 `tournamentId` 로 변경. layout 게이트가 본인 소유 토너먼트를 조회하게 되어 게스트도 통과합니다
- `result/group/_components/GroupResultClient.tsx` — 화면 정보(`useGetTournament`)는 자기 id, 그룹 결과(`useGetGroupResult`)는 `sourceTournamentId ?? 자기 id` 로 분리. ROOT 주인은 `sourceTournamentId` 가 없어 기존과 동일하게 동작합니다
- `result/group/page.tsx` — 서버 prefetch 도 같은 규칙 적용. URL 에서 원본 id 가 사라져 `ensureQueryData` 로 토너먼트를 확인한 뒤(layout 이 캐시에 넣었으면 재요청 없음) 원본 id 로 group-result 를 prefetch 하고, queryKey 도 `['groupResult', 원본id]` 로 클라이언트와 맞췄습니다

### 그룹 결과 로딩 상태 분리 + 화면 골격 중복 제거

- 기존에는 `isGroupResultPending` 도 빈 상태 분기에 묶여 있어, 로딩 중에 "아직 친구 결과가 없어요" 가 먼저 보였다가 결과가 나타났습니다. 로딩은 공통 `Spinner`(size 32) 로 분리하고, 빈 상태 문구는 에러·데이터 없음일 때만 노출합니다
- 로딩·빈 상태·결과 세 리턴이 `<main>` + 헤더(뒤로가기·타이틀)를 통째로 중복하고 있어 `GroupResultShell` 로컬 컴포넌트로 추출했습니다

### 검증

- dev 환경에서 플레이링크 게스트 시나리오 재현: layout 통과 → group-result(원본 id) 조회 성공 → 그룹 결과 화면 정상 진입 확인
- `check-types` / `lint` / `prettier` 통과

## 스크린샷

https://github.com/user-attachments/assets/fe902014-33b2-4a59-bf8e-2c045147ab5c


## 연관 이슈

closes #563


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 클론 토너먼트에서도 원본 토너먼트의 그룹 결과를 정확히 조회하도록 개선했습니다.
  * 그룹 결과 화면의 로딩 및 오류 상태 표시를 분리하고, 일관된 뒤로가기 헤더와 레이아웃을 적용했습니다.
  * 로딩 중에는 스피너가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->