### PR TITLE
feat: 프로필 이미지 크롭·회전 편집 화면 추가

### DIFF
--- a/apps/web/e2e/specs/mypage/profileImageEdit.spec.ts
+++ b/apps/web/e2e/specs/mypage/profileImageEdit.spec.ts
@@ -1,0 +1,101 @@
+import { ENDPOINTS } from '@/consts/api';
+
+import { expect, test } from '@e2e/fixtures/mockApiFixture';
+import { MOCK_MEMBER_ME } from '@e2e/mocks/me';
+
+const MOCK_UPLOAD_URL = 'https://s3.example/e2e/profile-upload';
+
+/** 브라우저 <img> 가 바로 디코드할 수 있는 원본 — 크롭 화면 진입 검증용 */
+const MOCK_PICKED_IMAGE_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="320" viewBox="0 0 320 320">' +
+  '<rect width="320" height="320" fill="#34d399"/>' +
+  '</svg>';
+
+test('프로필 이미지를 고르면 크롭 에디터가 열리고, 완료하면 JPEG 로 S3 에 직접 업로드된다', async ({
+  page,
+  api,
+}) => {
+  api.get(ENDPOINTS.USER, MOCK_MEMBER_ME);
+  api.post(ENDPOINTS.USER_PROFILE_IMAGE_PRESIGNED, {
+    imageKey: 'e2e-image-key',
+    uploadUrl: MOCK_UPLOAD_URL,
+    contentType: 'image/jpeg',
+  });
+  api.patch(ENDPOINTS.USER, MOCK_MEMBER_ME);
+
+  /** S3 직접 PUT — 서명과 어긋나면 실서버가 거부하므로 Content-Type·바이트를 검증한다 */
+  let putContentType: string | undefined;
+  let putBodyPrefixHex: string | undefined;
+  await page.route(MOCK_UPLOAD_URL, async route => {
+    putContentType = route.request().headers()['content-type'];
+    putBodyPrefixHex = route.request().postDataBuffer()?.subarray(0, 3).toString('hex');
+    await route.fulfill({ status: 200, body: '' });
+  });
+
+  await page.goto('/mypage/edit');
+
+  /** 카메라 뱃지만이 아니라 프로필 이미지 영역 전체가 클릭으로 피커를 연다 */
+  const fileChooserPromise = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: '프로필 이미지 변경' }).click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
+    name: 'photo.svg',
+    mimeType: 'image/svg+xml',
+    buffer: Buffer.from(MOCK_PICKED_IMAGE_SVG),
+  });
+
+  await expect(page.getByText('프로필 이미지 편집')).toBeVisible();
+  /** 터치 환경(기본 프로젝트는 iPhone 에뮬레이션)은 핀치줌을 쓰므로 줌 슬라이더가 숨겨진다 */
+  await expect(page.getByRole('slider', { name: '이미지 확대/축소' })).toBeHidden();
+
+  await page.getByRole('button', { name: '완료' }).click();
+  await expect(page.getByText('프로필 이미지 편집')).not.toBeVisible();
+
+  await page.getByRole('button', { name: '수정하기' }).click();
+
+  await expect(page).toHaveURL(/\/mypage$/);
+  expect(putContentType).toBe('image/jpeg');
+  // JPEG SOI 마커 — presign contentType 과 실제 바이트가 일치해야 서버 USER-011 을 피한다
+  expect(putBodyPrefixHex).toBe('ffd8ff');
+});
+
+test.describe('마우스(fine pointer) 환경', () => {
+  test.use({ hasTouch: false, isMobile: false });
+
+  test('핀치줌이 없는 마우스 환경에서는 줌 슬라이더가 노출된다', async ({ page, api }) => {
+    api.get(ENDPOINTS.USER, MOCK_MEMBER_ME);
+
+    await page.goto('/mypage/edit');
+    const fileChooserPromise = page.waitForEvent('filechooser');
+    await page.getByRole('button', { name: '프로필 이미지 변경' }).click();
+    await (
+      await fileChooserPromise
+    ).setFiles({
+      name: 'photo.svg',
+      mimeType: 'image/svg+xml',
+      buffer: Buffer.from(MOCK_PICKED_IMAGE_SVG),
+    });
+
+    await expect(page.getByText('프로필 이미지 편집')).toBeVisible();
+    await expect(page.getByRole('slider', { name: '이미지 확대/축소' })).toBeVisible();
+  });
+});
+
+test('브라우저가 디코드하지 못하는 이미지는 크롭 에디터 대신 안내 토스트를 띄운다', async ({
+  page,
+  api,
+}) => {
+  api.get(ENDPOINTS.USER, MOCK_MEMBER_ME);
+
+  await page.goto('/mypage/edit');
+  await expect(page.getByRole('button', { name: '프로필 이미지 변경' })).toBeVisible();
+
+  await page.locator('input[type="file"]').setInputFiles({
+    name: 'photo.heic',
+    mimeType: 'image/heic',
+    buffer: Buffer.from('not-an-image'),
+  });
+
+  await expect(page.getByText('지원하지 않는 이미지 형식이에요.')).toBeVisible();
+  await expect(page.getByText('프로필 이미지 편집')).not.toBeVisible();
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-easy-crop": "^6.2.3",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",

--- a/apps/web/src/app/mypage/edit/_components/ProfileImageCropEditor.tsx
+++ b/apps/web/src/app/mypage/edit/_components/ProfileImageCropEditor.tsx
@@ -33,14 +33,20 @@ function ProfileImageCropEditor({ imageSrc, onCancel, onConfirm }: ProfileImageC
   const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
 
+  // 처리 중 취소를 막는다 — 에디터가 먼저 닫히면 뒤늦게 완료된 onConfirm 이 취소한 이미지를 적용해버린다
+  const handleCancel = () => {
+    if (isProcessing) return;
+    onCancel();
+  };
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') onCancel();
+      if (event.key === 'Escape' && !isProcessing) onCancel();
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onCancel]);
+  }, [onCancel, isProcessing]);
 
   const handleRotate = () => setRotation(prev => (prev + ROTATION_STEP_DEGREE) % 360);
 
@@ -72,7 +78,7 @@ function ProfileImageCropEditor({ imageSrc, onCancel, onConfirm }: ProfileImageC
     >
       <div className="px-5">
         <Header
-          left={<HeaderIcon name="BACK" className="size-7.5" onClick={onCancel} />}
+          left={<HeaderIcon name="BACK" className="size-7.5" onClick={handleCancel} />}
           center={<h1 className="heading-1-bold text-text-neutral-primary">프로필 이미지 편집</h1>}
         />
       </div>

--- a/apps/web/src/app/mypage/edit/_components/ProfileImageCropEditor.tsx
+++ b/apps/web/src/app/mypage/edit/_components/ProfileImageCropEditor.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import Cropper, { type Area } from 'react-easy-crop';
+import { toast } from 'sonner';
+
+import { ReloaderIconOutline } from '@/assets/icons';
+import BottomCta from '@/components/bottom-cta';
+import Button from '@/components/button';
+import { Header, HeaderIcon } from '@/components/header';
+import { Z_INDEX } from '@/consts/zIndex';
+
+import { cropImage } from '../_utils/cropImage';
+
+const ROTATION_STEP_DEGREE = 90;
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 3;
+
+type ProfileImageCropEditorProps = {
+  /** 크롭할 원본 이미지 object URL */
+  imageSrc: string;
+  onCancel: () => void;
+  /** 확인 시 크롭·회전이 적용된 JPEG Blob 전달 */
+  onConfirm: (blob: Blob) => void;
+};
+
+/** 피커 선택 직후 화면 전체를 덮는 크롭·회전 에디터 */
+function ProfileImageCropEditor({ imageSrc, onCancel, onConfirm }: ProfileImageCropEditorProps) {
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(MIN_ZOOM);
+  const [rotation, setRotation] = useState(0);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onCancel();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onCancel]);
+
+  const handleRotate = () => setRotation(prev => (prev + ROTATION_STEP_DEGREE) % 360);
+
+  const handleCropComplete = (_croppedArea: Area, nextCroppedAreaPixels: Area) => {
+    setCroppedAreaPixels(nextCroppedAreaPixels);
+  };
+
+  const handleConfirm = async () => {
+    if (!croppedAreaPixels || isProcessing) return;
+
+    setIsProcessing(true);
+    try {
+      const blob = await cropImage(imageSrc, croppedAreaPixels, rotation);
+      onConfirm(blob);
+    } catch {
+      toast.error('이미지 처리 중 오류가 발생했어요.');
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="프로필 이미지 편집"
+      className="fixed inset-0 mx-auto flex w-full max-w-120 flex-col bg-bg-layer-basement pt-padding-top"
+      style={{ zIndex: Z_INDEX.DIALOG }}
+    >
+      <div className="px-5">
+        <Header
+          left={<HeaderIcon name="BACK" className="size-7.5" onClick={onCancel} />}
+          center={<h1 className="heading-1-bold text-text-neutral-primary">프로필 이미지 편집</h1>}
+        />
+      </div>
+
+      <div className="relative mt-6 min-h-0 flex-1 touch-none bg-black">
+        <Cropper
+          image={imageSrc}
+          crop={crop}
+          zoom={zoom}
+          rotation={rotation}
+          minZoom={MIN_ZOOM}
+          maxZoom={MAX_ZOOM}
+          aspect={1}
+          cropShape="round"
+          showGrid={false}
+          objectFit="cover"
+          onCropChange={setCrop}
+          onZoomChange={setZoom}
+          onCropComplete={handleCropComplete}
+        />
+      </div>
+
+      <div className="mb-bottom-cta flex items-center gap-4 px-5 py-4">
+        <button
+          type="button"
+          onClick={handleRotate}
+          disabled={isProcessing}
+          aria-label="이미지 90도 회전"
+          className="flex size-10 shrink-0 cursor-pointer items-center justify-center rounded-full text-icon-neutral-secondary active:bg-gray-50"
+        >
+          <ReloaderIconOutline className="size-6 shrink-0" />
+        </button>
+        {/* 줌 슬라이더는 핀치줌이 없는 마우스 환경에서만 노출 — 터치는 핀치줌으로 조작 */}
+        <input
+          type="range"
+          min={MIN_ZOOM}
+          max={MAX_ZOOM}
+          step={0.01}
+          value={zoom}
+          onChange={event => setZoom(Number(event.target.value))}
+          aria-label="이미지 확대/축소"
+          className="hidden w-full cursor-pointer accent-black pointer-fine:block"
+        />
+      </div>
+
+      <BottomCta>
+        <Button
+          type="button"
+          variant="primary"
+          size="lg"
+          className="w-full"
+          onClick={handleConfirm}
+          isLoading={isProcessing}
+          disabled={!croppedAreaPixels || isProcessing}
+        >
+          완료
+        </Button>
+      </BottomCta>
+    </div>,
+    document.body
+  );
+}
+
+export default ProfileImageCropEditor;

--- a/apps/web/src/app/mypage/edit/_components/ProfileImageField.tsx
+++ b/apps/web/src/app/mypage/edit/_components/ProfileImageField.tsx
@@ -45,26 +45,40 @@ function ProfileImageField({ userIdentityType, profileImage, onImageSelect }: Pr
   return (
     <>
       <div className="relative mx-auto size-[90px]">
-        <div className="relative size-[90px] overflow-hidden rounded-full">
-          <BaseImage
-            src={displayUrl}
-            alt="프로필 이미지"
-            sizes="90px"
-            className="object-cover"
-            loadingFallback={<Skeleton shape="circle" className="absolute inset-0" />}
-          />
-        </div>
-        {userIdentityType === 'MEMBER' && (
+        {userIdentityType === 'MEMBER' ? (
           <button
             type="button"
             onClick={openPicker}
             disabled={isPending}
             aria-label="프로필 이미지 변경"
-            className="absolute top-[54.5px] left-[59px] flex size-10 shrink-0 cursor-pointer items-center justify-center rounded-full bg-bg-layer-default"
-            style={{ zIndex: Z_INDEX.BASE_IMAGE + 1 }}
+            className="relative size-[90px] cursor-pointer"
           >
-            <CameraIconFill className="size-6 shrink-0 text-icon-neutral-secondary" />
+            <span className="relative block size-[90px] overflow-hidden rounded-full">
+              <BaseImage
+                src={displayUrl}
+                alt="프로필 이미지"
+                sizes="90px"
+                className="object-cover"
+                loadingFallback={<Skeleton shape="circle" className="absolute inset-0" />}
+              />
+            </span>
+            <span
+              className="absolute top-[54.5px] left-[59px] flex size-10 shrink-0 items-center justify-center rounded-full bg-bg-layer-default"
+              style={{ zIndex: Z_INDEX.BASE_IMAGE + 1 }}
+            >
+              <CameraIconFill className="size-6 shrink-0 text-icon-neutral-secondary" />
+            </span>
           </button>
+        ) : (
+          <div className="relative size-[90px] overflow-hidden rounded-full">
+            <BaseImage
+              src={displayUrl}
+              alt="프로필 이미지"
+              sizes="90px"
+              className="object-cover"
+              loadingFallback={<Skeleton shape="circle" className="absolute inset-0" />}
+            />
+          </div>
         )}
       </div>
 

--- a/apps/web/src/app/mypage/edit/_components/ProfileImageField.tsx
+++ b/apps/web/src/app/mypage/edit/_components/ProfileImageField.tsx
@@ -2,6 +2,7 @@
 
 import { SUPPORTED_IMAGE_MIME_TYPES } from '@piki/core';
 import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
 
 import { CameraIconFill } from '@/assets/icons';
 import BaseImage from '@/components/base-image';
@@ -9,6 +10,9 @@ import Skeleton from '@/components/skeleton';
 import { Z_INDEX } from '@/consts/zIndex';
 import { useImagePicker } from '@/hooks/useImagePicker';
 import type { UserIdentityTypeT } from '@/types/user';
+
+import { loadImage } from '../_utils/cropImage';
+import ProfileImageCropEditor from './ProfileImageCropEditor';
 
 type Props = {
   userIdentityType: UserIdentityTypeT;
@@ -18,18 +22,28 @@ type Props = {
 
 function ProfileImageField({ userIdentityType, profileImage, onImageSelect }: Props) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  /** 피커에서 고른 원본 object URL — 값이 있으면 크롭 에디터가 열린다 */
+  const [cropImageSrc, setCropImageSrc] = useState<string | null>(null);
 
   const { openPicker, inputRef, handleInputChange, isPending } = useImagePicker({
     maxCount: 1,
-    onSuccess: files => {
+    onSuccess: async files => {
       const [file] = files;
       if (!file) return;
 
-      setPreviewUrl(prev => {
+      const url = URL.createObjectURL(file);
+      try {
+        await loadImage(url);
+      } catch {
+        URL.revokeObjectURL(url);
+        toast.error('지원하지 않는 이미지 형식이에요.');
+        return;
+      }
+
+      setCropImageSrc(prev => {
         if (prev) URL.revokeObjectURL(prev);
-        return URL.createObjectURL(file);
+        return url;
       });
-      onImageSelect?.(file);
     },
   });
 
@@ -39,6 +53,29 @@ function ProfileImageField({ userIdentityType, profileImage, onImageSelect }: Pr
     },
     [previewUrl]
   );
+
+  useEffect(
+    () => () => {
+      if (cropImageSrc) URL.revokeObjectURL(cropImageSrc);
+    },
+    [cropImageSrc]
+  );
+
+  const closeCropEditor = () => {
+    setCropImageSrc(prev => {
+      if (prev) URL.revokeObjectURL(prev);
+      return null;
+    });
+  };
+
+  const handleCropConfirm = (blob: Blob) => {
+    setPreviewUrl(prev => {
+      if (prev) URL.revokeObjectURL(prev);
+      return URL.createObjectURL(blob);
+    });
+    onImageSelect?.(new File([blob], 'profile.jpg', { type: blob.type }));
+    closeCropEditor();
+  };
 
   const displayUrl = previewUrl ?? profileImage;
 
@@ -89,6 +126,14 @@ function ProfileImageField({ userIdentityType, profileImage, onImageSelect }: Pr
         className="hidden"
         onChange={handleInputChange}
       />
+
+      {cropImageSrc && (
+        <ProfileImageCropEditor
+          imageSrc={cropImageSrc}
+          onCancel={closeCropEditor}
+          onConfirm={handleCropConfirm}
+        />
+      )}
     </>
   );
 }

--- a/apps/web/src/app/mypage/edit/_utils/cropImage.ts
+++ b/apps/web/src/app/mypage/edit/_utils/cropImage.ts
@@ -9,6 +9,11 @@ const CROP_OUTPUT_MIME_TYPE = 'image/jpeg';
 const CROP_OUTPUT_QUALITY = 0.9;
 /** 프로필은 원형 90px 노출 — 원본이 커도 출력 한 변이 이 값을 넘지 않게 줄인다 */
 const CROP_OUTPUT_MAX_SIZE = 1080;
+/**
+ * 회전용 중간 canvas 한 변 상한. 5MB 이하 압축 이미지도 수천만 픽셀로 디코드될 수 있어,
+ * 원본 크기 그대로 canvas 를 할당하면 웹뷰 메모리를 터뜨릴 수 있다 — 넘으면 축소해 그린다
+ */
+const MAX_SOURCE_SIZE = 4096;
 
 /** 브라우저가 디코드 못 하는 형식(Chrome/Android WebView 의 HEIC 등)은 여기서 reject 된다 */
 export const loadImage = (src: string) =>
@@ -38,13 +43,22 @@ export const cropImage = async (
 ): Promise<Blob> => {
   const image = await loadImage(imageSrc);
 
+  // 원본·크롭 좌표를 같은 비율로 축소해 좌표계를 유지한다 (croppedAreaPixels 는 원본 픽셀 기준)
+  const sourceScale = Math.min(1, MAX_SOURCE_SIZE / Math.max(image.width, image.height));
+  const sourceWidth = Math.round(image.width * sourceScale);
+  const sourceHeight = Math.round(image.height * sourceScale);
+  const cropX = croppedAreaPixels.x * sourceScale;
+  const cropY = croppedAreaPixels.y * sourceScale;
+  const cropWidth = croppedAreaPixels.width * sourceScale;
+  const cropHeight = croppedAreaPixels.height * sourceScale;
+
   const rotatedCanvas = document.createElement('canvas');
   const rotatedCtx = rotatedCanvas.getContext('2d');
   if (!rotatedCtx) throw new Error('CANVAS_CONTEXT_FAILED');
 
   const { width: boxWidth, height: boxHeight } = getRotatedSize(
-    image.width,
-    image.height,
+    sourceWidth,
+    sourceHeight,
     rotation
   );
   rotatedCanvas.width = boxWidth;
@@ -52,25 +66,22 @@ export const cropImage = async (
 
   rotatedCtx.translate(boxWidth / 2, boxHeight / 2);
   rotatedCtx.rotate(getRadianAngle(rotation));
-  rotatedCtx.translate(-image.width / 2, -image.height / 2);
-  rotatedCtx.drawImage(image, 0, 0);
+  rotatedCtx.translate(-sourceWidth / 2, -sourceHeight / 2);
+  rotatedCtx.drawImage(image, 0, 0, sourceWidth, sourceHeight);
 
-  const scale = Math.min(
-    1,
-    CROP_OUTPUT_MAX_SIZE / Math.max(croppedAreaPixels.width, croppedAreaPixels.height)
-  );
+  const outputScale = Math.min(1, CROP_OUTPUT_MAX_SIZE / Math.max(cropWidth, cropHeight));
   const outputCanvas = document.createElement('canvas');
-  outputCanvas.width = Math.round(croppedAreaPixels.width * scale);
-  outputCanvas.height = Math.round(croppedAreaPixels.height * scale);
+  outputCanvas.width = Math.round(cropWidth * outputScale);
+  outputCanvas.height = Math.round(cropHeight * outputScale);
   const outputCtx = outputCanvas.getContext('2d');
   if (!outputCtx) throw new Error('CANVAS_CONTEXT_FAILED');
 
   outputCtx.drawImage(
     rotatedCanvas,
-    croppedAreaPixels.x,
-    croppedAreaPixels.y,
-    croppedAreaPixels.width,
-    croppedAreaPixels.height,
+    cropX,
+    cropY,
+    cropWidth,
+    cropHeight,
     0,
     0,
     outputCanvas.width,

--- a/apps/web/src/app/mypage/edit/_utils/cropImage.ts
+++ b/apps/web/src/app/mypage/edit/_utils/cropImage.ts
@@ -1,0 +1,87 @@
+import type { Area } from 'react-easy-crop';
+
+/**
+ * 크롭 출력 포맷은 JPEG 고정 — 프로필은 투명도가 필요 없고, HEIC 원본도 여기서 정규화된다.
+ * NOTE: presign 의 contentType 은 원본(file.type)이 아니라 반드시 이 출력 타입을 써야 한다.
+ * 어긋나면 PUT 바이트와 서명이 달라 서버가 USER-011(형식/내용 불일치)로 거부한다.
+ */
+const CROP_OUTPUT_MIME_TYPE = 'image/jpeg';
+const CROP_OUTPUT_QUALITY = 0.9;
+/** 프로필은 원형 90px 노출 — 원본이 커도 출력 한 변이 이 값을 넘지 않게 줄인다 */
+const CROP_OUTPUT_MAX_SIZE = 1080;
+
+/** 브라우저가 디코드 못 하는 형식(Chrome/Android WebView 의 HEIC 등)은 여기서 reject 된다 */
+export const loadImage = (src: string) =>
+  new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error('IMAGE_LOAD_FAILED'));
+    image.src = src;
+  });
+
+const getRadianAngle = (degree: number) => (degree * Math.PI) / 180;
+
+/** 회전된 이미지 전체를 담는 bounding box 크기 */
+const getRotatedSize = (width: number, height: number, rotation: number) => {
+  const rotRad = getRadianAngle(rotation);
+  return {
+    width: Math.abs(Math.cos(rotRad) * width) + Math.abs(Math.sin(rotRad) * height),
+    height: Math.abs(Math.sin(rotRad) * width) + Math.abs(Math.cos(rotRad) * height),
+  };
+};
+
+/** 크롭 화면에서 정한 영역·회전을 canvas 로 적용해 JPEG Blob 을 만든다 */
+export const cropImage = async (
+  imageSrc: string,
+  croppedAreaPixels: Area,
+  rotation: number
+): Promise<Blob> => {
+  const image = await loadImage(imageSrc);
+
+  const rotatedCanvas = document.createElement('canvas');
+  const rotatedCtx = rotatedCanvas.getContext('2d');
+  if (!rotatedCtx) throw new Error('CANVAS_CONTEXT_FAILED');
+
+  const { width: boxWidth, height: boxHeight } = getRotatedSize(
+    image.width,
+    image.height,
+    rotation
+  );
+  rotatedCanvas.width = boxWidth;
+  rotatedCanvas.height = boxHeight;
+
+  rotatedCtx.translate(boxWidth / 2, boxHeight / 2);
+  rotatedCtx.rotate(getRadianAngle(rotation));
+  rotatedCtx.translate(-image.width / 2, -image.height / 2);
+  rotatedCtx.drawImage(image, 0, 0);
+
+  const scale = Math.min(
+    1,
+    CROP_OUTPUT_MAX_SIZE / Math.max(croppedAreaPixels.width, croppedAreaPixels.height)
+  );
+  const outputCanvas = document.createElement('canvas');
+  outputCanvas.width = Math.round(croppedAreaPixels.width * scale);
+  outputCanvas.height = Math.round(croppedAreaPixels.height * scale);
+  const outputCtx = outputCanvas.getContext('2d');
+  if (!outputCtx) throw new Error('CANVAS_CONTEXT_FAILED');
+
+  outputCtx.drawImage(
+    rotatedCanvas,
+    croppedAreaPixels.x,
+    croppedAreaPixels.y,
+    croppedAreaPixels.width,
+    croppedAreaPixels.height,
+    0,
+    0,
+    outputCanvas.width,
+    outputCanvas.height
+  );
+
+  return new Promise((resolve, reject) => {
+    outputCanvas.toBlob(
+      blob => (blob ? resolve(blob) : reject(new Error('CROP_EXPORT_FAILED'))),
+      CROP_OUTPUT_MIME_TYPE,
+      CROP_OUTPUT_QUALITY
+    );
+  });
+};

--- a/apps/web/src/hooks/useImagePicker.ts
+++ b/apps/web/src/hooks/useImagePicker.ts
@@ -11,7 +11,6 @@ import { WebBridge, isWebview } from '@/utils/webBridge';
 
 const DEFAULT_MAX_COUNT = 5;
 
-/** 서버 업로드 한도(413) 사전검증 — 초과 파일은 업로드 전에 걸러 왕복을 막는다 */
 const MAX_IMAGE_FILE_SIZE_MB = 5;
 const MAX_IMAGE_FILE_SIZE_BYTES = MAX_IMAGE_FILE_SIZE_MB * 1024 * 1024;
 
@@ -55,7 +54,7 @@ export const useImagePicker = ({
 
   const handleImagesSelect = useCallback(
     async ({ files, skippedCount }: ImagePickerResultT) => {
-      // 서버 한도 초과 파일은 업로드 전에 걸러서 413 왕복을 막는다 (웹/웹뷰 공통 경로).
+      // 한도 초과 파일은 처리 전에 거른다 (웹/웹뷰 공통 경로).
       const validFiles = files.filter(file => file.size <= MAX_IMAGE_FILE_SIZE_BYTES);
       const oversizedCount = files.length - validFiles.length;
       if (oversizedCount > 0) {

--- a/docs/spec/api-status-audit.md
+++ b/docs/spec/api-status-audit.md
@@ -49,9 +49,7 @@
 
 ### C. 클라 사전검증 부재
 
-| 위치                  | 문제                                              |
-| --------------------- | ------------------------------------------------- |
-| `PATCH /users/me` 413 | 업로드 전 용량 체크 없이 서버 413 토스트에만 의존 |
+> 해소됨 — `PATCH /users/me` 413 은 presigned 직접 업로드 전환으로 status 자체가 사라졌고, `useImagePicker` 가 5MB 사전검증을 유지한다(웹뷰 base64 브릿지·크롭 canvas 메모리 보호 목적).
 
 ### D. 미구현·Dead code
 
@@ -329,13 +327,24 @@
 - 401: ✅ 전역
 - 403 / 404: ✅ 카탈로그 문구 토스트 (`USER-007` 게스트 탈퇴 불가 등) + dialog 닫힘
 
-### PATCH /api/v1/users/me (정보 수정) · 200, 400, 401, 403, 404, 409, 413, 502
+### POST /api/v1/users/me/profile-image (presigned URL 발급) · 200, 400, 401, 403, 502
+
+- 200: ✅ `{ imageKey, uploadUrl, contentType }` 단건 flat 응답 — S3 직접 PUT 후 `PATCH /users/me` 로 imageKey 확정
+- 400: ✅ 카탈로그 문구 토스트 (미지원 contentType 등)
+- 401: ✅ 전역
+- 403: ✅ `USER-008`(게스트) 카탈로그 문구 토스트 — 버튼 자체를 MEMBER 조건으로 가려 1차 방어
+- 502: ✅ `STORAGE-00x` 전역 (`isGlobalNetError`)
+- uploadUrl 만료 5분 · 미확정 원본은 하루 뒤 서버가 자동 삭제
+- S3 PUT 실패(`S3UploadError`)도 전역이 처리
+
+### PATCH /api/v1/users/me (정보 수정) · 200, 400, 401, 403, 404, 409, 502
 
 - 200: ✅ `['me']` invalidate + `router.replace(MYPAGE)`
-- 400 / 403 / 404: ✅ 카탈로그 문구 토스트
+- 400: ✅ 카탈로그 문구 토스트 — 닉네임 형식 오류 · `USER-009/010/011`(빈 파일·미지원 형식·형식/내용 불일치) · `UPLOAD-001/002`(발급 안 된 key·미업로드 key)
+- 403 / 404: ✅ 카탈로그 문구 토스트 (`USER-008` 게스트 imageKey 요청 등)
 - 401: ✅ 전역
 - 409: ✅ `USER-004`(닉네임 중복)는 `GET /users/nickname/check` 사전검증이 1차 — 경합 시 토스트 / `USER-003` 은 인터셉터가 세션 정리
-- 413(이미지 용량 초과): ⚠️ **클라 사전 용량검증 없음** — 서버 413 토스트에만 의존
+- 413: **사라짐** — 이미지 바이트가 서버를 거치지 않는다 (presigned 직접 업로드)
 - 502: ✅ 전역 `MutationCache.onError` 단독 처리 (로컬은 401·5xx 위임 → 중복 해소)
 
 ### GET /api/v1/users/nickname/check · 200, 400, 401

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,9 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      react-easy-crop:
+        specifier: ^6.2.3
+        version: 6.2.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -4523,6 +4526,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   css-in-js-utils@3.1.0:
     resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
@@ -6710,6 +6714,9 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-wheel@1.0.1:
+    resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
+
   npm-package-arg@11.0.3:
     resolution: {integrity: sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -7176,6 +7183,12 @@ packages:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
       react: 19.1.0
+
+  react-easy-crop@6.2.3:
+    resolution: {integrity: sha512-ebimG3OGlzizjxEZ77Cj9CVLcg5vDZ6QVz8ud1rx4WmsCDWHIROEhgMi0GpJ/jKAuwHrH0M+QZUK4hyvxbYhOA==}
+    peerDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0
 
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
@@ -15826,6 +15839,8 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  normalize-wheel@1.0.1: {}
+
   npm-package-arg@11.0.3:
     dependencies:
       hosted-git-info: 7.0.2
@@ -16318,6 +16333,12 @@ snapshots:
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
+
+  react-easy-crop@6.2.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      normalize-wheel: 1.0.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   react-fast-compare@3.2.2: {}
 


### PR DESCRIPTION
## 작업 요약

- 프로필 이미지를 고르면 업로드 전에 크롭·회전 편집 화면을 거치도록 변경합니다 (#596 presigned 전환의 후속)
- 데스크탑은 줌 슬라이더·휠 줌, 모바일은 핀치줌으로 확대/축소합니다
- 프로필 이미지 영역 전체를 클릭해 사진을 변경할 수 있게 확장합니다

## 작업 세부 내용

**크롭·회전 에디터 (`ProfileImageCropEditor`)**

- `react-easy-crop` 기반 전체 화면 에디터를 추가했습니다. 피커 선택 직후 열리고, 확인 시 크롭된 이미지가 기존 presign → S3 PUT → `PATCH /users/me` 체인으로 올라갑니다 (`EditForm`/`usePatchMe` 인터페이스 변경 없음)
- 화면 구성은 앱 패턴 그대로입니다 — 컨텐츠 폭(`max-w-120`) 안에만 뜨고, 공통 `Header`(BACK = 취소) + `BottomCta` 완료 버튼을 사용합니다
- `objectFit="cover"` 로 진입 시 이미지가 가로/세로 중 맞는 쪽으로 크롭 영역을 꽉 채웁니다
- 확대/축소는 입력 수단으로 분기했습니다 — 줌 슬라이더는 `pointer-fine`(마우스) 환경에서만 노출하고, 터치는 핀치줌(라이브러리 기본)을 사용합니다. 90° 회전 버튼은 제스처 대체가 없어 양쪽 모두 노출합니다. Esc 로 닫을 수 있습니다

**크롭 출력 (`_utils/cropImage.ts`)**

- canvas 로 크롭+회전을 적용해 **JPEG(0.9) 고정**으로 인코딩합니다. presign 의 `contentType` 은 원본 `file.type` 이 아니라 이 출력 타입과 자동으로 일치하게 되어, 서명·바이트 불일치(`USER-011`)가 구조적으로 발생하지 않습니다. HEIC 원본도 여기서 JPEG 로 정규화됩니다
- 출력 한 변을 1080px 로 캡해 과대 원본이 그대로 업로드되지 않게 했습니다

**예외 처리·판단 사항**

- Chrome/Android WebView 가 디코드하지 못하는 형식(HEIC 등)은 에디터 진입 전에 `loadImage` 로 걸러 "지원하지 않는 이미지 형식이에요." 토스트를 띄웁니다
- `useImagePicker` 의 5MB 사전 검증은 유지했습니다 — 413 은 사라졌지만 웹뷰 base64 브릿지·크롭 canvas 메모리 보호로 여전히 유효하다고 판단해, 주석만 현재 근거로 갱신했습니다
- 프로필 이미지 원과 카메라 뱃지를 하나의 버튼으로 합쳐, 이미지 어디를 눌러도 피커가 열립니다 (기존엔 뱃지만 클릭 가능)

**테스트·문서**

- E2E 스펙(`e2e/specs/mypage/profileImageEdit.spec.ts`)을 추가했습니다 — 이미지 클릭 → filechooser → 에디터 → 완료 → S3 PUT 의 `Content-Type: image/jpeg` 와 실제 JPEG 바이트(SOI 마커)까지 검증합니다. 슬라이더의 포인터별 노출 조건, 디코드 불가 토스트도 별도 케이스로 확인합니다
- `docs/spec/api-status-audit.md` 갱신 — `POST /users/me/profile-image` 섹션 신설, `PATCH /users/me` 에서 413 제거·`UPLOAD-00x` 반영

## 스크린샷

https://github.com/user-attachments/assets/950d3b2e-b5c0-4f2a-8eb2-41cd74017ec7

## 연관 이슈

closes #593


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 프로필 이미지 선택 후 자르기 및 회전 편집 기능을 추가했습니다.
  * 마우스 환경에서는 확대/축소 슬라이더를 제공하고, 터치 환경에서는 최적화된 편집 화면을 제공합니다.
  * 편집한 이미지를 JPEG 형식으로 변환해 업로드합니다.
  * 지원되지 않는 이미지 형식 선택 시 안내 메시지를 표시합니다.

* **문서**
  * 프로필 이미지 업로드 및 관련 상태 코드 안내를 최신화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->