### PR TITLE
chore: 배포 알림 메시지 포맷 개선

### DIFF
--- a/.github/workflows/web-deploy-notify.yml
+++ b/.github/workflows/web-deploy-notify.yml
@@ -76,8 +76,9 @@ jobs:
           # github 로그인 → discord id 멘션. 매핑 없으면 로그인 이름으로 폴백(핑은 안 감)
           DISCORD_MAP="$DISCORD_USER_MAP"; [ -n "$DISCORD_MAP" ] || DISCORD_MAP='{}'
           DISCORD_ID=$(echo "$DISCORD_MAP" | jq -r --arg login "$AUTHOR" '.[$login] // empty')
+          # 매핑 없으면 이름 텍스트 폴백(핑 없음) — 커밋 author 명은 외부 입력이라 Markdown 특수문자 이스케이프
           AUTHOR_MENTION="${DISCORD_ID:+<@$DISCORD_ID>}"
-          AUTHOR_MENTION="${AUTHOR_MENTION:-$AUTHOR}"
+          AUTHOR_MENTION="${AUTHOR_MENTION:-$(printf '%s' "$AUTHOR" | sed 's/[][\`]/\\&/g')}"
 
           if [ "$BRANCH" = "production" ]; then
             LABEL="[PROD]"; DOMAIN="piki.day"
@@ -85,11 +86,14 @@ jobs:
             LABEL="[DEV]"; DOMAIN="dev.piki.day"
           fi
 
-          # 배포 커밋을 가리키는 web-v* 태그 = 이번에 나간 버전 (승격 배포에서만 잡힌다)
+          # 배포 커밋을 가리키는 web-v* 태그 = 이번에 나간 버전 (승격 배포에서만 잡힌다).
+          # 조회 실패(API 오류·rate limit)는 알림을 막지 않는다 — 버전·릴리즈 줄만 생략.
+          # --paginate 는 페이지별 배열을 내므로 스트림으로 모은 뒤 semver 최신 하나를 고른다
           VERSION=""
           if [ "$BRANCH" = "production" ]; then
             VERSION=$(gh api --paginate "repos/${{ github.repository }}/tags?per_page=100" \
-              | jq -r --arg sha "$SHA" '[.[] | select(.commit.sha == $sha) | .name | select(startswith("web-v"))] | first // empty')
+              | jq -r --arg sha "$SHA" '.[] | select(.commit.sha == $sha) | .name | select(startswith("web-v"))' \
+              | sort -V | tail -1) || VERSION=""
           fi
 
           # prod 는 버전+릴리즈 노트, dev 는 무엇이 머지됐는지(커밋)를 보여준다.
@@ -102,14 +106,15 @@ jobs:
           if [ "$BRANCH" = "production" ]; then
             [ -n "$VERSION" ] && TEXT=$(printf '%s\n• 버전: `%s`' "$TEXT" "$VERSION")
           else
+            # 커밋 제목은 외부 입력 — 링크 라벨 탈출(](url)) 인젝션을 이스케이프로 차단
+            SAFE_MESSAGE=$(printf '%s' "$MESSAGE" | sed 's/[][\`]/\\&/g')
             COMMIT_URL="https://github.com/${{ github.repository }}/commit/$SHA"
-            TEXT=$(printf '%s\n• 커밋: [%s](<%s>)' "$TEXT" "$MESSAGE" "$COMMIT_URL")
+            TEXT=$(printf '%s\n• 커밋: [%s](<%s>)' "$TEXT" "$SAFE_MESSAGE" "$COMMIT_URL")
           fi
           TEXT=$(printf '%s\n• 배포자: %s' "$TEXT" "$AUTHOR_MENTION")
-          if [ "$STATE" = "success" ] && [ "$BRANCH" = "production" ]; then
-            if [ -n "$VERSION" ]; then NOTES_URL="https://github.com/${{ github.repository }}/releases/tag/$VERSION"
-            else NOTES_URL="https://github.com/${{ github.repository }}/releases/latest"; fi
-            TEXT=$(printf '%s\n• [릴리즈 노트](<%s>)' "$TEXT" "$NOTES_URL")
+          # releases/latest 폴백 금지 — 다른 릴리즈(예: app-v*)를 가리킬 수 있어 버전을 아는 경우에만 링크
+          if [ "$STATE" = "success" ] && [ "$BRANCH" = "production" ] && [ -n "$VERSION" ]; then
+            TEXT=$(printf '%s\n• [릴리즈 노트](<https://github.com/${{ github.repository }}/releases/tag/%s>)' "$TEXT" "$VERSION")
           fi
           # target_url 이 비면 깨진 링크(<>) 가 나가므로 값이 있을 때만 로그 줄을 붙인다
           if [ "$STATE" != "success" ] && [ -n "$LOG_URL" ]; then

--- a/.github/workflows/web-deploy-notify.yml
+++ b/.github/workflows/web-deploy-notify.yml
@@ -58,14 +58,13 @@ jobs:
       - name: Discord 전송 (허거덩 봇)
         if: steps.gate.outputs.notify == 'true'
         env:
+          GH_TOKEN: ${{ github.token }}
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           CHANNEL_ID: ${{ secrets.DISCORD_DEPLOY_CHANNEL_ID }}
           DISCORD_USER_MAP: ${{ secrets.DISCORD_USER_MAP }}
           STATE: ${{ github.event.deployment_status.state }}
-          ENVIRONMENT: ${{ github.event.deployment.environment }}
           BRANCH: ${{ steps.gate.outputs.branch }}
           SHA: ${{ github.event.deployment.sha }}
-          DEPLOY_URL: ${{ github.event.deployment_status.environment_url }}
           LOG_URL: ${{ github.event.deployment_status.target_url }}
           MESSAGE: ${{ steps.commit.outputs.message }}
           AUTHOR: ${{ steps.commit.outputs.author }}
@@ -80,24 +79,41 @@ jobs:
           AUTHOR_MENTION="${DISCORD_ID:+<@$DISCORD_ID>}"
           AUTHOR_MENTION="${AUTHOR_MENTION:-$AUTHOR}"
 
-          case "$ENVIRONMENT" in
-            Production*) TARGET="PiKi-Web-Prod" ;;
-            *)           TARGET="PiKi-Web-Dev" ;;
-          esac
-
-          SHORT_SHA="${SHA:0:7}"
-          COMMIT_URL="https://github.com/${{ github.repository }}/commit/$SHA"
-
-          # 서버 배포알림과 동일 포맷. named 링크도 임베드 카드를 만들므로 URL 을 <> 로 감싼다
-          if [ "$STATE" = "success" ]; then
-            TEXT=$(printf '✅ `%s` 배포 성공!\n• 경로: `%s` 브랜치 → %s (%s)\n• 배포자: %s\n• 커밋: [%s](<%s>)  %s' \
-              "$TARGET" "$BRANCH" "$TARGET" "${DEPLOY_URL:-vercel}" "$AUTHOR_MENTION" "$SHORT_SHA" "$COMMIT_URL" "$MESSAGE")
-            case "$ENVIRONMENT" in Production*) TEXT=$(printf '%s\n• [릴리즈 노트](<https://github.com/${{ github.repository }}/releases/latest>)' "$TEXT");; esac
+          if [ "$BRANCH" = "production" ]; then
+            LABEL="[PROD]"; DOMAIN="piki.day"
           else
-            TEXT=$(printf '❌ `%s` 배포 실패\n• 경로: `%s` 브랜치 → %s\n• 배포자: %s\n• 커밋: [%s](<%s>)  %s' \
-              "$TARGET" "$BRANCH" "$TARGET" "$AUTHOR_MENTION" "$SHORT_SHA" "$COMMIT_URL" "$MESSAGE")
-            # target_url 이 비면 깨진 링크(<>) 가 나가므로 값이 있을 때만 로그 줄을 붙인다
-            [ -n "$LOG_URL" ] && TEXT=$(printf '%s\n• [배포 로그](<%s>)' "$TEXT" "$LOG_URL")
+            LABEL="[DEV]"; DOMAIN="dev.piki.day"
+          fi
+
+          # 배포 커밋을 가리키는 web-v* 태그 = 이번에 나간 버전 (승격 배포에서만 잡힌다)
+          VERSION=""
+          if [ "$BRANCH" = "production" ]; then
+            VERSION=$(gh api --paginate "repos/${{ github.repository }}/tags?per_page=100" \
+              | jq -r --arg sha "$SHA" '[.[] | select(.commit.sha == $sha) | .name | select(startswith("web-v"))] | first // empty')
+          fi
+
+          # prod 는 버전+릴리즈 노트, dev 는 무엇이 머지됐는지(커밋)를 보여준다.
+          # named 링크도 임베드 카드를 만들므로 URL 은 <> 로 감싼다
+          if [ "$STATE" = "success" ]; then
+            TEXT=$(printf '✅ %s PiKi WEB 배포 성공! (<https://%s>)' "$LABEL" "$DOMAIN")
+          else
+            TEXT=$(printf '❌ %s PiKi WEB 배포 실패' "$LABEL")
+          fi
+          if [ "$BRANCH" = "production" ]; then
+            [ -n "$VERSION" ] && TEXT=$(printf '%s\n• 버전: `%s`' "$TEXT" "$VERSION")
+          else
+            COMMIT_URL="https://github.com/${{ github.repository }}/commit/$SHA"
+            TEXT=$(printf '%s\n• 커밋: [%s](<%s>)' "$TEXT" "$MESSAGE" "$COMMIT_URL")
+          fi
+          TEXT=$(printf '%s\n• 배포자: %s' "$TEXT" "$AUTHOR_MENTION")
+          if [ "$STATE" = "success" ] && [ "$BRANCH" = "production" ]; then
+            if [ -n "$VERSION" ]; then NOTES_URL="https://github.com/${{ github.repository }}/releases/tag/$VERSION"
+            else NOTES_URL="https://github.com/${{ github.repository }}/releases/latest"; fi
+            TEXT=$(printf '%s\n• [릴리즈 노트](<%s>)' "$TEXT" "$NOTES_URL")
+          fi
+          # target_url 이 비면 깨진 링크(<>) 가 나가므로 값이 있을 때만 로그 줄을 붙인다
+          if [ "$STATE" != "success" ] && [ -n "$LOG_URL" ]; then
+            TEXT=$(printf '%s\n• [배포 로그](<%s>)' "$TEXT" "$LOG_URL")
           fi
 
           HTTP_CODE=$(curl -s --max-time 10 -o resp.json -w '%{http_code}' \


### PR DESCRIPTION
## 작업 내용

배포 알림 메시지 포맷을 팀 피드백대로 개선합니다.

**변경 전 → 후**

- 제목: `✅ PiKi-Web-Dev 배포 성공!` → `✅ [DEV] PiKi WEB 배포 성공! (https://dev.piki.day)`
- 링크는 Vercel 배포 URL 대신 **고정 도메인**(dev.piki.day / piki.day), `<>`로 감싸 미리보기 카드 억제 — 기존에 경로 줄의 Vercel URL만 `<>` 없이 나가서 카드가 뜨던 문제도 함께 해소
- 항상 동일하던 경로 줄(`dev 브랜치 → ...`) 제거
- **prod**: 커밋 대신 `버전` 표시 (배포 커밋을 가리키는 `web-v*` 태그 조회) + 릴리즈 노트를 해당 버전 태그로 직링크
- **dev**: 무엇이 머지됐는지 보이도록 `커밋` 줄 유지 (squash PR 제목, 커밋 링크)

**메시지 예시**

```
✅ [PROD] PiKi WEB 배포 성공! (https://piki.day)
• 버전: web-v1.11.0
• 배포자: @xxx
• 릴리즈 노트 (버전 직링크)

✅ [DEV] PiKi WEB 배포 성공! (https://dev.piki.day)
• 커밋: feat: 홈 툴팁 A/B 테스트 추가 (#617)
• 배포자: @xxx
```

버전 조회 jq는 실제 태그 데이터(`862b76d` → `web-v1.10.0`)로 검증했습니다.

## 스크린샷

## 연관 이슈

#614


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 배포 알림에 환경별 레이블과 도메인 정보가 표시됩니다.
  * Production 배포 성공 시 버전, 릴리즈 노트 및 링크가 제공됩니다.
  * Dev 배포 알림에 커밋 메시지와 커밋 링크가 포함됩니다.
  * 배포 실패 시 배포 로그 링크가 추가됩니다.
  * 배포 성공 및 실패 알림 형식이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->