### PR TITLE
fix: 플레이 링크 생성 멱등화 대응 — 만료 링크 재발급

### DIFF
--- a/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ResultClient.tsx
@@ -137,7 +137,6 @@ function ResultClient({ tournamentId, isGuest = false, isApp = false }: ResultCl
         open={isShareDialogOpen}
         onOpenChange={setIsShareDialogOpen}
         tournamentId={tournamentId}
-        initialPlayLinkExpiresAt={tournamentData.completed.playLinkExpiresAt}
       />
 
       <ReceiptShareDialog

--- a/apps/web/src/app/tournament/[id]/result/_components/plate-share-dialog/PlateShareDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/plate-share-dialog/PlateShareDialog.tsx
@@ -17,8 +17,6 @@ type PlateShareDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   tournamentId: number;
-  /** 서버 응답의 playLinkExpiresAt — 아직 생성 전이면 undefined */
-  initialPlayLinkExpiresAt?: string;
 };
 
 const buildPlayLinkUrl = (tournamentId: number) => {
@@ -27,25 +25,20 @@ const buildPlayLinkUrl = (tournamentId: number) => {
   return `${window.location.origin}${path}`;
 };
 
-function PlateShareDialog({
-  open,
-  onOpenChange,
-  tournamentId,
-  initialPlayLinkExpiresAt,
-}: PlateShareDialogProps) {
+function PlateShareDialog({ open, onOpenChange, tournamentId }: PlateShareDialogProps) {
   const { postPlayLinkMutation, isPostPlayLinkPending } = usePostPlayLink(tournamentId);
 
-  // 이미 만들어진 플레이 링크가 있으면 mutation 건너뛰고 바로 공유한다.
-  const hasExistingPlayLink = Boolean(initialPlayLinkExpiresAt);
-
   const handleSendPlayLink = async () => {
-    if (!hasExistingPlayLink) {
-      try {
-        await postPlayLinkMutation();
-      } catch {
-        /** 안내는 usePostPlayLink 훅 레벨 onError 가 담당 — 여기선 공유 플로우만 중단 */
-        return;
-      }
+    /**
+     * 생성 API 가 멱등하므로 상태를 따지지 않고 항상 호출한다.
+     * 미생성이면 만들고, 만료됐으면 새로 발급하고, 살아 있으면 기존 만료시각을 그대로 준다.
+     * 클라가 만료 여부를 판단하려 들면 죽은 링크를 그대로 공유하게 된다.
+     */
+    try {
+      await postPlayLinkMutation();
+    } catch {
+      /** 안내는 usePostPlayLink 훅 레벨 onError 가 담당 — 여기선 공유 플로우만 중단 */
+      return;
     }
 
     const result = await share({

--- a/apps/web/src/app/tournament/[id]/result/_hooks/usePostPlayLink.ts
+++ b/apps/web/src/app/tournament/[id]/result/_hooks/usePostPlayLink.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 import { isGlobalNetError } from '@/utils/apiError';
@@ -7,16 +7,22 @@ import { getApiErrorMessage } from '@/utils/getApiErrorMessage';
 import { postPlayLink } from '../_apis/postPlayLink';
 
 export const usePostPlayLink = (tournamentId: number) => {
+  const queryClient = useQueryClient();
+
   const { mutateAsync: postPlayLinkMutation, isPending: isPostPlayLinkPending } = useMutation({
     mutationFn: () => postPlayLink(tournamentId),
+    /** 만료됐다면 새 기한을 받으므로 상세에 들고 있던 만료시각을 갱신한다 */
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tournament', tournamentId] });
+    },
     /** 문구는 훅 레벨에서만 — 호출부(mutateAsync catch)에서 토스트하면 전역 fallback 과 겹친다 */
     onError: error => {
       if (isGlobalNetError(error)) return;
 
       /**
-       * 403: 플레이 링크로 참여한 토너먼트는 공유 링크 생성 불가
+       * 403: 플레이 링크로 참여한 토너먼트·주최자가 아닌 경우
        * 404: 토너먼트 존재하지 않음
-       * 409: COMPLETED 아닌 토너먼트·이미 생성된 플레이 링크
+       * 409: COMPLETED 아닌 토너먼트
        */
       toast.error(getApiErrorMessage(error));
     },


### PR DESCRIPTION
## 작업 내용

서버가 플레이 링크 생성(`POST /{id}/play-link`)을 멱등하게 바꾸면서([core#985](https://github.com/TeamPiKi/core/pull/985) 머지·배포 완료), 그에 맞춰 클라의 방어 로직을 걷어냈습니다.

### 배경

기존 서버는 만료시각 컬럼이 비어 있는지만 보고 생성을 막았습니다. 그래서 값이 한번 박히면 만료 여부와 무관하게 409였고, 클라는 이를 피하려고 "이미 링크가 있으면 `POST` 를 건너뛰는" 가드를 두고 있었습니다.

서버가 멱등해진 지금 이 가드는 불필요할 뿐 아니라, **클라에만 남은 버그의 원인**입니다.

### 해소되는 버그 — 만료된 링크를 죽은 채로 공유함

가드가 값의 **존재만** 확인하고 시각을 비교하지 않았습니다.

```tsx
const hasExistingPlayLink = Boolean(initialPlayLinkExpiresAt);
```

14일이 지나 링크가 죽어도 컬럼에는 과거 시각이 남아 있어 `true` 가 됩니다. 클라는 `POST` 를 건너뛰고 **죽은 링크를 그대로 공유하면서 주최자에게는 "링크를 성공적으로 공유했어요" 토스트까지** 띄웠습니다. 받은 사람만 만료 에러를 보고, 주최자는 자기 링크가 죽은 줄 몰랐습니다.

이제 상태를 따지지 않고 항상 호출하므로, 만료됐다면 새 기한을 받아 살아 있는 링크를 공유합니다.

### 변경 사항

**1. 가드 제거 — 항상 `POST` 호출** (`PlateShareDialog.tsx`)

```diff
- const hasExistingPlayLink = Boolean(initialPlayLinkExpiresAt);
-
- if (!hasExistingPlayLink) {
-   try { await postPlayLinkMutation(); } catch { return; }
- }
+ try { await postPlayLinkMutation(); } catch { return; }
```

미생성이면 생성, 만료면 갱신, 유효하면 기존 만료시각을 그대로 받습니다. 세 경우 모두 200입니다.

**2. 성공 시 토너먼트 상세 쿼리 무효화** (`usePostPlayLink.ts`)

```ts
onSuccess: () => {
  queryClient.invalidateQueries({ queryKey: ['tournament', tournamentId] });
},
```

만료 후 재발급되면 새 기한을 받으므로, 상세가 들고 있던 낡은 만료시각을 갱신합니다.

**3. 주석 정정** (`usePostPlayLink.ts`)

`TOURNAMENT-025`(이미 생성됨)는 더 이상 발생하지 않아 409 설명에서 제거하고, 403 에 "주최자가 아닌 경우"를 추가했습니다.

**4. 미사용 prop 제거** (`PlateShareDialog.tsx`, `ResultClient.tsx`)

`initialPlayLinkExpiresAt` 은 가드 전용이라 함께 제거했습니다. 타입(`tournamentResponse.ts` 의 `playLinkExpiresAt`)은 다른 곳에서 쓰이므로 유지합니다.

### 유지한 것

`packages/core` 의 `TOURNAMENT-025` 엔트리는 **지우지 않았습니다.** 서버가 에러 코드를 클라 계약으로 보고 번호를 재사용하지 않기로 해, 결번으로 남깁니다.

## 테스트

로컬에서 `POST /api/v1/tournaments/182/play-link` 를 연속 두 번 호출해 확인했습니다.

| | HTTP | `data` (만료시각) |
| --- | --- | --- |
| 1회차 | 200 | `2026-09-08T22:59:49.256706+09:00` |
| 2회차 | 200 | `2026-09-08T22:59:49.256706+09:00` |

- **연속 호출이 모두 200** — 이전에는 2회차가 409였습니다
- **만료시각이 동일** — 유효한 링크는 연장되지 않는다는 서버 정책과 일치합니다

화면에서도 결과 화면 → `토너먼트 공유` → 재공유 시 Network 탭에 `play-link` 요청이 **두 번 모두 기록**되고, 뒤이어 상세(`182`) 재조회가 일어나는 것을 확인했습니다. 기존 코드는 2회차에 요청 자체를 보내지 않았습니다.

**만료 후 재발급**은 대상 토너먼트가 아직 유효(9/8 만료)해 로컬에서 확인하지 못했습니다. 서버 PR 에서 테스트로 고정된 동작입니다.

## 배포 순서

서버가 이미 배포되어 **클라 단독 배포로 안전합니다.** (반대 순서였다면 유효한 링크를 가진 가장 흔한 케이스가 409로 막혀 회귀했을 것입니다.)

## 연관 이슈

closes #573

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 결과 화면에서 플레이 링크 공유 시 항상 최신 링크가 생성됩니다.
  - 링크 생성이 완료되면 토너먼트 상세 정보가 자동으로 갱신됩니다.
  - 링크 생성 중 오류가 발생하면 공유 절차가 중단되어 잘못된 링크가 전달되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->