### PR TITLE
fix: 상품 링크 배너 파비콘을 비공식 API 대신 기본 링크 아이콘으로 대체

### DIFF
--- a/apps/web/src/components/common/item-info-screen/ItemLinkBanner.tsx
+++ b/apps/web/src/components/common/item-info-screen/ItemLinkBanner.tsx
@@ -1,43 +1,21 @@
-'use client';
-
-import { useState } from 'react';
-
 import { ChevronForwardIconFill, LinkIconFill } from '@/assets/icons';
-import { cn } from '@/utils/cn';
 
 type ItemLinkBannerProps = {
   sourceUrl: string;
   sourcePlatform: string | null;
 };
 
-/** 파비콘 후보 — 고해상도 순. 전부 실패하면 링크 아이콘으로 폴백 */
-const getSourceUrlParts = (sourceUrl: string) => {
+const getHostLabel = (sourceUrl: string) => {
   try {
-    const { hostname, origin } = new URL(sourceUrl);
-    return {
-      label: hostname,
-      faviconSrcs: [
-        `${origin}/apple-touch-icon.png`,
-        `${origin}/favicon.ico`,
-        `https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://${hostname}&size=128`,
-      ],
-    };
+    return new URL(sourceUrl).hostname;
   } catch {
-    return { label: sourceUrl, faviconSrcs: [] };
+    return sourceUrl;
   }
 };
 
 /** 상품 이미지 위에 겹쳐 두는 원본 링크 칩 */
 function ItemLinkBanner({ sourceUrl, sourcePlatform }: ItemLinkBannerProps) {
-  const [faviconIndex, setFaviconIndex] = useState(0);
-  const [isFaviconLoaded, setIsFaviconLoaded] = useState(false);
-
-  const { label: hostLabel, faviconSrcs } = getSourceUrlParts(sourceUrl);
-  const label = sourcePlatform ?? hostLabel;
-  const faviconSrc = faviconSrcs[faviconIndex];
-
-  const handleFaviconError = () => setFaviconIndex(prev => prev + 1);
-  const handleFaviconLoad = () => setIsFaviconLoaded(true);
+  const label = sourcePlatform ?? getHostLabel(sourceUrl);
 
   return (
     <a
@@ -46,24 +24,8 @@ function ItemLinkBanner({ sourceUrl, sourcePlatform }: ItemLinkBannerProps) {
       rel="noopener noreferrer"
       className="liquid-glass absolute bottom-4 left-4 flex max-w-[calc(100%-32px)] items-center gap-2 rounded-full p-1 pr-2"
     >
-      <span className="relative flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border-neutral-muted bg-bg-layer-default">
-        {!isFaviconLoaded && <LinkIconFill className="size-5 text-icon-neutral-primary" />}
-        {faviconSrc && (
-          // eslint-disable-next-line @next/next/no-img-element -- next/image는 .ico 미지원
-          <img
-            /** 하이드레이션 전에 로드가 끝나면 onLoad/onError가 오지 않아 ref에서 보정 */
-            ref={img => {
-              if (!img?.complete) return;
-              if (img.naturalWidth === 0) handleFaviconError();
-              else handleFaviconLoad();
-            }}
-            src={faviconSrc}
-            alt=""
-            className={cn('absolute inset-0 size-full object-cover', !isFaviconLoaded && 'invisible')}
-            onLoad={handleFaviconLoad}
-            onError={handleFaviconError}
-          />
-        )}
+      <span className="flex size-8 shrink-0 items-center justify-center rounded-full border border-border-neutral-muted bg-bg-layer-default">
+        <LinkIconFill className="size-5 text-icon-neutral-primary" />
       </span>
       <span className="truncate body-2-medium text-text-neutral-secondary">{label}</span>
       <ChevronForwardIconFill className="size-4 shrink-0 text-icon-neutral-primary" />


### PR DESCRIPTION
## 작업 요약

- 상품 상세 링크 배너(`ItemLinkBanner`)에서 파비콘 조회를 제거하고 항상 기본 링크 아이콘을 노출합니다
- 리다이렉트 링크(원링크 등)에서 브랜드와 무관한 파비콘이 뜨는 문제와 구글 비공식 API 의존을 함께 해소합니다

## 작업 세부 내용

기존에는 `apple-touch-icon.png` → `favicon.ico` → `t1.gstatic.com/faviconV2` 3단 폴백으로 파비콘을 가져왔습니다. 원링크처럼 중간 도메인을 거치는 URL은 최종 도착지가 아닌 중간 도메인 기준으로 아이콘이 잡혀 29cm 상품에 `29cm.onelink.me` 파비콘이 붙는 식으로 노출됐고, 마지막 폴백은 문서화되지 않은 구글 엔드포인트라 차단·변경을 감지할 방법이 없었습니다. 바로 옆에 몰 이름이 텍스트로 붙어 있어 틀린 아이콘은 정보를 더하기보다 혼란만 주므로, 파비콘을 걷어내고 `LinkIconFill`을 상시 노출합니다.

**변경 사항** (`apps/web/src/components/common/item-info-screen/ItemLinkBanner.tsx` 단일 파일)

- `getSourceUrlParts`의 `faviconSrcs` 생성과 `<img>` 렌더(ref 보정 로직 포함) 제거 → `hostname`만 반환하는 `getHostLabel`로 축소
- `faviconIndex` / `isFaviconLoaded` state, `handleFaviconError` / `handleFaviconLoad` 제거
- `LinkIconFill`을 조건부(`!isFaviconLoaded`)에서 상시 노출로 변경. 아이콘 컨테이너의 `relative`/`overflow-hidden`도 `<img>` 전용이라 함께 제거
- 상태가 사라져 `'use client'`·`useState`·`cn` import 제거 (사용처 `ItemDetailView`는 클라이언트 컴포넌트라 렌더 경계 변화 없음)

**유지한 것**

- 링크 라벨 `sourcePlatform ?? hostname` 과 배너 레이아웃(liquid-glass 칩, 위치, 크기)은 그대로입니다

**후속**

- 브랜드별 이미지를 직접 보유하는 방향은 별도 이슈로 분리합니다 (이 PR은 임시 조치)

## 스크린샷

<img width="481" height="794" alt="image" src="https://github.com/user-attachments/assets/ab0a6f4d-5f67-45c6-b294-bc658a6c9bb8" />

## 연관 이슈

closes #576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 링크 배너에서 파비콘 대신 일관된 기본 링크 아이콘을 표시합니다.
  * 유효한 URL은 호스트 이름을 라벨로 표시하며, URL을 해석할 수 없는 경우 원본 링크 문자열을 사용합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->