### PR TITLE
feat: INCOMPLETE 상품 상세 페이지에서 삭제 지원

### DIFF
--- a/apps/web/src/components/common/item-info-screen/index.tsx
+++ b/apps/web/src/components/common/item-info-screen/index.tsx
@@ -53,6 +53,9 @@ function ItemInfoScreen({
   /** 조회 모드 여부 — READY 이면서 수정 버튼을 누르지 않은 상태 */
   const isDetailMode = isReadyItemInfo(item) && !isEditing;
 
+  const isUnresolvedItem =
+    item.status === ITEM_STATUS.FAILED || item.status === ITEM_STATUS.INCOMPLETE;
+
   const handleRefreshFailedEdit = () => {
     priceRefresh?.closeFailedDialog();
     setIsEditing(true);
@@ -65,9 +68,9 @@ function ItemInfoScreen({
         left={<HeaderIcon name="BACK" {...(isEditing && { onClick: () => setIsEditing(false) })} />}
         center={isDetailMode ? viewTitle : '위시 정보 수정'}
         centerClassName="heading-1-bold"
-        /** 삭제는 조회 화면과 FAILED 수집 실패 화면에서 노출 */
+        /** 삭제는 조회 화면과 FAILED·INCOMPLETE 입력 화면에서 노출 */
         right={
-          (isDetailMode || item.status === ITEM_STATUS.FAILED) &&
+          (isDetailMode || isUnresolvedItem) &&
           !readOnly && (
             <button
               type="button"


### PR DESCRIPTION
## 작업 요약

- 정보를 일부만 가져온(INCOMPLETE) 상품도 상세 페이지에서 삭제할 수 있습니다

## 작업 세부 내용

- 위시 상세·토너먼트 상품 상세가 공용으로 쓰는 `ItemInfoScreen` 의 헤더 삭제 버튼 노출 조건에 `INCOMPLETE` 를 추가했습니다. 
- `FAILED` 와 성격이 같아 `isUnresolvedItem`(수집은 끝났지만 정보가 온전하지 않아 조회 화면 없이 입력 폼만 보이는 상태)으로 묶었습니다.
- 두 화면 모두 이미 `onDelete` / `isDeletePending` 을 넘기고 있어 공통 컴포넌트 한 곳 수정으로 위시리스트·담기 양쪽 진입 경로가 함께 해결
- 기존 동작은 그대로 유지됩니다.
  - `PENDING`·`PROCESSING`(수집 중) → 삭제 버튼 미노출
  - `READY` 에서 "상품 정보 수정"으로 진입한 폼 → 미노출 (뒤로가기는 조회 화면 복귀)
  - 토너먼트 상품은 `readOnly`(주최자·본인 아님)이면 미노출

## 스크린샷

|                 INCOMPLETE 상세 (as-is)                 |                 INCOMPLETE 상세 (to-be)                 |
| :-----------------------------------------------------: | :-----------------------------------------------------: |
| <img width="482" height="965" alt="image" src="https://github.com/user-attachments/assets/4a0437b7-5d2c-40bf-8f67-b6ca7ce31d33" /> |    <img width="481" height="979" alt="image" src="https://github.com/user-attachments/assets/e2c689a8-b734-48f2-80d5-65707f75f750" />  |

## 연관 이슈

closes #565 
