### PR TITLE
fix: 토너먼트 히스토리 라우트 권한 분류를 Member & Guest 로 정정

### DIFF
--- a/apps/web/src/consts/route.ts
+++ b/apps/web/src/consts/route.ts
@@ -18,10 +18,10 @@ export const ROUTES = {
   MYPAGE: '/mypage',
   MYPAGE_EDIT: '/mypage/edit',
   PLAY_FROM_LINK: (sourceTournamentId: number) => `/play/${sourceTournamentId}`,
+  TOURNAMENT_HISTORY: '/archive/tournament',
 
   /** 3. Member Only */
   WISHLIST: '/archive/wish',
-  TOURNAMENT_HISTORY: '/archive/tournament',
   WISH_EDIT: (wishId: number) => `/archive/wish/${wishId}`,
   MYPAGE_WITHDRAW: '/mypage/withdraw',
 

--- a/apps/web/src/utils/getRouteType.ts
+++ b/apps/web/src/utils/getRouteType.ts
@@ -30,6 +30,7 @@ const isMemberAndGuestRoute = (pathname: string) => {
   if (matchesPath(pathname, ROUTES.TOURNAMENT_JOIN_BY_CODE)) return true;
   if (matchesPath(pathname, '/play')) return true;
   if (matchesPath(pathname, ROUTES.NOTIFICATION)) return true;
+  if (matchesPath(pathname, ROUTES.TOURNAMENT_HISTORY)) return true;
   if (pathname === ROUTES.MYPAGE) return true;
   if (pathname === ROUTES.MYPAGE_EDIT) return true;
 
@@ -42,7 +43,6 @@ const isAuthorizedRoute = (pathname: string) =>
 const isMemberOnlyRoute = (pathname: string) => {
   if (pathname === ROUTES.MYPAGE_WITHDRAW) return true;
   if (matchesPath(pathname, ROUTES.WISHLIST)) return true;
-  if (matchesPath(pathname, ROUTES.TOURNAMENT_HISTORY)) return true;
 
   return false;
 };


### PR DESCRIPTION
## 작업 요약

- 토너먼트 히스토리(`/archive/tournament`) 라우트 권한 분류를 MEMBER_ONLY 에서 MEMBER_AND_GUEST 로 정정합니다

## 작업 세부 내용

토너먼트 히스토리는 게스트도 접근 가능한 페이지인데(하단 탭바에 게스트에게도 노출, 멤버 가드 없음) 라우트 분류만 멤버 전용으로 잘못 들어가 있었습니다. 이 때문에 두 가지 증상이 있었습니다.

1. 토큰이 없는 상태로 히스토리 URL 직접 진입 시 자동 게스트 발급 대신 로그인 페이지로 튕김 (`proxy.ts` 의 MEMBER_ONLY 분기)
2. 그 로그인 페이지에서 게스트로 시작해도 히스토리로 복귀하지 못하고 홈 + "멤버 전용" 토스트로 빠짐 (`getPostLoginRedirectPath` 의 MEMBER_ONLY 처리)

### 변경 (2줄, 두 파일 동기 수정)

- `utils/getRouteType.ts` — `TOURNAMENT_HISTORY` 체크를 `isMemberOnlyRoute` → `isMemberAndGuestRoute` 로 이동
- `consts/route.ts` — `TOURNAMENT_HISTORY` 선언을 "3. Member Only" → "2. Member & Guest" 섹션으로 이동 (파일 상단 NOTE 규칙)

멤버 전용으로 남는 것은 위시 아카이브(`WISHLIST` prefix 매치로 `WISH_EDIT` 포함)와 회원탈퇴(`MYPAGE_WITHDRAW`)뿐이며 변경 없습니다.

### 확인

- 소비처(`proxy.ts`, `loginRedirect.ts`, `notification-sse-provider`)는 전부 `getRouteType` 결과로만 분기하므로 분류 이동만으로 두 증상이 함께 해소됩니다
  - MEMBER_AND_GUEST 는 토큰이 전혀 없으면 `handleGuestLogin` 으로 자동 게스트 발급 → 증상 1 해소
  - `getPostLoginRedirectPath` 가 더 이상 MEMBER_ONLY 로 판정하지 않아 게스트 시작 후 히스토리로 복귀 → 증상 2 해소
- MEMBER_ONLY 라우트가 받던 `x-redirect-path` 헤더의 소비처는 위시 아카이브·탈퇴 layout 과 `serverApi` 401 fallback 뿐이라 히스토리에는 영향 없음 (다른 MEMBER_AND_GUEST 라우트와 동일 동작)
- `check-types` · `lint` 통과
- e2e `specs/archive` 는 4건이 실패하지만 변경을 되돌린 baseline 에서도 동일하게 실패함을 확인 — 이 PR 과 무관한 기존 실패 (쿼리 파라미터 포함 진입에서 Page Not Found 렌더)


## 연관 이슈

closes #606


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 토너먼트 기록 페이지가 추가되었습니다.
  - 로그인한 회원과 게스트 모두 토너먼트 기록을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->