### PR TITLE
공통 자산 부트스트랩을 client 에도 배선

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'tmp=$(mktemp); if gh api -H \"Accept: application/vnd.github.raw\" repos/TeamPiKi/infra/contents/install.sh >\"$tmp\" 2>/dev/null && [ -s \"$tmp\" ] && bash -n \"$tmp\" 2>/dev/null; then bash \"$tmp\"; fi; rm -f \"$tmp\"; exit 0'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,10 @@ yarn-error.log*
 # Misc
 .DS_Store
 *.pem
+
+# infra install.sh 가 세션 시작마다 설치하는 공통 자산 (정본은 TeamPiKi/infra)
+.claude/settings.local.json
+.claude/worktrees/
+.claude/commands/
+.claude/rules/testing-principles.md
+shared-infra/


### PR DESCRIPTION
## Situation

- core·extractor·renderer 는 세션을 열 때마다 infra 의 `install.sh` 를 받아 실행해 스킬(`/pr`·`/commit` 등 7종)·커밋 훅·규약 사본을 정본과 맞춰 왔는데, **client 만 이 배선이 빠져 있었다.** `.claude/` 에 부트스트랩이 없어 스킬도 커밋 훅도 설치되지 않는다.
- 의도적 제외가 아니다. `install.sh` 가 소비 repo 취급에서 빼는 대상은 infra 자신과 워크스페이스 루트 둘뿐이다. 자가치유 훅(`ensure-assets`)도 `gradlew` 명령에만 반응해 비JVM 인 client 는 원리적으로 덮지 못하고, 그래서 조용히 방치돼 왔다(하네스 백로그 전수 감사에서 발견).

## Task

- client 를 다른 소비 repo 와 같은 공통 자산 체계에 편입시킨다. 새 방식이 아니라 기존 방식의 누락 보정이므로, 같은 비JVM 소비 repo 인 renderer 의 구성을 그대로 따른다.

## Action

- `.claude/settings.json` 추가: SessionStart 부트스트랩 한 줄 (renderer 와 동일 내용).
- `.gitignore` 에 설치 자산 5줄 추가: 설치본은 정본이 infra 에 있어 repo 에 커밋하면 두 벌이 되므로 추적하지 않는다. renderer 의 목록에 `shared-infra/` 를 더한 것으로, install.sh 가 계약 카탈로그를 그 경로에 두기 때문이다.

## Result

- 이 PR 머지 후 client 에서 여는 세션부터 스킬 7종·commit-msg 훅이 자동 설치·최신화된다. 세션 시작이 원격 fetch 만큼(수 초) 느려지는 것은 다른 repo 와 같고, 오프라인이면 조용히 건너뛰어 세션은 정상 시작한다.
- 팀원에게 미치는 변화: 다음 세션부터 커밋 메시지가 `{feat|fix|...}: 제목` 형식 검사를 받는다(다른 repo 와 동일 규약). 원치 않는 개인 환경은 `~/.claude/.no-session-hooks` 로 홈 훅 등록만 opt-out 할 수 있다.
- `.claude/rules/testing-principles.md` 는 설치되지만 client `CLAUDE.md` 가 import 하지 않는 한 세션에 로드되지 않는다(실측된 동작). Flutter 에 JVM 원칙이 강제되는 일은 없다.

---
## 연관 이슈

- 
