### PR TITLE
fix: 웹뷰 핀치줌·포커스 자동 줌 방지 — 네이티브 앱처럼 보이게

### DIFF
--- a/apps/app/app/index.tsx
+++ b/apps/app/app/index.tsx
@@ -203,6 +203,7 @@ function Page() {
         onError={handleWebViewError}
         onHttpError={handleWebViewHttpError}
         allowsBackForwardNavigationGestures
+        setBuiltInZoomControls={false}
         cacheEnabled
         sharedCookiesEnabled
         webviewDebuggingEnabled={__DEV__}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -32,6 +32,9 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
+  // NOTE: 웹뷰 줌 방지용 — 일반 Safari 는 user-scalable=no 를 무시하므로 브라우저 확대 접근성은 유지된다.
+  maximumScale: 1,
+  userScalable: false,
   viewportFit: 'cover',
 };
 


### PR DESCRIPTION
## 작업 요약

- 웹뷰 안에서 핀치줌·더블탭 줌·input 포커스 자동 줌인이 일어나지 않도록 막습니다

## 작업 세부 내용

앱은 WebView가 웹을 감싸는 구조인데 줌 동작이 허용돼 있어 화면이 임의로 스케일링됐습니다. iOS와 Android가 막는 지점이 달라 두 곳을 수정했습니다.

### 1. 웹 viewport meta — iOS WKWebView (`apps/web/src/app/layout.tsx`)

viewport export에 `maximumScale: 1`, `userScalable: false`를 추가했습니다. WKWebView의 핀치줌·더블탭 줌·input 포커스 시 자동 줌인이 막힙니다.

- 일반 모바일 Safari는 접근성 정책상 `user-scalable=no`를 무시하므로, 브라우저로 접속한 사용자의 확대 접근성은 그대로 유지됩니다 (코드에 NOTE로 남김)

### 2. Android WebView 줌 컨트롤 해제 (`apps/app/app/index.tsx`)

Android WebView는 viewport meta와 별개로 자체 줌 컨트롤이 기본 활성이라, `<Webview>`에 `setBuiltInZoomControls={false}`를 추가해 꺼줬습니다.

### 배포

둘 다 바이너리 변경이 없어 **웹 배포 + OTA(EAS Update)** 로 반영 가능합니다.

- 웹 meta는 배포 즉시 구버전 앱 포함 iOS 전체에 적용됩니다
- `setBuiltInZoomControls`는 JS prop 변경이라 OTA로 나가며, `runtimeVersion` 정책(`appVersion`)상 현재 버전(1.2.2) 바이너리에만 적용됩니다 — 구버전 Android의 핀치줌만 다음 스토어 업데이트 때 해소됩니다

## 연관 이슈

closes #609


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 앱 내 웹뷰에서 내장 확대/축소 기능이 비활성화됩니다.
  * 웹 환경에서는 페이지 확대가 제한되며, 일반 Safari에서는 기존 확대 접근성이 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->