### PR TITLE
design: 모달 공통 좌우 여백·패딩을 시안 기준으로 통일

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/_components/owner-started-dialog/OwnerStartedDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/owner-started-dialog/OwnerStartedDialog.tsx
@@ -28,10 +28,7 @@ function OwnerStartedDialog({
 }: OwnerStartedDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        showCloseButton={false}
-        className="flex max-w-83 flex-col items-center gap-5 p-4"
-      >
+      <DialogContent showCloseButton={false} className="items-center gap-5">
         <FireIconFill className="size-10 text-icon-neutral-secondary" aria-hidden />
 
         <div className="flex flex-col items-center gap-1">

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/ByeWarningDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/ByeWarningDialog.tsx
@@ -22,10 +22,7 @@ function ByeWarningDialog({
 }: ByeWarningDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        showCloseButton={false}
-        className="flex max-w-83 flex-col items-center gap-5 p-4"
-      >
+      <DialogContent showCloseButton={false} className="items-center gap-5">
         <div className="flex flex-col items-center gap-3">
           <AlertIconFill className="size-10 text-icon-neutral-secondary" aria-hidden />
 

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/ConfirmStartDialog.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-start-button/ConfirmStartDialog.tsx
@@ -16,10 +16,7 @@ function ConfirmStartDialog({ open, onOpenChange, onConfirm }: ConfirmStartDialo
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        showCloseButton={false}
-        className="flex max-w-83 flex-col items-center gap-5 p-4"
-      >
+      <DialogContent showCloseButton={false} className="items-center gap-5">
         <div className="flex flex-col items-center gap-3">
           <ConfirmStartFace className="size-7.5 text-icon-neutral-secondary" aria-hidden />
 

--- a/apps/web/src/components/dialog/index.tsx
+++ b/apps/web/src/components/dialog/index.tsx
@@ -64,7 +64,7 @@ function DialogContent({
           if (!closeOnDimClick) event.preventDefault();
         }}
         className={cn(
-          'fixed top-1/2 left-1/2 grid w-[calc(100%-40px)] max-w-[calc(480px-40px)] -translate-x-1/2 -translate-y-1/2 rounded-3xl bg-white p-5 duration-100 outline-none data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95',
+          'fixed top-1/2 left-1/2 flex w-[calc(100%-70px)] max-w-[calc(480px-70px)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-3xl bg-white p-4 duration-100 outline-none data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95',
           className
         )}
         style={{ zIndex: Z_INDEX.DIALOG, ...props.style }}


### PR DESCRIPTION
## 작업 내용

모달 공통 `DialogContent` 의 좌우 여백과 패딩을 시안 기준으로 통일했습니다.

```diff
- grid w-[calc(100%-40px)] max-w-[calc(480px-40px)] p-5
+ flex w-[calc(100%-70px)] max-w-[calc(480px-70px)] flex-col p-4
```

**여백 기준** — 시안(캔버스 402 / 모달 332 / 좌우 여백 35)을 실측해 `100% - 70px` 로 잡았습니다. 고정폭(332)으로 두면 입력폼이 들어가는 모달이 좁아지고 넓은 화면에서 여백만 벌어지는데, 여백 기준이면 화면 크기와 무관하게 시안 의도가 유지됩니다.

**`grid` → `flex flex-col`** — 기존 기본값이 `grid` 라 개별 모달에서 `flex-col` 만 넘기면 무시됐습니다. tailwind-merge 는 `flex` 가 함께 있어야 `grid` 를 걷어냅니다. 실제로 이 문제로 레이아웃이 깨진 적이 있어 기본값을 바꿔 함정을 없앴습니다.

기본값이 올라가면서 안내 모달 3개의 중복 클래스(`flex max-w-83 flex-col ... p-4`)도 제거했습니다.

## 확인

- iPhone SE(375) — 모달 304px / 좌우 여백 36px (기대값 305 / 35)
- 넓은 화면 — 입력폼 모달 폭 확보 확인
- 22개 모달의 클래스 병합 결과 확인 — 개별 오버라이드(`home-onboarding` 의 `max-w-[334px] p-0`, `FriendListDialog` 의 `p-5`, `p-6` 2곳) 모두 정상 유지

## 스크린샷 (후/전)
<img width="959" height="681" alt="image" src="https://github.com/user-attachments/assets/fd7cbfb6-7730-4e04-abed-5eacbfbc2e34" />

## 연관 이슈

closes #603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 토너먼트 시작 관련 대화상자의 레이아웃과 여백을 조정했습니다.
  * 대화상자 콘텐츠의 너비, 내부 정렬 및 패딩을 개선해 화면 구성을 일관되게 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->