### PR TITLE
feat: 프로필 이미지 업로드를 presigned URL 방식으로 전환

### DIFF
--- a/apps/web/src/apis/patchMe.ts
+++ b/apps/web/src/apis/patchMe.ts
@@ -1,11 +1,11 @@
 import { ENDPOINTS } from '@/consts/api';
 import type { ApiResponseT } from '@/types/api';
-import type { UserT } from '@/types/user';
+import type { PatchMeRequestT, UserT } from '@/types/user';
 
 import { clientApi } from './client';
 
-export const patchMe = async (formData: FormData) => {
-  const { data } = await clientApi.patch<ApiResponseT<UserT>>(ENDPOINTS.USER, formData);
+export const patchMe = async (body: PatchMeRequestT) => {
+  const { data } = await clientApi.patch<ApiResponseT<UserT>>(ENDPOINTS.USER, body);
 
   return data.data;
 };

--- a/apps/web/src/apis/patchMe.ts
+++ b/apps/web/src/apis/patchMe.ts
@@ -1,7 +1,8 @@
-import { clientApi } from '@/apis/client';
 import { ENDPOINTS } from '@/consts/api';
 import type { ApiResponseT } from '@/types/api';
 import type { UserT } from '@/types/user';
+
+import { clientApi } from './client';
 
 export const patchMe = async (formData: FormData) => {
   const { data } = await clientApi.patch<ApiResponseT<UserT>>(ENDPOINTS.USER, formData);

--- a/apps/web/src/apis/postProfileImagePresignedUrl.ts
+++ b/apps/web/src/apis/postProfileImagePresignedUrl.ts
@@ -1,0 +1,20 @@
+import { ENDPOINTS } from '@/consts/api';
+import type { ApiResponseT } from '@/types/api';
+import type { PresignedImageUploadT } from '@/types/image';
+import type { PostProfileImagePresignedUrlRequestT } from '@/types/user';
+
+import { clientApi } from './client';
+
+/**
+ * 프로필 이미지 업로드용 presigned URL 발급 (MEMBER 전용)
+ *
+ * 위시/토너먼트와 달리 `uploads` 배열이 아닌 단건 flat 응답이다.
+ */
+export const postProfileImagePresignedUrl = async (body: PostProfileImagePresignedUrlRequestT) => {
+  const { data } = await clientApi.post<ApiResponseT<PresignedImageUploadT>>(
+    ENDPOINTS.USER_PROFILE_IMAGE_PRESIGNED,
+    body
+  );
+
+  return data.data;
+};

--- a/apps/web/src/app/mypage/edit/_components/EditForm.tsx
+++ b/apps/web/src/app/mypage/edit/_components/EditForm.tsx
@@ -9,8 +9,8 @@ import Spacing from '@/components/spacing';
 import { ROUTES } from '@/consts/route';
 import { useGetMe } from '@/hooks/useGetMe';
 import { useNicknameValidation } from '@/hooks/useNicknameValidation';
+import { usePatchMe } from '@/hooks/usePatchMe';
 
-import { usePatchMe } from '../_hooks/usePatchMe';
 import NicknameField from './NicknameField';
 import ProfileImageField from './ProfileImageField';
 

--- a/apps/web/src/app/tournament/join/[id]/_components/JoinPreviewClient.tsx
+++ b/apps/web/src/app/tournament/join/[id]/_components/JoinPreviewClient.tsx
@@ -3,7 +3,6 @@
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { usePatchMe } from '@/app/mypage/edit/_hooks/usePatchMe';
 import { EditIconFill } from '@/assets/icons/fill';
 import Button from '@/components/button';
 import JoinErrorDialog from '@/components/common/join-error-dialog';
@@ -16,6 +15,7 @@ import { ROUTES } from '@/consts/route';
 import { useGetMe } from '@/hooks/useGetMe';
 import { useNicknameValidation } from '@/hooks/useNicknameValidation';
 import { usePageBackground } from '@/hooks/usePageBackground';
+import { usePatchMe } from '@/hooks/usePatchMe';
 import type { GetInvitePreviewResponseT } from '@/types/tournament';
 
 import { usePostJoin } from '../../_hooks/usePostJoin';

--- a/apps/web/src/consts/api.ts
+++ b/apps/web/src/consts/api.ts
@@ -2,6 +2,7 @@ export const ENDPOINTS = {
   /** 유저 */
   USER: '/api/v1/users/me',
   USER_NICKNAME_CHECK: '/api/v1/users/nickname/check',
+  USER_PROFILE_IMAGE_PRESIGNED: '/api/v1/users/me/profile-image',
 
   /** 인증 */
   AUTH_URL: (provider: string) => `/api/v1/auth/${provider}/url`,

--- a/apps/web/src/hooks/usePatchMe.ts
+++ b/apps/web/src/hooks/usePatchMe.ts
@@ -2,6 +2,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 import { patchMe } from '@/apis/patchMe';
+import { postProfileImagePresignedUrl } from '@/apis/postProfileImagePresignedUrl';
+import { putImageToS3 } from '@/apis/putImageToS3';
 import { QUERY_KEYS } from '@/consts/queryKeys';
 import { isGlobalNetError } from '@/utils/apiError';
 import { getApiErrorMessage } from '@/utils/getApiErrorMessage';
@@ -10,12 +12,20 @@ export const usePatchMe = () => {
   const queryClient = useQueryClient();
 
   const { mutate: patchMeMutation, isPending: isPatchMePending } = useMutation({
-    mutationFn: ({ image, nickname }: { image?: File; nickname?: string }) => {
-      const formData = new FormData();
-      if (image) formData.append('image', image);
-      if (nickname) formData.append('nickname', nickname);
+    /** 이미지는 presign → S3 직접 PUT → imageKey 확정 순서로 올린다 */
+    mutationFn: async ({ image, nickname }: { image?: File; nickname?: string }) => {
+      let imageKey: string | undefined;
 
-      return patchMe(formData);
+      if (image) {
+        const upload = await postProfileImagePresignedUrl({ contentType: image.type });
+        await putImageToS3(upload, image);
+        imageKey = upload.imageKey;
+      }
+
+      return patchMe({
+        ...(nickname ? { nickname } : {}),
+        ...(imageKey ? { imageKey } : {}),
+      });
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.USER.ME });
@@ -24,10 +34,10 @@ export const usePatchMe = () => {
       if (isGlobalNetError(error)) return;
 
       /**
-       * 400: 이미지 형식 오류
-       * 403: 게스트는 프로필 이미지 변경 불가
-       * 409: 중복 닉네임
-       * 413: 이미지 용량 초과
+       * 400: 닉네임 형식 오류 · 이미지 형식/내용 오류(USER-009/010/011) · key 오류(UPLOAD-001/002)
+       * 403: 게스트는 프로필 이미지 변경 불가(USER-008)
+       * 409: 중복 닉네임(USER-004)
+       * S3 PUT 실패(S3UploadError)·502 STORAGE-00x 는 전역(isGlobalNetError)이 처리
        */
       toast.error(getApiErrorMessage(error));
     },

--- a/apps/web/src/hooks/usePatchMe.ts
+++ b/apps/web/src/hooks/usePatchMe.ts
@@ -1,11 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
+import { patchMe } from '@/apis/patchMe';
 import { QUERY_KEYS } from '@/consts/queryKeys';
 import { isGlobalNetError } from '@/utils/apiError';
 import { getApiErrorMessage } from '@/utils/getApiErrorMessage';
-
-import { patchMe } from '../_apis/patchMe';
 
 export const usePatchMe = () => {
   const queryClient = useQueryClient();

--- a/apps/web/src/types/user.ts
+++ b/apps/web/src/types/user.ts
@@ -27,6 +27,20 @@ type BaseUserT = {
   profileImage: string;
 };
 
+/** 유저 정보 수정 요청 — 담아 보낸 필드만 갱신된다 */
+export type PatchMeRequestT = {
+  /** 변경할 닉네임 (최대 10자) */
+  nickname?: string;
+  /** 업로드를 마친 프로필 이미지 key */
+  imageKey?: string;
+};
+
+/** 프로필 이미지 업로드 URL 발급 요청 */
+export type PostProfileImagePresignedUrlRequestT = {
+  /** 올릴 이미지의 MIME 타입 (png · jpeg · webp · heic · heif) */
+  contentType: string;
+};
+
 /** 닉네임 중복 체크 응답 */
 export type GetNicknameCheckResponseT = {
   available: boolean;

--- a/packages/core/src/consts/errorCode.ts
+++ b/packages/core/src/consts/errorCode.ts
@@ -117,6 +117,7 @@ export const ERROR_MESSAGE_MAP = {
   'STORAGE-002': '이미지 업로드 URL 을 발급하지 못했어요. 잠시 후 다시 시도해 주세요.',
   'STORAGE-003': '이미지 업로드 상태를 확인하지 못했어요. 잠시 후 다시 시도해 주세요.',
   'STORAGE-004': '이미지를 삭제하지 못했어요. 잠시 후 다시 시도해 주세요.',
+  'STORAGE-005': '이미지를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.',
 
   /** UPLOAD */
   'UPLOAD-001': '올바르지 않은 이미지 업로드 정보예요. 업로드를 다시 시도해 주세요.',
@@ -250,6 +251,7 @@ export const ERROR_CODE = {
   STORAGE_PRESIGN_FAILED: 'STORAGE-002',
   STORAGE_EXISTS_CHECK_FAILED: 'STORAGE-003',
   STORAGE_DELETE_FAILED: 'STORAGE-004',
+  STORAGE_LOAD_FAILED: 'STORAGE-005',
 
   /** 이미지 업로드 */
   UPLOAD_INVALID_KEY: 'UPLOAD-001',


### PR DESCRIPTION
## 작업 요약

- 서버가 프로필 수정에서 multipart 를 더 이상 받지 않도록 스펙이 바뀌어 현재 프로필 이미지 변경이 동작하지 않습니다. 클라이언트가 S3 로 직접 업로드하도록 전환해 이를 복구합니다.

## 작업 내용

- 업로드를 `POST /users/me/profile-image` 로 presigned URL 발급 → S3 직접 PUT → `PATCH /users/me` 에 `imageKey` 확정, 3단계로 변경 (기존 `usePostWishOCR` 과 같은 패턴, `putImageToS3` 재사용)
- `PATCH /users/me` 요청을 `FormData` 에서 JSON `{ nickname?, imageKey? }` 로 교체
- `tournament/join/[id]` 이 `mypage/edit/_hooks/usePatchMe` 를 직접 import 하고 있어, 배치 규칙대로 `patchMe`·`usePatchMe` 를 `src/apis`·`src/hooks` 로 이동 (순수 rename 커밋으로 분리)
- api-docs 대조 중 카탈로그에 없던 `STORAGE-005`(원본 읽기 실패) 를 `@piki/core` 에 추가
- 참고: 바이트가 서버를 거치지 않아 413 이 사라집니다. 크롭·회전 편집 UI 는 후속 PR 에서 이어집니다.

## 스크린샷

https://github.com/user-attachments/assets/8d855d44-2ade-48d4-954b-572c51884c32


## 연관 이슈

related to #593


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 프로필 이미지 업로드 및 변경 기능을 개선했습니다.
  * 프로필 정보와 이미지를 함께 수정할 수 있습니다.
  * 이미지 로드 실패 시 안내 메시지를 표시합니다.

* **버그 수정**
  * 프로필 수정 과정의 이미지 업로드 오류 처리를 개선했습니다.
  * 프로필 수정 후 사용자 정보가 최신 상태로 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->