### PR TITLE
프로젝트 보드 동기화 caller 추가

### DIFF
--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -1,0 +1,25 @@
+# 프로젝트 보드 동기화 — 본문은 TeamPiKi/infra 의 reusable 정본에 있고, 이 caller 는 트리거·권한·
+# secrets 전달만 소유한다. @main 참조는 허거덩과 같은 SSOT 선택 — 정본 머지 즉시 이 repo 에 반영된다.
+# 이슈 오픈(보드 등록·본문 날짜/우선순위 파싱·작성자 할당)과 PR 오픈/닫힘(연관 이슈 In review/Done
+# 전이·default branch 머지 PR 의 보드 반영)을 구독한다.
+# 동작에는 repo secret PROJECT_TOKEN(조직 보드 쓰기 PAT: project + repo 스코프)이 필요하다 —
+# 미설정이면 정본이 경고 후 skip 해 CI 는 빨갛게 되지 않는다.
+name: Project Board Sync
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened, closed]
+
+# 최소권한: 상단은 비우고 job 단위로만 준다.
+permissions: {}
+
+jobs:
+  sync:
+    # 정본 job 들이 요구하는 권한의 합집합 — 이슈 작성자 자동 할당(issue-auto-assign)의 issues:write.
+    # 보드 쓰기는 GITHUB_TOKEN 이 아니라 PROJECT_TOKEN(PAT)이라 여기 권한이 필요 없다.
+    permissions:
+      issues: write
+    uses: TeamPiKi/infra/.github/workflows/project-board-sync.yml@main
+    secrets: inherit

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -22,4 +22,6 @@ jobs:
     permissions:
       issues: write
     uses: TeamPiKi/infra/.github/workflows/project-board-sync.yml@main
-    secrets: inherit
+    # caller secret 전체를 넘기는 inherit 대신 정본이 요구하는 것만 명시 전달 (최소 전달).
+    secrets:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## Situation

- 이 리포의 이슈·PR 은 조직 보드(PiKi 일정관리)에 등록되지 않아 리포 횡단 추적에서 빠져 있었다. infra 에 보드 동기화 reusable 정본이 생긴다 (TeamPiKi/infra#64).

## Task

- infra 정본을 구독하는 얇은 caller 를 추가해, 이 리포의 이슈·PR 이 열리고 머지될 때 보드에 자동 반영되게 한다.

## Action

- `project-board-sync.yml` caller 를 추가했다. caller 는 트리거(이슈 오픈, PR 오픈/닫힘)·권한(issues:write)·secrets 전달만 소유하고, 동작 본문은 전부 infra 정본에 있다 (허거덩 caller 와 같은 구조).

## Result

- **infra 정본 PR 이 먼저 머지된 뒤에 이 PR 을 머지해야 한다** (`@main` 참조).
- 동작에는 repo secret PROJECT_TOKEN(조직 보드 쓰기 PAT) 등록이 필요하다. 미등록 동안은 경고 후 skip 이라 CI 실패는 없다.

---
## 연관 이슈

- close #590


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 이슈와 풀 리퀘스트가 생성되거나 종료될 때 프로젝트 보드 동기화가 자동으로 실행됩니다.
  - 필요한 권한만 사용하도록 보안 설정이 적용되었습니다.
  - 보드 연동에 필요한 인증 정보가 없더라도 CI가 실패하지 않고 안내 후 건너뜁니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->