### PR TITLE
design: 영수증 상품명 2줄 제한 및 공유 이미지 레이아웃 시안 반영

### DIFF
--- a/apps/web/src/app/tournament/[id]/result/_components/ReceiptPaper.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ReceiptPaper.tsx
@@ -183,7 +183,7 @@ function ProductCard({ tournamentId, product, highlight = false }: ProductCardPr
         )}
       </div>
       <div className="flex min-w-0 flex-1 flex-col">
-        <p className="body-2-regular wrap-break-word break-keep text-text-neutral-primary">
+        <p className="line-clamp-2 body-2-regular break-keep text-text-neutral-primary">
           {product.name}
         </p>
         <p className="body-2-semibold text-text-neutral-primary">{formatPrice(product.price)}</p>

--- a/apps/web/src/app/tournament/[id]/result/_components/ReceiptPaper.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/ReceiptPaper.tsx
@@ -183,7 +183,10 @@ function ProductCard({ tournamentId, product, highlight = false }: ProductCardPr
         )}
       </div>
       <div className="flex min-w-0 flex-1 flex-col">
-        <p className="line-clamp-2 body-2-regular break-keep text-text-neutral-primary">
+        <p
+          data-receipt-product-name
+          className="line-clamp-2 body-2-regular break-keep text-text-neutral-primary"
+        >
           {product.name}
         </p>
         <p className="body-2-semibold text-text-neutral-primary">{formatPrice(product.price)}</p>

--- a/apps/web/src/app/tournament/[id]/result/_components/receipt-share-dialog/ReceiptShareCaptureLayer.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/receipt-share-dialog/ReceiptShareCaptureLayer.tsx
@@ -13,10 +13,10 @@ const RECEIPT_RENDER_WIDTH_PX = RECEIPT_PAPER_WIDTH_PX / RECEIPT_ZOOM;
 /** 이 높이를 넘길 때만 배율을 낮춘다 — 로고 위까지 남는 공간 */
 const RECEIPT_MAX_HEIGHT_PX = 750;
 
-/** 종이가 짧을 때 시안처럼 아래로 내려오는 기본 여백. 길어지면 이만큼까지 잠식한다 */
+/** 종이가 짧을 때 내려오는 여백 — 길어지면 이만큼까지 잠식한다 */
 const RECEIPT_TOP_OFFSET_PX = 65;
 
-/** 공유 이미지 전용 상품명 크기 — 화면 영수증은 읽기 크기를 유지한다 */
+/** 공유 이미지 전용 — 화면 영수증은 읽기 크기를 유지한다 */
 const SHARE_PRODUCT_NAME_FONT_SIZE_PX = 12.2;
 const SHARE_PRODUCT_NAME_LINE_HEIGHT_PX = 17.4;
 
@@ -33,20 +33,31 @@ const ReceiptShareCaptureLayer = forwardRef<HTMLDivElement, ReceiptShareCaptureL
     const zoomRef = useRef<HTMLDivElement>(null);
     const paperAreaRef = useRef<HTMLDivElement>(null);
 
-    /**
-     * 배율을 낮추면 레이아웃 폭이 넓어져 긴 상품명의 줄바꿈이 달라지고, 그러면 높이가 다시
-     * 변한다. 한 번만 계산하면 이 되먹임 때문에 결과가 어긋나므로 값이 안정될 때까지 반복한다.
-     * 줄바꿈은 계단식이라 두 값을 오갈 수 있어, 그중 상한을 넘지 않는 최대 배율을 고른다.
-     */
     useLayoutEffect(() => {
       const paper = paperRef.current;
       const zoomWrap = zoomRef.current;
       if (!paper || !zoomWrap) return;
 
-      /** 상품명만 시안 크기로 낮춘다 */
+      /** line-clamp 의 말줄임표는 캡처 복제본에 남지 않아 글자로 직접 넣는다 */
       paper.querySelectorAll<HTMLElement>('[data-receipt-product-name]').forEach(name => {
         name.style.fontSize = `${SHARE_PRODUCT_NAME_FONT_SIZE_PX}px`;
         name.style.lineHeight = `${SHARE_PRODUCT_NAME_LINE_HEIGHT_PX}px`;
+
+        const fullText = name.dataset.fullText ?? name.textContent ?? '';
+        name.dataset.fullText = fullText;
+        name.textContent = fullText;
+        if (name.scrollHeight <= name.clientHeight) return;
+
+        /** 들어가는 최대 글자 수 */
+        let low = 0;
+        let high = fullText.length;
+        while (low < high) {
+          const mid = Math.ceil((low + high) / 2);
+          name.textContent = `${fullText.slice(0, mid).trimEnd()}…`;
+          if (name.scrollHeight > name.clientHeight) high = mid - 1;
+          else low = mid;
+        }
+        name.textContent = `${fullText.slice(0, low).trimEnd()}…`;
       });
 
       let best = 0;
@@ -70,7 +81,7 @@ const ReceiptShareCaptureLayer = forwardRef<HTMLDivElement, ReceiptShareCaptureL
       zoomWrap.style.zoom = String(fitZoom);
       zoomWrap.style.width = `${RECEIPT_PAPER_WIDTH_PX / fitZoom}px`;
 
-      /** 남는 만큼만 내린다 — 종이가 길면 여백이 0 이 되어 시안처럼 위로 붙는다 */
+      /** 남는 만큼만 내린다 — 종이가 길면 0 이 되어 위로 붙는다 */
       const spare = RECEIPT_MAX_HEIGHT_PX - paper.scrollHeight * fitZoom;
       paperAreaRef.current?.style.setProperty(
         'padding-top',
@@ -84,7 +95,6 @@ const ReceiptShareCaptureLayer = forwardRef<HTMLDivElement, ReceiptShareCaptureL
           ref={ref}
           className="flex h-240 w-135 flex-col items-center justify-between bg-sky-blue-200 pt-21.75 pb-11.25"
         >
-          {/* 종이가 짧으면 시안처럼 내려오고, 길어지면 이 여백을 잠식한다 */}
           <div ref={paperAreaRef} className="flex w-92.5 items-center justify-center">
             <div ref={zoomRef} style={{ zoom: RECEIPT_ZOOM, width: RECEIPT_RENDER_WIDTH_PX }}>
               <div ref={paperRef}>

--- a/apps/web/src/app/tournament/[id]/result/_components/receipt-share-dialog/ReceiptShareCaptureLayer.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/receipt-share-dialog/ReceiptShareCaptureLayer.tsx
@@ -13,6 +13,9 @@ const RECEIPT_RENDER_WIDTH_PX = RECEIPT_PAPER_WIDTH_PX / RECEIPT_ZOOM;
 /** 이 높이를 넘길 때만 배율을 낮춘다 — 로고 위까지 남는 공간 */
 const RECEIPT_MAX_HEIGHT_PX = 750;
 
+/** 종이가 짧을 때 시안처럼 아래로 내려오는 기본 여백. 길어지면 이만큼까지 잠식한다 */
+const RECEIPT_TOP_OFFSET_PX = 65;
+
 /** 공유 이미지 전용 상품명 크기 — 화면 영수증은 읽기 크기를 유지한다 */
 const SHARE_PRODUCT_NAME_FONT_SIZE_PX = 12.2;
 const SHARE_PRODUCT_NAME_LINE_HEIGHT_PX = 17.4;
@@ -28,6 +31,7 @@ const ReceiptShareCaptureLayer = forwardRef<HTMLDivElement, ReceiptShareCaptureL
   function ReceiptShareCaptureLayer({ tournamentId, tournamentName, result, date }, ref) {
     const paperRef = useRef<HTMLDivElement>(null);
     const zoomRef = useRef<HTMLDivElement>(null);
+    const paperAreaRef = useRef<HTMLDivElement>(null);
 
     /**
      * 배율을 낮추면 레이아웃 폭이 넓어져 긴 상품명의 줄바꿈이 달라지고, 그러면 높이가 다시
@@ -65,6 +69,13 @@ const ReceiptShareCaptureLayer = forwardRef<HTMLDivElement, ReceiptShareCaptureL
       const fitZoom = best || candidate;
       zoomWrap.style.zoom = String(fitZoom);
       zoomWrap.style.width = `${RECEIPT_PAPER_WIDTH_PX / fitZoom}px`;
+
+      /** 남는 만큼만 내린다 — 종이가 길면 여백이 0 이 되어 시안처럼 위로 붙는다 */
+      const spare = RECEIPT_MAX_HEIGHT_PX - paper.scrollHeight * fitZoom;
+      paperAreaRef.current?.style.setProperty(
+        'padding-top',
+        `${Math.max(0, Math.min(RECEIPT_TOP_OFFSET_PX, spare))}px`
+      );
     }, [result, tournamentName, date]);
 
     return (
@@ -73,7 +84,8 @@ const ReceiptShareCaptureLayer = forwardRef<HTMLDivElement, ReceiptShareCaptureL
           ref={ref}
           className="flex h-240 w-135 flex-col items-center justify-between bg-sky-blue-200 pt-21.75 pb-11.25"
         >
-          <div className="flex w-92.5 items-center justify-center">
+          {/* 종이가 짧으면 시안처럼 내려오고, 길어지면 이 여백을 잠식한다 */}
+          <div ref={paperAreaRef} className="flex w-92.5 items-center justify-center">
             <div ref={zoomRef} style={{ zoom: RECEIPT_ZOOM, width: RECEIPT_RENDER_WIDTH_PX }}>
               <div ref={paperRef}>
                 <ReceiptPaper

--- a/apps/web/src/app/tournament/[id]/result/_components/receipt-share-dialog/ReceiptShareCaptureLayer.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/receipt-share-dialog/ReceiptShareCaptureLayer.tsx
@@ -10,11 +10,15 @@ const RECEIPT_PAPER_WIDTH_PX = 370;
 const RECEIPT_ZOOM = 1.42;
 const RECEIPT_RENDER_WIDTH_PX = RECEIPT_PAPER_WIDTH_PX / RECEIPT_ZOOM;
 
-/** 이 높이를 넘길 때만 배율을 낮춘다 */
-const RECEIPT_MAX_HEIGHT_PX = 737;
+/** 이 높이를 넘길 때만 배율을 낮춘다 — 시안의 상품 4개 기준 종이 높이 */
+const RECEIPT_MAX_HEIGHT_PX = 772;
 
 /** ReceiptPaper 하단 물결(h-4.5). absolute 라 종이 높이에 안 잡힌다 */
 const RECEIPT_ZIGZAG_HEIGHT_PX = 18;
+
+/** 공유 이미지 전용 상품명 크기 — 화면 영수증은 읽기 크기를 유지한다 */
+const SHARE_PRODUCT_NAME_FONT_SIZE_PX = 12.2;
+const SHARE_PRODUCT_NAME_LINE_HEIGHT_PX = 17.4;
 
 type ReceiptShareCaptureLayerProps = {
   tournamentId: number;
@@ -38,6 +42,12 @@ const ReceiptShareCaptureLayer = forwardRef<HTMLDivElement, ReceiptShareCaptureL
       const paper = paperRef.current;
       const zoomWrap = zoomRef.current;
       if (!paper || !zoomWrap) return;
+
+      /** 상품명만 시안 크기로 낮춘다 */
+      paper.querySelectorAll<HTMLElement>('[data-receipt-product-name]').forEach(name => {
+        name.style.fontSize = `${SHARE_PRODUCT_NAME_FONT_SIZE_PX}px`;
+        name.style.lineHeight = `${SHARE_PRODUCT_NAME_LINE_HEIGHT_PX}px`;
+      });
 
       let best = 0;
       let candidate = RECEIPT_ZOOM;

--- a/apps/web/src/app/tournament/[id]/result/_components/receipt-share-dialog/ReceiptShareCaptureLayer.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/receipt-share-dialog/ReceiptShareCaptureLayer.tsx
@@ -13,9 +13,6 @@ const RECEIPT_RENDER_WIDTH_PX = RECEIPT_PAPER_WIDTH_PX / RECEIPT_ZOOM;
 /** 이 높이를 넘길 때만 배율을 낮춘다 — 시안의 상품 4개 기준 종이 높이 */
 const RECEIPT_MAX_HEIGHT_PX = 772;
 
-/** ReceiptPaper 하단 물결(h-4.5). absolute 라 종이 높이에 안 잡힌다 */
-const RECEIPT_ZIGZAG_HEIGHT_PX = 18;
-
 /** 공유 이미지 전용 상품명 크기 — 화면 영수증은 읽기 크기를 유지한다 */
 const SHARE_PRODUCT_NAME_FONT_SIZE_PX = 12.2;
 const SHARE_PRODUCT_NAME_LINE_HEIGHT_PX = 17.4;
@@ -31,7 +28,6 @@ const ReceiptShareCaptureLayer = forwardRef<HTMLDivElement, ReceiptShareCaptureL
   function ReceiptShareCaptureLayer({ tournamentId, tournamentName, result, date }, ref) {
     const paperRef = useRef<HTMLDivElement>(null);
     const zoomRef = useRef<HTMLDivElement>(null);
-    const logoAreaRef = useRef<HTMLDivElement>(null);
 
     /**
      * 배율을 낮추면 레이아웃 폭이 넓어져 긴 상품명의 줄바꿈이 달라지고, 그러면 높이가 다시
@@ -69,16 +65,14 @@ const ReceiptShareCaptureLayer = forwardRef<HTMLDivElement, ReceiptShareCaptureL
       const fitZoom = best || candidate;
       zoomWrap.style.zoom = String(fitZoom);
       zoomWrap.style.width = `${RECEIPT_PAPER_WIDTH_PX / fitZoom}px`;
-
-      /** 물결 높이를 여백으로 되돌려야 로고가 물결 끝 기준으로 가운데 온다 */
-      if (logoAreaRef.current) {
-        logoAreaRef.current.style.paddingTop = `${RECEIPT_ZIGZAG_HEIGHT_PX * fitZoom}px`;
-      }
     }, [result, tournamentName, date]);
 
     return (
       <div aria-hidden className="pointer-events-none fixed top-0 -left-250">
-        <div ref={ref} className="flex h-240 w-135 flex-col items-center bg-sky-blue-200 pt-27.75">
+        <div
+          ref={ref}
+          className="flex h-240 w-135 flex-col items-center justify-between bg-sky-blue-200 pt-16 pb-11.25"
+        >
           <div className="flex w-92.5 items-center justify-center">
             <div ref={zoomRef} style={{ zoom: RECEIPT_ZOOM, width: RECEIPT_RENDER_WIDTH_PX }}>
               <div ref={paperRef}>
@@ -92,10 +86,7 @@ const ReceiptShareCaptureLayer = forwardRef<HTMLDivElement, ReceiptShareCaptureL
             </div>
           </div>
 
-          {/* 종이 아래 남는 공간의 한가운데에 로고를 둔다 */}
-          <div ref={logoAreaRef} className="flex flex-1 items-center justify-center">
-            <PikiLogoCart aria-hidden className="h-8 w-11 shrink-0 text-white" />
-          </div>
+          <PikiLogoCart aria-hidden className="h-8 w-11 shrink-0 text-white" />
         </div>
       </div>
     );

--- a/apps/web/src/app/tournament/[id]/result/_components/receipt-share-dialog/ReceiptShareCaptureLayer.tsx
+++ b/apps/web/src/app/tournament/[id]/result/_components/receipt-share-dialog/ReceiptShareCaptureLayer.tsx
@@ -10,8 +10,8 @@ const RECEIPT_PAPER_WIDTH_PX = 370;
 const RECEIPT_ZOOM = 1.42;
 const RECEIPT_RENDER_WIDTH_PX = RECEIPT_PAPER_WIDTH_PX / RECEIPT_ZOOM;
 
-/** 이 높이를 넘길 때만 배율을 낮춘다 — 시안의 상품 4개 기준 종이 높이 */
-const RECEIPT_MAX_HEIGHT_PX = 772;
+/** 이 높이를 넘길 때만 배율을 낮춘다 — 로고 위까지 남는 공간 */
+const RECEIPT_MAX_HEIGHT_PX = 750;
 
 /** 공유 이미지 전용 상품명 크기 — 화면 영수증은 읽기 크기를 유지한다 */
 const SHARE_PRODUCT_NAME_FONT_SIZE_PX = 12.2;
@@ -71,7 +71,7 @@ const ReceiptShareCaptureLayer = forwardRef<HTMLDivElement, ReceiptShareCaptureL
       <div aria-hidden className="pointer-events-none fixed top-0 -left-250">
         <div
           ref={ref}
-          className="flex h-240 w-135 flex-col items-center justify-between bg-sky-blue-200 pt-16 pb-11.25"
+          className="flex h-240 w-135 flex-col items-center justify-between bg-sky-blue-200 pt-21.75 pb-11.25"
         >
           <div className="flex w-92.5 items-center justify-center">
             <div ref={zoomRef} style={{ zoom: RECEIPT_ZOOM, width: RECEIPT_RENDER_WIDTH_PX }}>

--- a/apps/web/src/app/tournament/[id]/result/group/_components/GroupResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/group/_components/GroupResultClient.tsx
@@ -236,7 +236,9 @@ function GroupProductCard({ item, highlight = false }: GroupProductCardProps) {
           )}
         </div>
         <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <p className="body-2-regular break-keep text-text-neutral-primary">{item.name}</p>
+          <p className="line-clamp-2 body-2-regular break-keep text-text-neutral-primary">
+            {item.name}
+          </p>
           {count > 0 && (
             <button
               type="button"


### PR DESCRIPTION
## 작업 내용

영수증 상품명을 2줄로 제한하고, 공유 이미지의 크기·배치를 시안에 맞췄습니다.

### 1. 상품명 2줄 제한

`ReceiptPaper` 의 `ProductCard` 와 `GroupResultClient` 의 `GroupProductCard` 양쪽에 `line-clamp-2` 를 적용했습니다. 넘치는 부분은 `…` 로 말줄임되어, 상품명 길이와 무관하게 카드 높이가 고정됩니다.

기존 `wrap-break-word` 는 `line-clamp` 와 중복이라 제거했습니다.

### 2. 공유 이미지 상품명 크기

시안 값(1080 기준 font 34.6 / line-height 49.4)을 배율(1.42)로 환산해 적용했습니다.

| | 이전 | 현재 |
| --- | --- | --- |
| font-size | 14 | 12.2 |
| line-height | 20 | 17.4 |

`ReceiptPaper` 는 결과 화면과 캡처 레이어가 함께 쓰는 컴포넌트입니다. 직접 줄이면 화면 영수증까지 작아지므로, `data-receipt-product-name` 마커를 두고 **캡처 레이어에서만** 오버라이드했습니다. 화면 영수증은 기존 크기를 유지합니다.

### 3. 로고 하단 고정

중앙 정렬을 `justify-between` 으로 바꿔, 상품 수와 무관하게 로고가 같은 자리에 오도록 했습니다. 중앙 정렬을 위해 두었던 물결 높이 보정 로직은 불필요해져 제거했습니다.

### 4. 종이 위치 — 상품이 적으면 아래로

시안은 상품이 적을 때 종이가 아래로 내려오고, 많아지면 위로 확장됩니다. 배율이 정해진 뒤 남는 공간을 재서 그만큼만 내리는 방식으로 구현했습니다.

```ts
const spare = RECEIPT_MAX_HEIGHT_PX - paper.scrollHeight * fitZoom;
paddingTop = clamp(0, spare, RECEIPT_TOP_OFFSET_PX)
```

종이 상단 그라데이션(`absolute -top-6`)이 24px 위로 넘치는 것을 반영해 컨테이너 여백을 잡았습니다. 이 부분을 빼고 계산해 종이가 시안보다 위에 붙어 있었습니다.

## 확인

캡처 결과를 시안과 대조했습니다 (1080 기준).

| | 보이는 종이 top (현재/시안) | 로고 bottom | 하단 여백 |
| --- | --- | --- | --- |
| 2개 | 256 / 257 | 1830 | 90 |
| 3개 | 256 / 257 | 1830 | 90 |
| 4개 | 126 / 126 | 1830 | 90 |

- 상품 수가 줄면 아래에서 하나씩 빠지고 종이가 짧아집니다
- 2~4개 모두 배율이 유지되어 글자 크기가 동일합니다
- 로고는 전 케이스 하단 여백 90 으로 고정입니다
- `html-to-image` 가 `line-clamp`(`-webkit-box`)를 정상 렌더하는지 별도 검증했습니다 (DOM 40px → 캡처 56px, 말줄임 미적용 시 60px 이상)

상품명이 2줄로 꽉 찬 상태에서 4개면 배율 축소가 걸립니다. 종이 위치를 시안에 맞추는 쪽을 우선했습니다.

## 스크린샷
<img width="490" height="556" alt="image" src="https://github.com/user-attachments/assets/03f08c2c-5ad2-4252-a324-92e23287efcf" />

## 연관 이슈

closes #605