### PR TITLE
fix: 친구 토너먼트 결과에서 선택받지 않은 후보 제외

### DIFF
--- a/apps/web/src/app/tournament/[id]/result/group/_components/GroupResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/group/_components/GroupResultClient.tsx
@@ -97,7 +97,8 @@ function GroupResultClient({ tournamentId }: GroupResultClientProps) {
     );
   }
 
-  if (isGroupResultError || !groupResultData) {
+  const chosenItems = groupResultData?.items.filter(item => item.chosenBy.length > 0) ?? [];
+  if (isGroupResultError || !groupResultData || chosenItems.length === 0) {
     return (
       <GroupResultShell onBack={handleBack}>
         <div className="flex flex-1 flex-col items-center justify-center gap-2 px-5">
@@ -112,7 +113,7 @@ function GroupResultClient({ tournamentId }: GroupResultClientProps) {
     );
   }
 
-  const sortedItems = [...groupResultData.items].sort((a, b) => a.rank - b.rank);
+  const sortedItems = [...chosenItems].sort((a, b) => a.rank - b.rank);
   const firstItem = sortedItems.find(item => item.rank === 1);
   const otherItems = sortedItems.filter(item => item.rank !== 1);
 


### PR DESCRIPTION
## 작업 내용

친구 토너먼트 결과 영수증에 아무도 선택하지 않은 후보까지 노출되던 문제를 수정했습니다.

- `chosenBy` 가 비어 있는 상품을 목록에서 제외 (1st Place · Others 모두 적용)
- 선택받은 상품이 하나도 없으면 기존 `아직 친구 결과가 없어요` 안내로 처리 — 로고만 남은 빈 영수증이 나오지 않도록

`rank` 는 선택 인원 순위이므로 1st Place(가장 많이 선택받은 상품)와 Others(그다음 선택받은 상품들) 구조는 그대로 유지됩니다.

## 연관 이슈

closes #572