### PR TITLE
fix: SSE 정상 종료 감지 및 화면 복귀 시 재연결 보강

### DIFF
--- a/apps/web/src/hooks/useNotificationSSE.ts
+++ b/apps/web/src/hooks/useNotificationSSE.ts
@@ -18,6 +18,8 @@ import { WebBridge, isWebview } from '@/utils/webBridge';
 
 const MAX_RETRY_DELAY_MS = 30_000;
 
+const INITIAL_RETRY_DELAY_MS = 1_000;
+
 const MAX_AUTH_RETRY_COUNT = 2;
 
 /** 아이템 파싱 알림의 refId 는 itemId 라서, 위시 상세 캐시(`['wish', wishId]`)는 item.id 로 찾는다 */
@@ -32,7 +34,7 @@ const buildToastMessage = (payload: NotificationSsePayloadT) =>
 export const useNotificationSSE = (enabled: boolean) => {
   const pathname = usePathname();
   const queryClient = useQueryClient();
-  const retryDelayRef = useRef(1_000);
+  const retryDelayRef = useRef(INITIAL_RETRY_DELAY_MS);
   const abortRef = useRef<AbortController | null>(null);
   const hasConnectedRef = useRef(false);
   const authFailCountRef = useRef(0);
@@ -47,11 +49,25 @@ export const useNotificationSSE = (enabled: boolean) => {
     if (!enabled) return;
 
     let cancelled = false;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     // ref 는 언마운트/재로그인 후에도 남으므로, 이전 세션의 실패 횟수를 물려받지 않도록 초기화
     authFailCountRef.current = 0;
 
+    const scheduleReconnect = (delay: number) => {
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      const jitteredDelay = delay * (0.5 + Math.random() * 0.5);
+      reconnectTimer = setTimeout(connect, jitteredDelay);
+    };
+
     const connect = () => {
       if (cancelled) return;
+
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      // 기존 연결 정리 — 중복 알림 방지
+      abortRef.current?.abort();
 
       const controller = new AbortController();
       abortRef.current = controller;
@@ -76,11 +92,12 @@ export const useNotificationSSE = (enabled: boolean) => {
         headers,
         credentials: 'include',
         signal: controller.signal,
+        // 가시성 변화에 따른 라이브러리의 자동 연결 관리는 끄고, 아래 핸들러에서 백오프를 리셋해 직접 재연결한다
         openWhenHidden: true,
 
         onopen: async response => {
           if (response.ok) {
-            retryDelayRef.current = 1_000;
+            retryDelayRef.current = INITIAL_RETRY_DELAY_MS;
             authFailCountRef.current = 0;
             if (hasConnectedRef.current) {
               // 재연결 성공 — 끊긴 동안 SSE 이벤트로 놓쳤을 수 있는 도메인만 재조회
@@ -98,9 +115,7 @@ export const useNotificationSSE = (enabled: boolean) => {
               cancelled = true;
               throw new Error('unauthorized');
             }
-            // 토큰 만료 시 공유 refresh 함수를 통해 갱신 후 재연결.
-            // 단일 진입점 — page request / API 호출과 같은 dedupe 큐를 공유한다.
-            // (직접 fetch 로 호출하면 동시 다발 race 로 백엔드가 401/500 거부 → 사용자 로그아웃)
+            // 토큰 만료 시 공유 갱신 경로를 사용해 동시 갱신 요청을 막는다
             try {
               await refreshClientToken();
               // refresh 성공 → onerror backoff 로 재연결
@@ -208,6 +223,14 @@ export const useNotificationSSE = (enabled: boolean) => {
           }
         },
 
+        // 서버가 스트림을 정상 종료한 경우는 onerror를 호출하지 않으므로 직접 재연결한다
+        onclose: () => {
+          if (cancelled) return;
+
+          retryDelayRef.current = INITIAL_RETRY_DELAY_MS;
+          scheduleReconnect(INITIAL_RETRY_DELAY_MS);
+        },
+
         onerror: err => {
           if (cancelled) throw err; // fetchEventSource 재시도 중단
 
@@ -216,9 +239,7 @@ export const useNotificationSSE = (enabled: boolean) => {
 
           // throw하면 fetchEventSource가 재시도 멈춤 → setTimeout으로 수동 재연결
           controller.abort();
-          // 다수 클라이언트가 동시에 끊겼을 때 재연결이 한 시점에 몰리는 것 방지
-          const jitteredDelay = delay * (0.5 + Math.random() * 0.5);
-          setTimeout(connect, jitteredDelay);
+          scheduleReconnect(delay);
           throw err;
         },
       }).catch(() => {
@@ -226,10 +247,22 @@ export const useNotificationSSE = (enabled: boolean) => {
       });
     };
 
+    // 화면 복귀 시 예약된 재연결을 즉시 실행해 알림 공백을 줄인다
+    const handleVisibilityChange = () => {
+      if (document.hidden || !reconnectTimer) return;
+
+      retryDelayRef.current = INITIAL_RETRY_DELAY_MS;
+      connect();
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
     connect();
 
     return () => {
       cancelled = true;
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      if (reconnectTimer) clearTimeout(reconnectTimer);
       abortRef.current?.abort();
     };
   }, [enabled, queryClient]);


### PR DESCRIPTION
## 작업 요약
- SSE 정상 종료·화면 복귀 시 재연결을 보완해 알림이 조용히 멈추거나 최대 30초 지연되는 문제를 해결했습니다.

## 작업 세부 내용

### 1. 서버가 SSE 를 정상 종료하면 재연결하지 않던 문제

`@microsoft/fetch-event-source` 는 스트림이 **정상 종료**되면 `onclose` 를 호출하고 그대로 끝냅니다.
재연결은 예외가 발생하는 `catch` 경로에서만 일어납니다.

    await getBytes(...)   // 스트림 종료
    onclose?.()           // 호출만 하고
    dispose(); resolve()  // 끝. 재시도 없음

훅에 `onclose` 가 정의돼 있지 않아, 서버가 연결을 정상 종료하면 **재연결하지 않고 조용히 멈췄습니다.**
> 새로고침 전까지 알림이 오지 않는 상태가 됨

서버에 "하트비트 미수신 시 SSE 정상 종료" 정책이 도입될 예정이라 이 경로를 상시로 타게 되므로, 하트비트 작업(#628)보다 먼저 처리했습니다.

`onclose` 는 장애가 아니라 서버의 의도적 종료이므로, 실패 백오프를 물려받지 않고 초기 지연으로 곧바로 재연결합니다.

### 2. 화면 복귀 시 최대 30초 알림 공백

재연결이 지수 백오프(최대 30초)로 동작해, 복귀 시점에도 직전 실패로 늘어난 백오프를 그대로 기다렸습니다.
복귀 시점은 네트워크가 회복됐을 가능성이 높아 기다릴 이유가 없어, 백오프를 리셋하고 즉시 재연결합니다.

단, **예약된 재연결이 있을 때만** 동작합니다.

    if (document.hidden || !reconnectTimer) return;

연결이 살아 있으면 건드리지 않습니다. 복귀할 때마다 무조건 재연결하면 멀쩡한 커넥션을 끊고 `onopen` 에서 쿼리 3개를 재조회하게 되어 오히려 낭비가 됩니다.

### 3. 재연결 예약 일원화

지터 로직이 여러 곳에 흩어지지 않도록 `scheduleReconnect` 로 묶었습니다.
그 결과 `reconnectTimer` 가 **"재연결 대기 중"을 판단하는 단일 근거**가 되어 2번 조건이 성립합니다.

`connect()` 진입 시 예약된 타이머를 해제하고 `null` 로 되돌립니다.

- `clearTimeout` — 복귀 경로에서 직접 `connect()` 를 호출할 때 예약된 타이머가 나중에 또 실행돼
  커넥션이 두 개 열리는 것을 방지
- `= null` — 타이머가 발화한 뒤에도 옛 id 가 남아 있으면 계속 truthy 라, 연결이 멀쩡한데도
  복귀 때마다 재연결로 판단하게 되는 것을 방지

아울러 `connect()` 진입 시 이전 커넥션을 abort 해 통로가 중복되지 않도록 했습니다.

### 4. openWhenHidden 

값은 `true` 로 유지했습니다. 라이브러리 자체 가시성 처리(숨김 시 abort, 복귀 시 재연결)를 켜면 훅의 재연결 루프와 이중으로 돌아 커넥션이 꼬입니다. 

## 이번 범위가 아닌 것

**숨김 시 연결 중단은 포함하지 않았습니다.** 서버의 하트비트 미수신 종료 정책과 함께 가야 하며, 지금 도입하면 백그라운드에서 알림을 받지 못하는 퇴행이 됩니다. 하트비트 이슈에서 함께 처리합니다.


## 스크린샷

UI 변경 없음

## 연관 이슈

closes #627


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 알림 실시간 연결이 예기치 않게 종료된 후 자동으로 재연결됩니다.
  * 중복 연결과 중복 알림을 줄이도록 재연결 처리가 개선되었습니다.
  * 화면에 다시 표시될 때 대기 중인 재연결이 즉시 실행됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->