### PR TITLE
feat: 영수증 공유 버튼 통합 (공유 1개 + 인스타 스토리 공유)

### DIFF
--- a/apps/web/e2e/specs/tournament/tournamentResult.spec.ts
+++ b/apps/web/e2e/specs/tournament/tournamentResult.spec.ts
@@ -79,8 +79,8 @@ test('웹 브라우저에서는 공유 시트에 스토리 공유 버튼이 없�
   await page.goto('/tournament/3/result');
   await page.getByRole('button', { name: '영수증 저장' }).click();
 
-  await expect(page.getByRole('button', { name: '이미지 저장' })).toBeVisible();
-  await expect(page.getByRole('button', { name: '스토리 공유' })).toBeHidden();
+  await expect(page.getByRole('button', { name: '공유하기', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: '스토리로 바로 공유하기' })).toBeHidden();
 });
 
 test.describe('앱(웹뷰) 환경', () => {
@@ -126,7 +126,7 @@ test.describe('앱(웹뷰) 환경', () => {
     await page.goto('/tournament/3/result');
     await page.getByRole('button', { name: '영수증 저장' }).click();
 
-    const storyButton = page.getByRole('button', { name: '스토리 공유' });
+    const storyButton = page.getByRole('button', { name: '스토리로 바로 공유하기' });
     await expect(storyButton).toBeEnabled();
     await storyButton.click();
 

--- a/apps/web/src/app/tournament/[id]/result/_components/receipt-share-dialog/ReceiptShareDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/receipt-share-dialog/ReceiptShareDialog.tsx
@@ -3,23 +3,16 @@
 import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import { toast } from 'sonner';
 
-import { CopyIconFill, DownloadIconFill, LinkIconOutline } from '@/assets/icons';
-import InstagramIcon from '@/assets/icons/social/instagram.svg';
+import Button from '@/components/button';
 import { Drawer, DrawerContent, DrawerDescription, DrawerTitle } from '@/components/drawer';
 import Skeleton from '@/components/skeleton';
 import { ANALYTICS_EVENT } from '@/consts/analytics';
 import { useInstagramStoryShare } from '@/hooks/useInstagramStoryShare';
 import { logAnalyticsEvent } from '@/utils/analytics';
-import { cn } from '@/utils/cn';
 import { isWebview } from '@/utils/webBridge';
 
 import type { RankedProductT } from '../../../_common/_types/tournament';
-import {
-  captureReceiptImage,
-  copyReceiptImage,
-  saveReceiptImage,
-  shareReceiptImageFile,
-} from '../../_utils/shareReceiptImage';
+import { captureReceiptImage, shareReceiptImageFile } from '../../_utils/shareReceiptImage';
 import ReceiptShareCaptureLayer from './ReceiptShareCaptureLayer';
 
 type ReceiptShareDialogProps = {
@@ -32,42 +25,6 @@ type ReceiptShareDialogProps = {
   /** 서버가 UA 로 판정한 앱 여부 — 스토리 공유 버튼 노출에 쓴다 */
   isApp?: boolean;
 };
-
-type ShareActionProps = {
-  icon: React.ReactNode;
-  label: string;
-  /** 원형 배경색 클래스 — 브랜드 아이콘은 고유 배경을 쓴다 */
-  iconBackgroundClassName?: string;
-  disabled?: boolean;
-  onClick: () => void;
-};
-
-function ShareAction({
-  icon,
-  label,
-  iconBackgroundClassName = 'bg-gray-50',
-  disabled,
-  onClick,
-}: ShareActionProps) {
-  return (
-    <button
-      type="button"
-      disabled={disabled}
-      onClick={onClick}
-      className="flex cursor-pointer flex-col items-center gap-2 disabled:cursor-not-allowed disabled:opacity-40"
-    >
-      <span
-        className={cn(
-          'flex size-14 items-center justify-center rounded-full',
-          iconBackgroundClassName
-        )}
-      >
-        {icon}
-      </span>
-      <span className="body-2-medium text-text-neutral-secondary">{label}</span>
-    </button>
-  );
-}
 
 function ReceiptShareDialog({
   open,
@@ -131,37 +88,6 @@ function ReceiptShareDialog({
       setPreviewUrl(null);
     };
   }, [open]);
-
-  const handleSave = () => {
-    if (!imageBlob) return;
-    const isSaved = saveReceiptImage(imageBlob);
-    if (!isSaved) {
-      toast.error('저장에 실패했습니다.');
-      return;
-    }
-
-    logAnalyticsEvent(ANALYTICS_EVENT.RECEIPT_SHARE, {
-      tournament_id: tournamentId,
-      method: 'save',
-    });
-    toast.success('이미지를 저장했어요.');
-  };
-
-  const handleCopy = async () => {
-    if (!imageBlob) return;
-
-    const isCopied = await copyReceiptImage(imageBlob);
-    if (!isCopied) {
-      toast.warning('이 브라우저에서는 복사를 지원하지 않아요. 저장을 이용해주세요.');
-      return;
-    }
-
-    logAnalyticsEvent(ANALYTICS_EVENT.RECEIPT_SHARE, {
-      tournament_id: tournamentId,
-      method: 'copy',
-    });
-    toast.success('이미지를 복사했어요.');
-  };
 
   const handleShareToStory = async () => {
     if (!imageBlob) return;
@@ -239,7 +165,7 @@ function ReceiptShareDialog({
               영수증 공유
             </DrawerTitle>
             <DrawerDescription className="sr-only">
-              영수증 이미지를 저장하거나 공유할 수 있어요.
+              영수증 이미지를 공유할 수 있어요.
             </DrawerDescription>
 
             <div className="aspect-1080/1920 w-full max-w-52.5">
@@ -255,34 +181,26 @@ function ReceiptShareDialog({
               )}
             </div>
 
-            {/* 앱에서는 스토리 공유가 더해져 4개 — 좁은 화면에서 넘치지 않게 간격 상한을 둔다 */}
-            <div className="flex w-full items-start justify-center gap-[clamp(1rem,7vw,2.5rem)] border-t border-gray-75 pt-5">
-              <ShareAction
-                icon={<DownloadIconFill className="size-6 text-text-neutral-secondary" />}
-                label="이미지 저장"
-                disabled={!imageBlob}
-                onClick={handleSave}
-              />
-              <ShareAction
-                icon={<CopyIconFill className="size-6 text-text-neutral-secondary" />}
-                label="이미지 복사"
-                disabled={!imageBlob}
-                onClick={handleCopy}
-              />
-              <ShareAction
-                icon={<LinkIconOutline className="size-6 text-text-neutral-secondary" />}
-                label="링크 공유"
+            <div className="flex w-full flex-col items-center gap-4">
+              <Button
+                variant="primary"
+                size="lg"
+                className="w-full"
                 disabled={!imageBlob || isSharingLink}
                 onClick={handleShareLink}
-              />
+              >
+                공유하기
+              </Button>
+
               {isAppEnvironment && (
-                <ShareAction
-                  icon={<InstagramIcon className="size-7" />}
-                  iconBackgroundClassName="border border-gray-75 bg-white"
-                  label="스토리 공유"
+                <button
+                  type="button"
                   disabled={!imageBlob || isSharing}
                   onClick={handleShareToStory}
-                />
+                  className="cursor-pointer body-2-medium text-text-neutral-secondary disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  스토리로 바로 공유하기
+                </button>
               )}
             </div>
           </div>

--- a/apps/web/src/app/tournament/[id]/result/_utils/shareReceiptImage.ts
+++ b/apps/web/src/app/tournament/[id]/result/_utils/shareReceiptImage.ts
@@ -6,20 +6,6 @@ const MIME = 'image/png';
 /** 공유 이미지 가로 폭 (디자인 스펙) — 캡처 대상 실제 폭에 맞춰 pixelRatio 를 역산한다 */
 export const SHARE_IMAGE_WIDTH = 1080;
 
-const downloadBlob = (blob: Blob, fileName: string) => {
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = fileName;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-  URL.revokeObjectURL(url);
-};
-
-/** `download` 속성 미지원(iOS 웹뷰 등) 이면 클릭해도 저장되지 않는다 */
-const isDownloadSupported = () => 'download' in document.createElement('a');
-
 const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T> =>
   new Promise<T>((resolve, reject) => {
     const timeoutId = window.setTimeout(() => reject(new Error('TIMEOUT')), ms);
@@ -84,33 +70,6 @@ export const captureReceiptImage = async (element: HTMLElement): Promise<Blob> =
   if (!blob) throw new Error('영수증 이미지 변환 실패');
 
   return blob;
-};
-
-/** 캡처된 blob 을 파일로 저장 — 다운로드 시작에 실패하면 false */
-export const saveReceiptImage = (blob: Blob): boolean => {
-  if (!isDownloadSupported()) return false;
-
-  try {
-    downloadBlob(blob, FILE_NAME);
-    return true;
-  } catch {
-    return false;
-  }
-};
-
-/**
- * 캡처된 blob 을 클립보드에 복사.
- * ClipboardItem 미지원(안드로이드 웹뷰 등) 이면 false 를 반환해 호출부가 대체 동작을 고른다.
- */
-export const copyReceiptImage = async (blob: Blob): Promise<boolean> => {
-  if (typeof ClipboardItem === 'undefined' || !navigator.clipboard?.write) return false;
-
-  try {
-    await navigator.clipboard.write([new ClipboardItem({ [MIME]: blob })]);
-    return true;
-  } catch {
-    return false;
-  }
 };
 
 /**


### PR DESCRIPTION
## 작업 내용

영수증 공유 시트 하단 액션을 시안대로 정리했습니다. 4개 원형 아이콘 버튼을 `공유하기` 버튼 하나와 `스토리로 바로 공유하기` 텍스트 링크로 통합했습니다.

- `공유하기` — OS 기본 공유 시트 (기존 링크 공유 동작)
- `스토리로 바로 공유하기` — 인스타그램 스토리, 앱 환경에서만 노출

**제거한 기능**
- 이미지 저장 · 이미지 복사

관련 유틸(`saveReceiptImage`, `copyReceiptImage`, `downloadBlob`, `isDownloadSupported`)과 `ShareAction` 컴포넌트도 함께 정리했습니다.

애널리틱스 `receipt_share` 의 `method` 는 `story` · `link` 두 값만 남습니다.

## 스크린샷
<img width="522" height="247" alt="image" src="https://github.com/user-attachments/assets/26834305-484f-4b8c-b364-0d2a516a926b" />


## 연관 이슈

closes #482


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 영수증 공유 화면에서 저장 및 복사 기능을 제거했습니다.
  * 링크 공유 버튼을 전체 너비의 기본 버튼으로 변경했습니다.
  * 앱 환경에서 스토리 공유 옵션을 텍스트 버튼으로 제공합니다.
  * 안내 문구에서 저장 기능 관련 내용을 삭제했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->