### PR TITLE
chore: 웹 승격·배포 알림 워크플로우 도입

### DIFF
--- a/.github/workflows/web-deploy-notify.yml
+++ b/.github/workflows/web-deploy-notify.yml
@@ -1,0 +1,82 @@
+# Vercel 배포 결과 Discord 알림 — Vercel Git 연동이 배포마다 만드는 GitHub Deployment 의
+# 상태 변화(deployment_status)를 구독한다. 이 이벤트는 default 브랜치(dev)에 있는 워크플로우만
+# 실행하므로, dev 에 머지된 뒤부터 동작한다.
+# 전송은 webhook 이 아니라 허거덩 봇 본인(DISCORD_BOT_TOKEN — PR 봇과 공유)이 한다.
+# secrets: DISCORD_BOT_TOKEN(기존), DISCORD_DEPLOY_CHANNEL_ID(신규 — 배포알림 채널), DISCORD_USER_MAP(기존)
+name: Web Deploy Notify
+
+on: deployment_status
+
+permissions: {}
+
+jobs:
+  notify:
+    # Production 승격과 dev 브랜치 배포만 알린다 — PR Preview 는 소음이라 제외
+    if: >-
+      contains(fromJSON('["success", "failure", "error"]'), github.event.deployment_status.state) &&
+      (startsWith(github.event.deployment.environment, 'Production') || github.event.deployment.ref == 'dev')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Vercel 배포의 actor 는 vercel[bot] 이라, 배포자는 커밋 author 로 잡는다
+      - name: 커밋 정보 조회
+        id: commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.deployment.sha }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${{ github.repository }}/commits/$SHA" > commit.json
+          echo "message=$(jq -r '.commit.message | split("\n")[0]' commit.json)" >> "$GITHUB_OUTPUT"
+          echo "author=$(jq -r '.author.login // .commit.author.name' commit.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Discord 전송 (허거덩 봇)
+        env:
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          CHANNEL_ID: ${{ secrets.DISCORD_DEPLOY_CHANNEL_ID }}
+          DISCORD_USER_MAP: ${{ secrets.DISCORD_USER_MAP }}
+          STATE: ${{ github.event.deployment_status.state }}
+          ENVIRONMENT: ${{ github.event.deployment.environment }}
+          REF: ${{ github.event.deployment.ref }}
+          SHA: ${{ github.event.deployment.sha }}
+          DEPLOY_URL: ${{ github.event.deployment_status.environment_url }}
+          LOG_URL: ${{ github.event.deployment_status.target_url }}
+          MESSAGE: ${{ steps.commit.outputs.message }}
+          AUTHOR: ${{ steps.commit.outputs.author }}
+        run: |
+          set -euo pipefail
+          [ -n "$DISCORD_BOT_TOKEN" ] || { echo "::error::DISCORD_BOT_TOKEN secret 이 없습니다"; exit 1; }
+          [ -n "$CHANNEL_ID" ] || { echo "::error::DISCORD_DEPLOY_CHANNEL_ID secret 이 없습니다"; exit 1; }
+
+          # github 로그인 → discord id 멘션. 매핑 없으면 로그인 이름으로 폴백(핑은 안 감)
+          DISCORD_MAP="$DISCORD_USER_MAP"; [ -n "$DISCORD_MAP" ] || DISCORD_MAP='{}'
+          DISCORD_ID=$(echo "$DISCORD_MAP" | jq -r --arg login "$AUTHOR" '.[$login] // empty')
+          AUTHOR_MENTION="${DISCORD_ID:+<@$DISCORD_ID>}"
+          AUTHOR_MENTION="${AUTHOR_MENTION:-$AUTHOR}"
+
+          case "$ENVIRONMENT" in
+            Production*) TARGET="PiKi-Web-Prod" ;;
+            *)           TARGET="PiKi-Web-Dev" ;;
+          esac
+
+          SHORT_SHA="${SHA:0:7}"
+          COMMIT_URL="https://github.com/${{ github.repository }}/commit/$SHA"
+
+          # 서버 배포알림과 동일 포맷. named 링크도 임베드 카드를 만들므로 URL 을 <> 로 감싼다
+          if [ "$STATE" = "success" ]; then
+            TEXT=$(printf '✅ `%s` 배포 성공!\n• 경로: `%s` 브랜치 → %s (%s)\n• 배포자: %s\n• 커밋: [%s](<%s>)  %s' \
+              "$TARGET" "$REF" "$TARGET" "${DEPLOY_URL:-vercel}" "$AUTHOR_MENTION" "$SHORT_SHA" "$COMMIT_URL" "$MESSAGE")
+            case "$ENVIRONMENT" in Production*) TEXT=$(printf '%s\n• [릴리즈 노트](<https://github.com/${{ github.repository }}/releases/latest>)' "$TEXT");; esac
+          else
+            TEXT=$(printf '❌ `%s` 배포 실패\n• 경로: `%s` 브랜치 → %s\n• 배포자: %s\n• 커밋: [%s](<%s>)  %s\n• [배포 로그](<%s>)' \
+              "$TARGET" "$REF" "$TARGET" "$AUTHOR_MENTION" "$SHORT_SHA" "$COMMIT_URL" "$MESSAGE" "$LOG_URL")
+          fi
+
+          HTTP_CODE=$(curl -s --max-time 10 -o resp.json -w '%{http_code}' \
+            -X POST "https://discord.com/api/v10/channels/$CHANNEL_ID/messages" \
+            -H "Authorization: Bot $DISCORD_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$(jq -n --arg content "$TEXT" '{content: $content, allowed_mentions: {parse: ["users"]}}')") || HTTP_CODE="000"
+          [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ] \
+            || { echo "::error::Discord 알림 전송 실패 (HTTP $HTTP_CODE) $(cat resp.json 2>/dev/null)"; exit 1; }

--- a/.github/workflows/web-deploy-notify.yml
+++ b/.github/workflows/web-deploy-notify.yml
@@ -69,14 +69,17 @@ jobs:
               "$TARGET" "$REF" "$TARGET" "${DEPLOY_URL:-vercel}" "$AUTHOR_MENTION" "$SHORT_SHA" "$COMMIT_URL" "$MESSAGE")
             case "$ENVIRONMENT" in Production*) TEXT=$(printf '%s\n• [릴리즈 노트](<https://github.com/${{ github.repository }}/releases/latest>)' "$TEXT");; esac
           else
-            TEXT=$(printf '❌ `%s` 배포 실패\n• 경로: `%s` 브랜치 → %s\n• 배포자: %s\n• 커밋: [%s](<%s>)  %s\n• [배포 로그](<%s>)' \
-              "$TARGET" "$REF" "$TARGET" "$AUTHOR_MENTION" "$SHORT_SHA" "$COMMIT_URL" "$MESSAGE" "$LOG_URL")
+            TEXT=$(printf '❌ `%s` 배포 실패\n• 경로: `%s` 브랜치 → %s\n• 배포자: %s\n• 커밋: [%s](<%s>)  %s' \
+              "$TARGET" "$REF" "$TARGET" "$AUTHOR_MENTION" "$SHORT_SHA" "$COMMIT_URL" "$MESSAGE")
+            # target_url 이 비면 깨진 링크(<>) 가 나가므로 값이 있을 때만 로그 줄을 붙인다
+            [ -n "$LOG_URL" ] && TEXT=$(printf '%s\n• [배포 로그](<%s>)' "$TEXT" "$LOG_URL")
           fi
 
           HTTP_CODE=$(curl -s --max-time 10 -o resp.json -w '%{http_code}' \
             -X POST "https://discord.com/api/v10/channels/$CHANNEL_ID/messages" \
             -H "Authorization: Bot $DISCORD_BOT_TOKEN" \
             -H "Content-Type: application/json; charset=utf-8" \
-            --data "$(jq -n --arg content "$TEXT" '{content: $content, allowed_mentions: {parse: ["users"]}}')") || HTTP_CODE="000"
+            --data "$(jq -n --arg content "$TEXT" --arg did "$DISCORD_ID" \
+              '{content: $content, allowed_mentions: {parse: [], users: (if $did != "" then [$did] else [] end)}}')") || HTTP_CODE="000"
           [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ] \
             || { echo "::error::Discord 알림 전송 실패 (HTTP $HTTP_CODE) $(cat resp.json 2>/dev/null)"; exit 1; }

--- a/.github/workflows/web-promote.yml
+++ b/.github/workflows/web-promote.yml
@@ -1,0 +1,86 @@
+# 웹 승격 — dev HEAD 를 web-v* 로 태깅하고 production 브랜치에 fast-forward 로 반영한 뒤
+# GitHub Release 를 생성한다. 순서가 계약이다: 푸터 버전이 빌드 시 GitHub API 로 최신 web-v* 태그를
+# 읽으므로, production 푸시(→ Vercel 빌드 시작)보다 태그 푸시가 반드시 먼저여야 한다.
+# 실행: Actions → Web Promote → Run workflow (bump 선택 또는 version 직접 입력)
+name: Web Promote
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: '버전 증가 단위'
+        type: choice
+        options:
+          - minor
+          - patch
+          - major
+        default: minor
+      version:
+        description: '버전 직접 지정 (예: 1.11.0) — 입력 시 bump 무시'
+        required: false
+
+permissions: {}
+
+# 승격 동시 실행 방지 — 태그 계산과 ff 푸시 사이의 레이스를 차단한다.
+concurrency:
+  group: web-promote
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # 어느 ref 에서 dispatch 하든 승격 대상은 항상 dev
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: 다음 버전 계산
+        id: version
+        env:
+          BUMP: ${{ inputs.bump }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -n "$VERSION" ]; then
+            [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::버전 형식은 X.Y.Z 여야 합니다: $VERSION"; exit 1; }
+            next="$VERSION"
+          else
+            latest=$(git tag -l 'web-v*' --sort=-v:refname | head -1)
+            [ -n "$latest" ] || { echo "::error::web-v* 태그가 없습니다"; exit 1; }
+            ver=${latest#web-v}
+            IFS=. read -r major minor patch <<< "$ver"
+            case "$BUMP" in
+              major) next="$((major + 1)).0.0" ;;
+              minor) next="${major}.$((minor + 1)).0" ;;
+              patch) next="${major}.${minor}.$((patch + 1))" ;;
+            esac
+          fi
+          echo "tag=web-v${next}" >> "$GITHUB_OUTPUT"
+          echo "승격 버전: web-v${next} ($(git rev-parse --short HEAD))"
+
+      - name: fast-forward 가능 확인
+        run: |
+          set -euo pipefail
+          git fetch origin production
+          git merge-base --is-ancestor origin/production HEAD \
+            || { echo "::error::production 이 dev 의 조상이 아니라 fast-forward 불가 — production 에만 있는 커밋을 먼저 정리하세요"; exit 1; }
+
+      - name: 태그 푸시 → production ff 푸시 (순서 변경 금지)
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git tag "$TAG"
+          git push origin "refs/tags/$TAG"
+          git push origin HEAD:refs/heads/production
+
+      # 직전 web-v* 태그부터의 squash 커밋(=PR 제목)으로 릴리즈 노트 자동 생성
+      - name: GitHub Release 생성
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: gh release create "$TAG" --verify-tag --generate-notes --title "$TAG"

--- a/.github/workflows/web-promote.yml
+++ b/.github/workflows/web-promote.yml
@@ -78,9 +78,16 @@ jobs:
           git push origin "refs/tags/$TAG"
           git push origin HEAD:refs/heads/production
 
-      # 직전 web-v* 태그부터의 squash 커밋(=PR 제목)으로 릴리즈 노트 자동 생성
+      # 직전 web-v* 태그부터의 squash 커밋(=PR 제목)으로 릴리즈 노트 자동 생성.
+      # 첫 줄 "배포일: YYYY-MM-DD(요일)" 은 기존 릴리즈들과의 포맷 통일
       - name: GitHub Release 생성
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
-        run: gh release create "$TAG" --verify-tag --generate-notes --title "$TAG"
+          TZ: Asia/Seoul
+        run: |
+          set -euo pipefail
+          days=(월 화 수 목 금 토 일)
+          wd=${days[$(($(date +%u) - 1))]}
+          gh release create "$TAG" --verify-tag --generate-notes --title "$TAG" \
+            --notes "배포일: $(date +%Y-%m-%d)(${wd})"

--- a/.github/workflows/web-promote.yml
+++ b/.github/workflows/web-promote.yml
@@ -45,12 +45,12 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
+          latest=$(git tag -l 'web-v*' --sort=-v:refname | head -1)
+          [ -n "$latest" ] || { echo "::error::web-v* 태그가 없습니다"; exit 1; }
           if [ -n "$VERSION" ]; then
             [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::버전 형식은 X.Y.Z 여야 합니다: $VERSION"; exit 1; }
             next="$VERSION"
           else
-            latest=$(git tag -l 'web-v*' --sort=-v:refname | head -1)
-            [ -n "$latest" ] || { echo "::error::web-v* 태그가 없습니다"; exit 1; }
             ver=${latest#web-v}
             IFS=. read -r major minor patch <<< "$ver"
             case "$BUMP" in
@@ -60,7 +60,8 @@ jobs:
             esac
           fi
           echo "tag=web-v${next}" >> "$GITHUB_OUTPUT"
-          echo "승격 버전: web-v${next} ($(git rev-parse --short HEAD))"
+          echo "prev=${latest}" >> "$GITHUB_OUTPUT"
+          echo "승격 버전: ${latest} → web-v${next} ($(git rev-parse --short HEAD))"
 
       - name: fast-forward 가능 확인
         run: |
@@ -79,15 +80,18 @@ jobs:
           git push origin HEAD:refs/heads/production
 
       # 직전 web-v* 태그부터의 squash 커밋(=PR 제목)으로 릴리즈 노트 자동 생성.
+      # 시작 태그를 명시해야 한다 — 자동 추론은 "마지막 발행 릴리즈" 기준이라 app-v* 릴리즈가 생기면 어긋난다.
       # 첫 줄 "배포일: YYYY-MM-DD(요일)" 은 기존 릴리즈들과의 포맷 통일
       - name: GitHub Release 생성
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
+          PREV: ${{ steps.version.outputs.prev }}
           TZ: Asia/Seoul
         run: |
           set -euo pipefail
           days=(월 화 수 목 금 토 일)
           wd=${days[$(($(date +%u) - 1))]}
           gh release create "$TAG" --verify-tag --generate-notes --title "$TAG" \
+            --notes-start-tag "$PREV" \
             --notes "배포일: $(date +%Y-%m-%d)(${wd})"


### PR DESCRIPTION
## 작업 내용

수동 2단계(태그 푸시 → production 머지 푸시)로 하던 웹 승격을 워크플로우로 자동화하고, Vercel 배포 결과를 서버(core)와 동일한 포맷으로 Discord에 알립니다.

**`web-promote.yml`** — Actions → Web Promote → Run workflow

- bump(minor/patch/major) 선택 또는 버전 직접 입력 → 최신 `web-v*` 태그에서 다음 버전 계산
- production ⊂ dev 검증(ff 불가 시 명확한 에러로 중단) 후 **태그 푸시 → production ff 푸시** 순서 보장 — 푸터 버전이 빌드 시 최신 태그를 읽으므로 이 순서가 계약
- 직전 태그 구간의 squash PR 제목으로 GitHub Release 자동 생성

**`web-deploy-notify.yml`** — Vercel Git 연동이 만드는 GitHub Deployment의 `deployment_status` 구독

- Production·dev 배포만 알림 (PR Preview 제외), 실패 시 ❌ + 배포 로그 링크
- 허거덩 봇 본인(`DISCORD_BOT_TOKEN` — PR 봇과 공유)이 서버 배포알림과 동일 포맷으로 전송, `DISCORD_USER_MAP`으로 배포자 멘션
- `deployment_status`는 default 브랜치의 워크플로우만 실행하므로 이 PR 머지 후부터 동작

**함께 진행된 사전 작업** (워크플로우 밖, 완료됨)

- production 브랜치를 dev 계보(`862b76d`, 내용 diff 0)로 일회성 재정렬 — 이후 ff 승격 가능
- `DISCORD_DEPLOY_CHANNEL_ID` secret 등록
- 과거 태그 16개(web-v1.0.0–1.10.0) 릴리즈 노트 백필 (본문에 원 배포일 명시)

**머지 후 검증 계획**: 첫 승격(web-v1.11.0)으로 태그·ff·Release·Discord 알림·dev 배포 알림 필터를 실전 확인합니다. dev Preview 알림의 `ref == 'dev'` 필터는 Vercel payload 실측값에 따라 조정될 수 있습니다.

## 스크린샷

## 연관 이슈

closes #614


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 수동 실행으로 개발 버전을 지정된 버전으로 승격하고, 태그와 릴리스를 자동 생성할 수 있습니다.
  - 마이너·패치·메이저 버전 증가 또는 직접 버전 입력을 지원합니다.
  - 배포 성공 및 실패 상태를 Discord 채널에서 확인할 수 있습니다.
  - 배포 커밋 정보와 작성자 식별 정보가 알림에 포함됩니다.

- **오류 처리**
  - 버전 형식이 올바르지 않거나 승격 조건을 충족하지 않으면 작업을 중단하고 오류를 표시합니다.
  - 중복 승격 실행을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->