### PR TITLE
chore: iOS 앱 배포 진행 스레드 알림 도입 (EAS·ASC 웹훅 수신기)

### DIFF
--- a/.github/workflows/web-deploy-notify.yml
+++ b/.github/workflows/web-deploy-notify.yml
@@ -81,9 +81,9 @@ jobs:
           AUTHOR_MENTION="${AUTHOR_MENTION:-$(printf '%s' "$AUTHOR" | sed 's/[][\`]/\\&/g')}"
 
           if [ "$BRANCH" = "production" ]; then
-            LABEL="[PROD]"; DOMAIN="piki.day"
+            LABEL="[WEB·PROD]"; DOMAIN="piki.day"
           else
-            LABEL="[DEV]"; DOMAIN="dev.piki.day"
+            LABEL="[WEB·DEV]"; DOMAIN="dev.piki.day"
           fi
 
           # 배포 커밋을 가리키는 web-v* 태그 = 이번에 나간 버전 (승격 배포에서만 잡힌다).
@@ -99,9 +99,9 @@ jobs:
           # prod 는 버전+릴리즈 노트, dev 는 무엇이 머지됐는지(커밋)를 보여준다.
           # named 링크도 임베드 카드를 만들므로 URL 은 <> 로 감싼다
           if [ "$STATE" = "success" ]; then
-            TEXT=$(printf '✅ %s PiKi WEB 배포 성공! (<https://%s>)' "$LABEL" "$DOMAIN")
+            TEXT=$(printf '✅ %s PiKi 배포 성공! (<https://%s>)' "$LABEL" "$DOMAIN")
           else
-            TEXT=$(printf '❌ %s PiKi WEB 배포 실패' "$LABEL")
+            TEXT=$(printf '❌ %s PiKi 배포 실패' "$LABEL")
           fi
           if [ "$BRANCH" = "production" ]; then
             [ -n "$VERSION" ] && TEXT=$(printf '%s\n• 버전: `%s`' "$TEXT" "$VERSION")

--- a/apps/hooks/README.md
+++ b/apps/hooks/README.md
@@ -1,0 +1,55 @@
+# @piki/hooks
+
+iOS 앱 배포 이벤트(EAS Build·Submit, App Store Connect)를 받아 허거덩 봇으로 Discord에 알리는 웹훅 수신기.
+`apps/web`과 분리된 **별도 Vercel 프로젝트**로 배포한다 — 봇 토큰을 서비스 런타임과 격리하고, 알림 코드가 프로덕트 배포에 묶이지 않게 하기 위함. (#618)
+
+## 동작 방식 — 버전당 스레드 1개
+
+첫 빌드 완료 이벤트가 배포알림 채널에 **루트 상태판**을 올리고 스레드를 연다.
+이후 이벤트는 최근 메시지에서 진행 중(`📦`로 시작) 루트를 찾아 상태판을 수정하고 스레드에 로그를 쌓는다.
+별도 DB 없이 Discord 메시지 자체가 상태 저장소다. 출시·반려 시 제목이 `🎉`/`❌`로 바뀌며 사이클이 닫힌다.
+
+```
+📦 [iOS] PiKi v1.2.0 배포 진행 중          ← 이벤트마다 수정되는 상태판
+• 심사용 (production): 심사 제출 완료
+• 팀 테스트용 (production-dev): TestFlight 업로드 완료 — 처리 대기
+• TestFlight 처리: 2건 완료
+• 심사: 📮 대기 중
+  └ 스레드: 🛠 빌드 완료 → ✅ 제출 완료 → … → 🎉 출시 완료!   ← append-only 로그
+```
+
+## 엔드포인트
+
+| 경로 | 발신자 | 서명 검증 |
+| --- | --- | --- |
+| `POST /api/webhooks/eas-build` | EAS Build (BUILD 이벤트) | `expo-signature` — HMAC-SHA1 |
+| `POST /api/webhooks/eas` | EAS Submit (SUBMIT 이벤트) | `expo-signature` — HMAC-SHA1 |
+| `POST /api/webhooks/asc` | App Store Connect | `x-apple-signature` — HMAC-SHA256 |
+
+## Vercel 프로젝트 설정
+
+1. Vercel에서 **Add New Project** → 이 레포 선택 → Root Directory를 `apps/hooks`로 지정 (Framework: Other)
+2. 환경변수 등록:
+   - `DISCORD_BOT_TOKEN` — 허거덩 봇 토큰 (GitHub Actions secret과 동일 값)
+   - `DISCORD_DEPLOY_CHANNEL_ID` — 배포알림 채널 ID
+   - `EAS_WEBHOOK_SECRET` — 16자 이상 임의 문자열 (아래 EAS 등록 시 같은 값 사용)
+   - `ASC_WEBHOOK_SECRET` — ASC 웹훅 등록 시 입력한 Secret과 같은 값
+   - `EXPO_TOKEN` (선택) — expo.dev Access Token (robot 권장). 있으면 제출 이벤트에서
+     빌드 프로필(심사용/팀 테스트용)·버전을 조회해 상태판에 반영, 없으면 로그만 남는다
+
+봇에게 배포알림 채널의 **View Channel / Send Messages / Read Message History /
+Create Public Threads / Send Messages in Threads** 권한이 필요하다 (루트 검색·스레드 기록).
+
+## 웹훅 등록
+
+**EAS** (레포의 `apps/app`에서 실행, 시크릿은 둘 다 같은 값):
+
+```sh
+eas webhook:create --event BUILD --url https://<hooks-domain>/api/webhooks/eas-build --secret <EAS_WEBHOOK_SECRET>
+eas webhook:create --event SUBMIT --url https://<hooks-domain>/api/webhooks/eas --secret <EAS_WEBHOOK_SECRET>
+```
+
+**App Store Connect** (계정 Admin):
+App Store Connect → Users and Access → Integrations → Webhooks → `+`
+URL에 `https://<hooks-domain>/api/webhooks/asc`, Secret에 `ASC_WEBHOOK_SECRET` 값 입력 후
+이벤트로 **Build upload state changes**, **App version state changes** 선택.

--- a/apps/hooks/README.md
+++ b/apps/hooks/README.md
@@ -18,38 +18,31 @@ iOS 앱 배포 이벤트(EAS Build·Submit, App Store Connect)를 받아 허거�
   └ 스레드: 🛠 빌드 완료 → ✅ 제출 완료 → … → 🎉 출시 완료!   ← append-only 로그
 ```
 
+- **심사 표시는 대기·통과·출시·반려만** — 수동/자동 출시 구분은 통과 후 전이 상태로 드러난다
+- **TestFlight 처리는 건수 집계** — ASC 페이로드에 빌드 식별 정보가 없어 어느 빌드인지 알 수 없다
+- **무시 케이스** — 제출 취소·미매핑 상태·테스트 ping·미구독 이벤트는 200으로 조용히 응답 (재시도 유발 금지)
+
 ## 엔드포인트
 
-| 경로 | 발신자 | 서명 검증 |
-| --- | --- | --- |
-| `POST /api/webhooks/eas-build` | EAS Build (BUILD 이벤트) | `expo-signature` — HMAC-SHA1 |
-| `POST /api/webhooks/eas` | EAS Submit (SUBMIT 이벤트) | `expo-signature` — HMAC-SHA1 |
-| `POST /api/webhooks/asc` | App Store Connect | `x-apple-signature` — HMAC-SHA256 |
+| 경로 | 발신자 | 서명 검증 | 역할 |
+| --- | --- | --- | --- |
+| `POST /api/webhooks/eas-build` | EAS Build (BUILD 이벤트) | `expo-signature` — HMAC-SHA1 | 빌드 완료가 사이클(스레드)을 연다 |
+| `POST /api/webhooks/eas` | EAS Submit (SUBMIT 이벤트) | `expo-signature` — HMAC-SHA1 | 심사 제출·TestFlight 업로드 기록 |
+| `POST /api/webhooks/asc` | App Store Connect | `x-apple-signature` — HMAC-SHA256 | TestFlight 빌드 처리·심사 상태 전이 기록 |
 
-## Vercel 프로젝트 설정
+## 런타임 요구사항
 
-1. Vercel에서 **Add New Project** → 이 레포 선택 → Root Directory를 `apps/hooks`로 지정 (Framework: Other)
-2. 환경변수 등록:
-   - `DISCORD_BOT_TOKEN` — 허거덩 봇 토큰 (GitHub Actions secret과 동일 값)
-   - `DISCORD_DEPLOY_CHANNEL_ID` — 배포알림 채널 ID
-   - `EAS_WEBHOOK_SECRET` — 16자 이상 임의 문자열 (아래 EAS 등록 시 같은 값 사용)
-   - `ASC_WEBHOOK_SECRET` — ASC 웹훅 등록 시 입력한 Secret과 같은 값
-   - `EXPO_TOKEN` (선택) — expo.dev Access Token (robot 권장). 있으면 제출 이벤트에서
-     빌드 프로필(심사용/팀 테스트용)·버전을 조회해 상태판에 반영, 없으면 로그만 남는다
+환경변수:
+
+| 변수 | 용도 |
+| --- | --- |
+| `DISCORD_BOT_TOKEN` | 허거덩 봇 토큰 (GitHub Actions secret과 동일 값) |
+| `DISCORD_DEPLOY_CHANNEL_ID` | 배포알림 채널 ID |
+| `EAS_WEBHOOK_SECRET` | EAS 웹훅 서명 검증 키 (`eas webhook:create`에 넣은 값) |
+| `ASC_WEBHOOK_SECRET` | ASC 웹훅 서명 검증 키 (ASC 웹훅 등록 시 입력한 Secret) |
+| `EXPO_TOKEN` (선택) | EAS API로 빌드 프로필(심사용/팀 테스트용)·버전 조회. 없으면 해당 줄만 생략 |
 
 봇에게 배포알림 채널의 **View Channel / Send Messages / Read Message History /
 Create Public Threads / Send Messages in Threads** 권한이 필요하다 (루트 검색·스레드 기록).
 
-## 웹훅 등록
-
-**EAS** (레포의 `apps/app`에서 실행, 시크릿은 둘 다 같은 값):
-
-```sh
-eas webhook:create --event BUILD --url https://<hooks-domain>/api/webhooks/eas-build --secret <EAS_WEBHOOK_SECRET>
-eas webhook:create --event SUBMIT --url https://<hooks-domain>/api/webhooks/eas --secret <EAS_WEBHOOK_SECRET>
-```
-
-**App Store Connect** (계정 Admin):
-App Store Connect → Users and Access → Integrations → Webhooks → `+`
-URL에 `https://<hooks-domain>/api/webhooks/asc`, Secret에 `ASC_WEBHOOK_SECRET` 값 입력 후
-이벤트로 **Build upload state changes**, **App version state changes** 선택.
+웹훅·Vercel 프로젝트 등록 등 1회성 셋업 진행 상황은 #618 체크리스트에서 관리한다.

--- a/apps/hooks/api/webhooks/asc.ts
+++ b/apps/hooks/api/webhooks/asc.ts
@@ -1,0 +1,109 @@
+import { updateReleaseThread } from '../../lib/release';
+import { verifySignature } from '../../lib/verify';
+
+type AscWebhookPayloadT = {
+  data?: {
+    type?: string;
+    attributes?: {
+      oldState?: string;
+      newState?: string;
+      oldValue?: string;
+      newValue?: string;
+    };
+  };
+};
+
+type VersionStateT = {
+  status: string;
+  log: string;
+  final?: { emoji: string; text: string };
+};
+
+/** 심사 대기·통과·출시·반려만 기록 — 수동/자동 출시는 통과 후 전이로 드러난다 */
+const VERSION_STATE: Record<string, VersionStateT> = {
+  WAITING_FOR_REVIEW: { status: '📮 대기 중', log: '📮 심사 대기 중' },
+  ACCEPTED: { status: '✅ 통과', log: '✅ 심사 통과' },
+  PENDING_DEVELOPER_RELEASE: {
+    status: '✅ 통과 — 수동 출시 대기',
+    log: '✅ 심사 통과 — 수동 출시 대기',
+  },
+  PROCESSING_FOR_DISTRIBUTION: { status: '🚚 출시 처리 중', log: '🚚 출시 처리 중 (자동 출시)' },
+  READY_FOR_DISTRIBUTION: {
+    status: '🎉 출시 완료',
+    log: '🎉 출시 완료!',
+    final: { emoji: '🎉', text: '출시 완료!' },
+  },
+  READY_FOR_SALE: {
+    status: '🎉 출시 완료',
+    log: '🎉 출시 완료!',
+    final: { emoji: '🎉', text: '출시 완료!' },
+  },
+  REJECTED: { status: '❌ 반려', log: '❌ 심사 반려', final: { emoji: '❌', text: '심사 반려' } },
+  METADATA_REJECTED: {
+    status: '❌ 반려 (메타데이터)',
+    log: '❌ 심사 반려 (메타데이터)',
+    final: { emoji: '❌', text: '심사 반려' },
+  },
+};
+
+/** App Store Connect 웹훅 — TestFlight 빌드 처리·심사 상태 전이를 배포 스레드에 기록 */
+export async function POST(request: Request) {
+  const secret = process.env.ASC_WEBHOOK_SECRET;
+  if (!secret) {
+    console.error('ASC_WEBHOOK_SECRET 환경변수가 없습니다');
+    return Response.json({ error: 'server misconfigured' }, { status: 500 });
+  }
+
+  const rawBody = await request.text();
+  if (!verifySignature(rawBody, request.headers.get('x-apple-signature'), secret, 'sha256')) {
+    return Response.json({ error: 'invalid signature' }, { status: 401 });
+  }
+
+  let payload: AscWebhookPayloadT;
+  try {
+    payload = JSON.parse(rawBody) as AscWebhookPayloadT;
+  } catch {
+    return Response.json({ error: 'invalid json' }, { status: 400 });
+  }
+
+  const eventType = payload.data?.type ?? '';
+  const attributes = payload.data?.attributes ?? {};
+  /** 이벤트별로 attributes 키가 다르다 (build: newState, version: newValue) */
+  const newState = attributes.newState ?? attributes.newValue ?? '';
+  const oldState = attributes.oldState ?? attributes.oldValue ?? '';
+
+  let update: Parameters<typeof updateReleaseThread>[0] | null = null;
+  if (eventType === 'buildUploadStateUpdated') {
+    if (newState === 'COMPLETE') {
+      update = {
+        log: '✅ TestFlight 빌드 처리 완료 — 테스트 배포 가능',
+        /** ASC 페이로드로는 어느 빌드인지 알 수 없어 건수로 집계한다 */
+        line: { key: 'TestFlight 처리', value: prev => `${(parseInt(prev ?? '', 10) || 0) + 1}건 완료` },
+      };
+    } else if (newState === 'FAILED') {
+      update = { log: '❌ TestFlight 빌드 처리 실패' };
+    }
+  } else if (eventType === 'appStoreVersionAppVersionStateUpdated') {
+    const state = VERSION_STATE[newState];
+    if (state) {
+      update = {
+        log: oldState ? `${state.log}\n• 상태: \`${oldState}\` → \`${newState}\`` : state.log,
+        line: { key: '심사', value: state.status },
+        final: state.final,
+      };
+    }
+  }
+
+  /** ping·미구독 이벤트·매핑 없는 상태는 200 으로 무시 (재시도 유발 금지) */
+  if (!update) {
+    return Response.json({ ok: true, skipped: `${eventType}:${newState}` });
+  }
+
+  try {
+    await updateReleaseThread(update);
+  } catch (error) {
+    console.error(error);
+    return Response.json({ error: 'discord update failed' }, { status: 502 });
+  }
+  return Response.json({ ok: true });
+}

--- a/apps/hooks/api/webhooks/eas-build.ts
+++ b/apps/hooks/api/webhooks/eas-build.ts
@@ -1,0 +1,72 @@
+import { escapeMarkdown } from '../../lib/discord';
+import { PROFILE_LABEL, updateReleaseThread } from '../../lib/release';
+import { verifySignature } from '../../lib/verify';
+
+type EasBuildPayloadT = {
+  platform?: 'ios' | 'android';
+  status?: 'finished' | 'errored' | 'canceled';
+  buildDetailsPageUrl?: string;
+  metadata?: {
+    appVersion?: string | null;
+    appBuildVersion?: string | null;
+    buildProfile?: string | null;
+  } | null;
+  error?: { message?: string; errorCode?: string } | null;
+};
+
+/** EAS Build 웹훅 (eas webhook:create --event BUILD) — 빌드 완료가 배포 사이클(스레드)을 연다 */
+export async function POST(request: Request) {
+  const secret = process.env.EAS_WEBHOOK_SECRET;
+  if (!secret) {
+    console.error('EAS_WEBHOOK_SECRET 환경변수가 없습니다');
+    return Response.json({ error: 'server misconfigured' }, { status: 500 });
+  }
+
+  const rawBody = await request.text();
+  if (!verifySignature(rawBody, request.headers.get('expo-signature'), secret, 'sha1')) {
+    return Response.json({ error: 'invalid signature' }, { status: 401 });
+  }
+
+  let payload: EasBuildPayloadT;
+  try {
+    payload = JSON.parse(rawBody) as EasBuildPayloadT;
+  } catch {
+    return Response.json({ error: 'invalid json' }, { status: 400 });
+  }
+
+  /** iOS 스토어 파이프라인 외(안드로이드·취소·개발 빌드)는 스레드 대상이 아니다 */
+  const profile = payload.metadata?.buildProfile ?? '';
+  if (payload.platform !== 'ios' || !PROFILE_LABEL[profile] || payload.status === 'canceled') {
+    return Response.json({ ok: true, skipped: `${payload.platform}:${profile}:${payload.status}` });
+  }
+
+  const label = PROFILE_LABEL[profile];
+  const version = payload.metadata?.appVersion ?? null;
+  const versionText = version
+    ? ` v${version}${payload.metadata?.appBuildVersion ? ` (${payload.metadata.appBuildVersion})` : ''}`
+    : '';
+
+  const logLines: string[] = [];
+  let lineValue: string;
+  if (payload.status === 'finished') {
+    lineValue = '빌드 완료';
+    logLines.push(`🛠 ${label}${versionText} 빌드 완료`);
+  } else {
+    lineValue = '빌드 실패';
+    logLines.push(`❌ ${label}${versionText} 빌드 실패`);
+    if (payload.error?.message) logLines.push(`• 원인: ${escapeMarkdown(payload.error.message)}`);
+  }
+  if (payload.buildDetailsPageUrl) logLines.push(`• [빌드 상세](<${payload.buildDetailsPageUrl}>)`);
+
+  try {
+    await updateReleaseThread({
+      log: logLines.join('\n'),
+      line: { key: label, value: lineValue },
+      version,
+    });
+  } catch (error) {
+    console.error(error);
+    return Response.json({ error: 'discord update failed' }, { status: 502 });
+  }
+  return Response.json({ ok: true });
+}

--- a/apps/hooks/api/webhooks/eas.ts
+++ b/apps/hooks/api/webhooks/eas.ts
@@ -1,0 +1,87 @@
+import { escapeMarkdown, sendDiscordMessage } from '../../lib/discord';
+import { getEasBuildInfo } from '../../lib/eas';
+import type { ReleaseUpdateT } from '../../lib/release';
+import { PROFILE_LABEL, updateReleaseThread } from '../../lib/release';
+import { verifySignature } from '../../lib/verify';
+
+type EasSubmitPayloadT = {
+  platform?: 'ios' | 'android';
+  status?: 'finished' | 'errored' | 'canceled';
+  turtleBuildId?: string | null;
+  submissionDetailsPageUrl?: string;
+  submissionInfo?: {
+    error?: { message?: string; errorCode?: string };
+    logsUrl?: string;
+  } | null;
+};
+
+/** EAS Submit 웹훅 (eas webhook:create --event SUBMIT) — 배포 스레드에 제출 결과를 기록 */
+export async function POST(request: Request) {
+  const secret = process.env.EAS_WEBHOOK_SECRET;
+  if (!secret) {
+    console.error('EAS_WEBHOOK_SECRET 환경변수가 없습니다');
+    return Response.json({ error: 'server misconfigured' }, { status: 500 });
+  }
+
+  const rawBody = await request.text();
+  if (!verifySignature(rawBody, request.headers.get('expo-signature'), secret, 'sha1')) {
+    return Response.json({ error: 'invalid signature' }, { status: 401 });
+  }
+
+  let payload: EasSubmitPayloadT;
+  try {
+    payload = JSON.parse(rawBody) as EasSubmitPayloadT;
+  } catch {
+    return Response.json({ error: 'invalid json' }, { status: 400 });
+  }
+
+  if (payload.status !== 'finished' && payload.status !== 'errored') {
+    return Response.json({ ok: true, skipped: payload.status ?? 'unknown' });
+  }
+
+  const buildInfo = payload.turtleBuildId ? await getEasBuildInfo(payload.turtleBuildId) : null;
+  const profile = buildInfo?.buildProfile ?? '';
+  const label = PROFILE_LABEL[profile] ?? '제출';
+  const versionText = buildInfo?.appVersion
+    ? ` v${buildInfo.appVersion}${buildInfo.appBuildVersion ? ` (${buildInfo.appBuildVersion})` : ''}`
+    : '';
+
+  const logLines: string[] = [];
+  let lineValue: string;
+  if (payload.status === 'finished') {
+    lineValue = profile === 'production' ? '심사 제출 완료' : 'TestFlight 업로드 완료 — 처리 대기';
+    logLines.push(
+      profile === 'production'
+        ? `✅ ${label}${versionText} 심사 제출 완료`
+        : `✅ ${label}${versionText} TestFlight 업로드 완료`
+    );
+  } else {
+    lineValue = '제출 실패';
+    logLines.push(`❌ ${label}${versionText} 스토어 제출 실패`);
+    const errorMessage = payload.submissionInfo?.error?.message;
+    if (errorMessage) logLines.push(`• 원인: ${escapeMarkdown(errorMessage)}`);
+  }
+  if (payload.submissionDetailsPageUrl) {
+    logLines.push(`• [제출 상세](<${payload.submissionDetailsPageUrl}>)`);
+  }
+  if (payload.status === 'errored' && payload.submissionInfo?.logsUrl) {
+    logLines.push(`• [제출 로그](<${payload.submissionInfo.logsUrl}>)`);
+  }
+  const log = logLines.join('\n');
+
+  try {
+    if (payload.platform === 'ios') {
+      const update: ReleaseUpdateT = { log, version: buildInfo?.appVersion ?? null };
+      /** 프로필을 모르면(EXPO_TOKEN 없음 등) 상태판 줄은 건드리지 않고 로그만 남긴다 */
+      if (PROFILE_LABEL[profile]) update.line = { key: label, value: lineValue };
+      await updateReleaseThread(update);
+    } else {
+      /** Android 는 스레드 사이클 밖 — 단건 알림으로 전송 */
+      await sendDiscordMessage(`[AND] PiKi ${log}`);
+    }
+  } catch (error) {
+    console.error(error);
+    return Response.json({ error: 'discord update failed' }, { status: 502 });
+  }
+  return Response.json({ ok: true });
+}

--- a/apps/hooks/eslint.config.mjs
+++ b/apps/hooks/eslint.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from 'eslint/config';
+
+import baseConfig from '../../eslint.config.mjs';
+
+export default defineConfig([...baseConfig]);

--- a/apps/hooks/lib/discord.ts
+++ b/apps/hooks/lib/discord.ts
@@ -1,0 +1,78 @@
+export type DiscordMessageT = { id: string; content: string; timestamp: string };
+
+const API_BASE = 'https://discord.com/api/v10';
+
+const discordRequest = async (path: string, init?: RequestInit) => {
+  const token = process.env.DISCORD_BOT_TOKEN;
+  if (!token) throw new Error('DISCORD_BOT_TOKEN 환경변수가 없습니다');
+
+  const response = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bot ${token}`,
+      'Content-Type': 'application/json; charset=utf-8',
+      ...init?.headers,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Discord API 실패 (${init?.method ?? 'GET'} ${path} → HTTP ${response.status}) ${await response.text()}`
+    );
+  }
+  return response;
+};
+
+const requireChannelId = () => {
+  const channelId = process.env.DISCORD_DEPLOY_CHANNEL_ID;
+  if (!channelId) throw new Error('DISCORD_DEPLOY_CHANNEL_ID 환경변수가 없습니다');
+  return channelId;
+};
+
+/** 외부 텍스트가 섞여도 멘션이 울리지 않도록 파싱 차단 */
+const messageBody = (content: string) => JSON.stringify({ content, allowed_mentions: { parse: [] } });
+
+export const sendDiscordMessage = async (content: string) => {
+  await discordRequest(`/channels/${requireChannelId()}/messages`, {
+    method: 'POST',
+    body: messageBody(content),
+  });
+};
+
+export const listRecentMessages = async (): Promise<DiscordMessageT[]> => {
+  const response = await discordRequest(`/channels/${requireChannelId()}/messages?limit=50`);
+  return (await response.json()) as DiscordMessageT[];
+};
+
+export const postChannelMessage = async (content: string): Promise<DiscordMessageT> => {
+  const response = await discordRequest(`/channels/${requireChannelId()}/messages`, {
+    method: 'POST',
+    body: messageBody(content),
+  });
+  return (await response.json()) as DiscordMessageT;
+};
+
+export const editChannelMessage = async (messageId: string, content: string) => {
+  await discordRequest(`/channels/${requireChannelId()}/messages/${messageId}`, {
+    method: 'PATCH',
+    body: messageBody(content),
+  });
+};
+
+/** 메시지에서 스레드 생성 (스레드 id == 메시지 id) — 이미 있으면 400이 오므로 무시 */
+export const ensureThreadOnMessage = async (messageId: string, name: string) => {
+  try {
+    await discordRequest(`/channels/${requireChannelId()}/messages/${messageId}/threads`, {
+      method: 'POST',
+      body: JSON.stringify({ name, auto_archive_duration: 10080 }),
+    });
+  } catch {
+    /* 스레드가 이미 존재 */
+  }
+};
+
+export const postThreadMessage = async (threadId: string, content: string) => {
+  await discordRequest(`/channels/${threadId}/messages`, { method: 'POST', body: messageBody(content) });
+};
+
+/** 링크 라벨 인젝션(](url)) 차단용 Markdown 특수문자 이스케이프 */
+export const escapeMarkdown = (text: string) => text.replace(/[[\]`\\]/g, '\\$&');

--- a/apps/hooks/lib/discord.ts
+++ b/apps/hooks/lib/discord.ts
@@ -1,6 +1,16 @@
 export type DiscordMessageT = { id: string; content: string; timestamp: string };
 
 const API_BASE = 'https://discord.com/api/v10';
+const REQUEST_TIMEOUT_MS = 10_000;
+
+export class DiscordApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message);
+  }
+}
 
 const discordRequest = async (path: string, init?: RequestInit) => {
   const token = process.env.DISCORD_BOT_TOKEN;
@@ -8,6 +18,7 @@ const discordRequest = async (path: string, init?: RequestInit) => {
 
   const response = await fetch(`${API_BASE}${path}`, {
     ...init,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     headers: {
       Authorization: `Bot ${token}`,
       'Content-Type': 'application/json; charset=utf-8',
@@ -15,8 +26,9 @@ const discordRequest = async (path: string, init?: RequestInit) => {
     },
   });
   if (!response.ok) {
-    throw new Error(
-      `Discord API 실패 (${init?.method ?? 'GET'} ${path} → HTTP ${response.status}) ${await response.text()}`
+    throw new DiscordApiError(
+      `Discord API 실패 (${init?.method ?? 'GET'} ${path} → HTTP ${response.status}) ${await response.text()}`,
+      response.status
     );
   }
   return response;
@@ -58,15 +70,16 @@ export const editChannelMessage = async (messageId: string, content: string) => 
   });
 };
 
-/** 메시지에서 스레드 생성 (스레드 id == 메시지 id) — 이미 있으면 400이 오므로 무시 */
+/** 메시지에서 스레드 생성 (스레드 id == 메시지 id) — "이미 존재"(400)만 무시, 그 외는 전파 */
 export const ensureThreadOnMessage = async (messageId: string, name: string) => {
   try {
     await discordRequest(`/channels/${requireChannelId()}/messages/${messageId}/threads`, {
       method: 'POST',
       body: JSON.stringify({ name, auto_archive_duration: 10080 }),
     });
-  } catch {
-    /* 스레드가 이미 존재 */
+  } catch (error) {
+    if (error instanceof DiscordApiError && error.status === 400) return;
+    throw error;
   }
 };
 

--- a/apps/hooks/lib/eas.ts
+++ b/apps/hooks/lib/eas.ts
@@ -12,6 +12,7 @@ export const getEasBuildInfo = async (buildId: string): Promise<EasBuildInfoT | 
   try {
     const response = await fetch('https://api.expo.dev/graphql', {
       method: 'POST',
+      signal: AbortSignal.timeout(10_000),
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',

--- a/apps/hooks/lib/eas.ts
+++ b/apps/hooks/lib/eas.ts
@@ -1,0 +1,35 @@
+export type EasBuildInfoT = {
+  buildProfile?: string | null;
+  appVersion?: string | null;
+  appBuildVersion?: string | null;
+};
+
+/** EAS GraphQL로 빌드 프로필·버전 조회 — 토큰 없음·조회 실패 시 null (알림 자체는 계속) */
+export const getEasBuildInfo = async (buildId: string): Promise<EasBuildInfoT | null> => {
+  const token = process.env.EXPO_TOKEN;
+  if (!token) return null;
+
+  try {
+    const response = await fetch('https://api.expo.dev/graphql', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query:
+          'query Build($buildId: ID!) { builds { byId(buildId: $buildId) { buildProfile appVersion appBuildVersion } } }',
+        variables: { buildId },
+      }),
+    });
+    if (!response.ok) return null;
+
+    const result = (await response.json()) as {
+      data?: { builds?: { byId?: EasBuildInfoT | null } };
+    };
+    return result.data?.builds?.byId ?? null;
+  } catch (error) {
+    console.error('EAS 빌드 조회 실패:', error);
+    return null;
+  }
+};

--- a/apps/hooks/lib/release.ts
+++ b/apps/hooks/lib/release.ts
@@ -33,10 +33,10 @@ export const updateReleaseThread = async (update: ReleaseUpdateT) => {
   let root = (await listRecentMessages()).find(message => {
     if (!message.content.startsWith(OPEN_PREFIX)) return false;
     if (Date.now() - Date.parse(message.timestamp) >= MAX_AGE_MS) return false;
-    /** 버전을 아는 이벤트는 다른 버전의 열린 루트에 붙지 않는다 (ASC 이벤트는 버전이 없어 최신 열린 루트) */
+    /** 버전을 아는 이벤트는 같은 버전 루트에만 붙는다 (ASC 이벤트는 버전이 없어 최신 열린 루트) */
     if (update.version) {
       const rootVersion = / v([\d.]+)/.exec(message.content.split('\n')[0] ?? '')?.[1];
-      if (rootVersion && rootVersion !== update.version) return false;
+      if (rootVersion !== update.version) return false;
     }
     return true;
   });
@@ -47,9 +47,6 @@ export const updateReleaseThread = async (update: ReleaseUpdateT) => {
 
   const [title = '', ...lines] = root.content.split('\n');
   let nextTitle = title;
-  if (update.version && !/ v\d/.test(nextTitle)) {
-    nextTitle = nextTitle.replace('PiKi', `PiKi v${update.version}`);
-  }
   if (update.final) {
     const version = / v[\d.]+/.exec(nextTitle)?.[0] ?? '';
     nextTitle = `${update.final.emoji} [iOS] PiKi${version} ${update.final.text}`;

--- a/apps/hooks/lib/release.ts
+++ b/apps/hooks/lib/release.ts
@@ -30,10 +30,16 @@ export type ReleaseUpdateT = {
 export const updateReleaseThread = async (update: ReleaseUpdateT) => {
   const versionSuffix = update.version ? ` v${update.version}` : '';
 
-  let root = (await listRecentMessages()).find(
-    message =>
-      message.content.startsWith(OPEN_PREFIX) && Date.now() - Date.parse(message.timestamp) < MAX_AGE_MS
-  );
+  let root = (await listRecentMessages()).find(message => {
+    if (!message.content.startsWith(OPEN_PREFIX)) return false;
+    if (Date.now() - Date.parse(message.timestamp) >= MAX_AGE_MS) return false;
+    /** 버전을 아는 이벤트는 다른 버전의 열린 루트에 붙지 않는다 (ASC 이벤트는 버전이 없어 최신 열린 루트) */
+    if (update.version) {
+      const rootVersion = / v([\d.]+)/.exec(message.content.split('\n')[0] ?? '')?.[1];
+      if (rootVersion && rootVersion !== update.version) return false;
+    }
+    return true;
+  });
   if (!root) {
     root = await postChannelMessage(`${OPEN_PREFIX}${versionSuffix} 배포 진행 중`);
   }

--- a/apps/hooks/lib/release.ts
+++ b/apps/hooks/lib/release.ts
@@ -1,0 +1,64 @@
+import {
+  editChannelMessage,
+  ensureThreadOnMessage,
+  listRecentMessages,
+  postChannelMessage,
+  postThreadMessage,
+} from './discord';
+
+/** 진행 중 사이클 판별 마커 — 출시/반려 시 제목이 🎉/❌로 바뀌며 다음 사이클과 분리된다 */
+const OPEN_PREFIX = '📦 [iOS] PiKi';
+const MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+
+export const PROFILE_LABEL: Record<string, string> = {
+  production: '심사용 (production)',
+  'production-dev': '팀 테스트용 (production-dev)',
+};
+
+export type ReleaseUpdateT = {
+  /** 스레드에 남길 로그 */
+  log: string;
+  /** 루트 상태판에서 갱신할 줄 — 함수면 기존 값 기반으로 계산 (카운터 등) */
+  line?: { key: string; value: string | ((prev: string | null) => string) };
+  /** 알게 된 시점에 제목·스레드명에 1회 채워지는 버전 */
+  version?: string | null;
+  /** 사이클 종료 (출시·반려) 시 제목 교체 */
+  final?: { emoji: string; text: string };
+};
+
+/** 진행 중 루트 상태판을 찾아(없으면 새로 열어) 갱신하고 스레드에 로그를 남긴다 */
+export const updateReleaseThread = async (update: ReleaseUpdateT) => {
+  const versionSuffix = update.version ? ` v${update.version}` : '';
+
+  let root = (await listRecentMessages()).find(
+    message =>
+      message.content.startsWith(OPEN_PREFIX) && Date.now() - Date.parse(message.timestamp) < MAX_AGE_MS
+  );
+  if (!root) {
+    root = await postChannelMessage(`${OPEN_PREFIX}${versionSuffix} 배포 진행 중`);
+  }
+  await ensureThreadOnMessage(root.id, `iOS${versionSuffix} 배포`);
+
+  const [title = '', ...lines] = root.content.split('\n');
+  let nextTitle = title;
+  if (update.version && !/ v\d/.test(nextTitle)) {
+    nextTitle = nextTitle.replace('PiKi', `PiKi v${update.version}`);
+  }
+  if (update.final) {
+    const version = / v[\d.]+/.exec(nextTitle)?.[0] ?? '';
+    nextTitle = `${update.final.emoji} [iOS] PiKi${version} ${update.final.text}`;
+  }
+
+  if (update.line) {
+    const prefix = `• ${update.line.key}:`;
+    const index = lines.findIndex(line => line.startsWith(prefix));
+    const prev = index >= 0 ? (lines[index]?.slice(prefix.length).trim() ?? null) : null;
+    const value = typeof update.line.value === 'function' ? update.line.value(prev) : update.line.value;
+    const nextLine = `${prefix} ${value}`;
+    if (index >= 0) lines[index] = nextLine;
+    else lines.push(nextLine);
+  }
+
+  await editChannelMessage(root.id, [nextTitle, ...lines].join('\n'));
+  await postThreadMessage(root.id, update.log);
+};

--- a/apps/hooks/lib/verify.ts
+++ b/apps/hooks/lib/verify.ts
@@ -1,0 +1,18 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/** raw body 의 HMAC hex digest 를 서명 헤더와 상수 시간 비교 ("sha1=", "hmacsha256=" prefix 허용) */
+export const verifySignature = (
+  rawBody: string,
+  signatureHeader: string | null,
+  secret: string,
+  algorithm: 'sha1' | 'sha256'
+) => {
+  if (!signatureHeader) return false;
+
+  const received = signatureHeader.split('=').pop() ?? '';
+  const expected = createHmac(algorithm, secret).update(rawBody).digest('hex');
+
+  const receivedBuffer = Buffer.from(received, 'utf8');
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  return receivedBuffer.length === expectedBuffer.length && timingSafeEqual(receivedBuffer, expectedBuffer);
+};

--- a/apps/hooks/package.json
+++ b/apps/hooks/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@piki/hooks",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "eslint",
+    "check-types": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@piki/typescript-config": "workspace:*",
+    "@types/node": "^22.15.3",
+    "typescript": "5.9.2"
+  }
+}

--- a/apps/hooks/tsconfig.json
+++ b/apps/hooks/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@piki/typescript-config/base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["api/**/*.ts", "lib/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/hooks/turbo.json
+++ b/apps/hooks/turbo.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "check-types": {
+      "env": [
+        "DISCORD_BOT_TOKEN",
+        "DISCORD_DEPLOY_CHANNEL_ID",
+        "EAS_WEBHOOK_SECRET",
+        "ASC_WEBHOOK_SECRET",
+        "EXPO_TOKEN"
+      ]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,18 @@ importers:
         specifier: 5.9.2
         version: 5.9.2
 
+  apps/hooks:
+    devDependencies:
+      '@piki/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      '@types/node':
+        specifier: ^22.15.3
+        version: 22.15.3
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+
   apps/web:
     dependencies:
       '@microsoft/fetch-event-source':


### PR DESCRIPTION
---

## 작업 요약

- iOS 앱 배포 진행상황(빌드·제출·TestFlight·심사·출시)을 허거덩 봇이 Discord에 알립니다
- 배포 1회당 스레드 1개를 열어 진행 로그를 쌓고, 메인 글은 현재 상태판으로 계속 갱신됩니다
- 웹훅 수신기는 apps/web이 아닌 별도 Vercel 프로젝트(`apps/hooks`)로 분리했습니다
- 웹 배포 알림 라벨을 `[WEB·DEV]`/`[WEB·PROD]`로 통일했습니다

## 작업 세부 내용

### 배치 결정 — 이슈 초안(apps/web)에서 별도 프로젝트로 변경

이슈에는 `apps/web` route handler로 잡혀 있었지만, 봇 토큰이 서비스 런타임 환경에 들어가고 배포 *알림* 코드가 프로덕트 배포에 묶이는 문제가 있어 분리했습니다. n8n·Make 같은 자동화 SaaS도 검토했지만 서명 검증 코드는 어차피 필요하고, 설정이 레포·리뷰 밖 개인 계정에 종속되는 단점이 커서 제외했습니다.

| 선택지 | 장점 | 단점 |
| --- | --- | --- |
| apps/web route handler (이슈 초안) | 새 인프라 없음 | 봇 토큰이 서비스 런타임에 노출, 알림이 프로덕트 배포에 결합 |
| **apps/hooks 별도 Vercel 프로젝트 (채택)** | 토큰 격리, 배포 분리, 코드는 레포에 유지 | Vercel 프로젝트 1개 추가 |
| n8n / Make | 코드 최소화 | 호스팅·구독 비용, 검증 로직은 어차피 코드, 리뷰·git 밖 |

Next 없이 플레인 Vercel Functions만 쓰는 최소 구성이고, lint·check-types는 기존 turbo 파이프라인에 합류합니다.

### 알림 구조 — 버전당 스레드 1개, 메인 글은 살아있는 상태판

첫 빌드 완료 이벤트가 채널에 상태판을 올리고 스레드를 엽니다. 이후 이벤트는 상태판을 수정하고 스레드에만 로그를 쌓아, 배포 1회에 이벤트가 7건 이상이어도 채널이 도배되지 않습니다.

```
📦 [iOS] PiKi v1.2.0 배포 진행 중        ← 이벤트마다 수정, 출시되면 🎉 ... 출시 완료! 로 변경
• 심사용 (production): 심사 제출 완료
• 팀 테스트용 (production-dev): TestFlight 업로드 완료 — 처리 대기
• TestFlight 처리: 2건 완료
• 심사: 📮 대기 중
  └ 스레드: 🛠 빌드 완료 → ✅ 제출 완료 → 📮 심사 대기 → ✅ 통과 → 🎉 출시 완료!
```

- **Discord가 상태 저장소** — 별도 DB 없이 채널 최근 메시지에서 진행 중(`📦`) 루트를 찾아 갱신합니다. 출시·반려로 제목이 `🎉`/`❌`가 되면 사이클이 닫히고, 다음 배포는 새 루트를 만듭니다 (14일 지난 루트는 무시)
- **심사 표시는 대기·통과·출시·반려만** — 수동/자동 출시 구분은 통과 후 전이(`PENDING_DEVELOPER_RELEASE` = 수동 대기)로 자연히 드러납니다

### 엔드포인트

| 경로 | 발신자 | 서명 검증 | 역할 |
| --- | --- | --- | --- |
| `POST /api/webhooks/eas-build` | EAS Build | `expo-signature` (HMAC-SHA1) | 빌드 완료가 사이클(스레드)을 엶 |
| `POST /api/webhooks/eas` | EAS Submit | `expo-signature` (HMAC-SHA1) | 심사 제출·TestFlight 업로드 기록 |
| `POST /api/webhooks/asc` | App Store Connect | `x-apple-signature` (HMAC-SHA256) | TestFlight 빌드 처리·심사 상태 전이 기록 |

### 구현 디테일

- **빌드 프로필 구분** — 팀은 심사용(production)·팀 테스트용(production-dev)을 항상 함께 배포하므로 구분이 필요한데, EAS SUBMIT 페이로드에 프로필이 없어 `turtleBuildId`로 EAS API를 조회해 프로필·버전을 표시합니다 (`EXPO_TOKEN` 없으면 해당 줄만 생략)
- **TestFlight 처리 건수 집계** — ASC 페이로드에는 빌드 식별 정보가 없어 어느 빌드인지 알 수 없습니다. 건수 카운터로 집계하고, 정확한 구분은 ASC API 키 셋업이 필요해 후속으로 미뤘습니다
- **무시 케이스** — 제출 취소·미매핑 상태 전이·ASC 테스트 ping·미구독 이벤트는 200으로 조용히 응답합니다 (Apple 재시도 유발 금지)
- **빌드 "시작" 시점 웹훅은 EAS에 없음** — 빌드 완료 이벤트가 사이클 시작점입니다
- **웹 알림 라벨 통일** — 대괄호 의미가 웹은 환경(`[DEV]`), 앱은 플랫폼(`[iOS]`)으로 어긋나 있어 "어느 표면의 알림인지"로 통일(`[WEB·DEV]`/`[WEB·PROD]`)하고, 본문의 중복 단어 `PiKi WEB`은 `PiKi`로 축약했습니다

### 검증

가짜 Discord 채널·EAS API를 모킹해 전체 사이클을 시뮬레이션했습니다 — 빌드 2건 → 제출 2건 → TestFlight 처리 2건 → 심사 대기/통과/수동 출시 대기/출시의 이벤트 10건이 **루트 1개 + 스레드 로그 10건**으로 수렴하는 것, 사이클 종료 후 새 이벤트가 새 루트를 만드는 것, 무시 케이스가 아무것도 만들지 않는 것, 서명 불일치 401 거부까지 확인했습니다. 단, ASC 웹훅 페이로드는 실측 전이라 문서 기반으로 방어적으로 파싱했고, 실제 배포 1회에서 필드가 다르면 조정이 필요합니다.

### 남은 셋업

이 PR은 수신기 코드까지입니다. Vercel 프로젝트 생성·웹훅 등록·실측 등 남은 셋업 체크리스트는 #618에서 관리하고, 전부 끝난 뒤 이슈를 닫습니다.

## 스크린샷

## 연관 이슈

#618


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * EAS Build·Submit 및 App Store Connect 이벤트를 수신하는 iOS 배포 웹훅을 추가했습니다.
  * 배포 상태, 빌드 정보, 제출 결과를 Discord 릴리스 스레드에 자동으로 기록합니다.
  * Android 제출 결과는 Discord 알림으로 전송됩니다.
  * 웹훅 서명 검증과 잘못된 요청에 대한 오류 처리를 지원합니다.

* **문서**
  * iOS 배포 웹훅의 사용 방법, 환경 변수, Discord 설정 및 운영 절차를 문서화했습니다.

* **변경 사항**
  * 웹 배포 Discord 알림의 Production·개발 라벨과 메시지 문구를 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->