### PR TITLE
feat: 위시 파싱 알림 클릭 시 위시 상세로 직행

### DIFF
--- a/apps/web/src/app/notification/_components/NotificationContent.tsx
+++ b/apps/web/src/app/notification/_components/NotificationContent.tsx
@@ -50,6 +50,7 @@ function NotificationContent() {
     const route = getNotificationRoute(notification.type, notification.refId, {
       kind: notification.kind,
       tournamentId: notification.tournamentId,
+      wishId: notification.wishId,
     });
     postNotificationsReadMutation({ ids: [notification.id] });
     if (route) router.push(route);

--- a/apps/web/src/app/notification/_utils/getNotificationRoute.test.ts
+++ b/apps/web/src/app/notification/_utils/getNotificationRoute.test.ts
@@ -20,7 +20,14 @@ describe('getNotificationRoute', () => {
     }
   );
 
-  it.each(PARSING_TYPES)('%s — 위시에서 담은 아이템은 위시리스트로 보낸다', type => {
+  it.each(PARSING_TYPES)(
+    '%s — 위시에서 담은 아이템은 refId 가 아니라 wishId 로 위시 상세로 이동한다',
+    type => {
+      expect(getNotificationRoute(type, 99, { kind: 'WISH', wishId: 12 })).toBe('/archive/wish/12');
+    }
+  );
+
+  it.each(PARSING_TYPES)('%s — wishId 가 없는 구버전 알림은 위시함 목록으로 보낸다', type => {
     expect(getNotificationRoute(type, 99, { kind: 'WISH' })).toBe('/archive/wish');
   });
 });

--- a/apps/web/src/app/notification/_utils/getNotificationRoute.test.ts
+++ b/apps/web/src/app/notification/_utils/getNotificationRoute.test.ts
@@ -4,14 +4,15 @@ import type { NotificationTypeT } from '@/types/notification';
 
 import { getNotificationRoute } from './getNotificationRoute';
 
-const PARSING_TYPES: NotificationTypeT[] = [
+const ITEM_TYPES: NotificationTypeT[] = [
   'ITEM_PARSING_COMPLETED',
   'ITEM_PARSING_INCOMPLETE',
   'ITEM_PARSING_FAILED',
+  'ITEM_REFRESH_COMPLETED',
 ];
 
 describe('getNotificationRoute', () => {
-  it.each(PARSING_TYPES)(
+  it.each(ITEM_TYPES)(
     '%s — 토너먼트에서 담은 아이템은 refId 가 아니라 tournamentId 로 이동한다',
     type => {
       expect(getNotificationRoute(type, 99, { kind: 'TOURNAMENT', tournamentId: 7 })).toBe(
@@ -20,14 +21,14 @@ describe('getNotificationRoute', () => {
     }
   );
 
-  it.each(PARSING_TYPES)(
+  it.each(ITEM_TYPES)(
     '%s — 위시에서 담은 아이템은 refId 가 아니라 wishId 로 위시 상세로 이동한다',
     type => {
       expect(getNotificationRoute(type, 99, { kind: 'WISH', wishId: 12 })).toBe('/archive/wish/12');
     }
   );
 
-  it.each(PARSING_TYPES)('%s — wishId 가 없는 구버전 알림은 위시함 목록으로 보낸다', type => {
+  it.each(ITEM_TYPES)('%s — wishId 가 없는 구버전 알림은 위시함 목록으로 보낸다', type => {
     expect(getNotificationRoute(type, 99, { kind: 'WISH' })).toBe('/archive/wish');
   });
 });

--- a/apps/web/src/app/notification/_utils/getNotificationRoute.ts
+++ b/apps/web/src/app/notification/_utils/getNotificationRoute.ts
@@ -1,11 +1,10 @@
 import { ROUTES } from '@/consts/route';
-
 import type { NotificationItemT, NotificationTypeT } from '@/types/notification';
 
 export const getNotificationRoute = (
   type: NotificationTypeT,
   refId: number,
-  extra?: Pick<NotificationItemT, 'kind' | 'tournamentId'>
+  extra?: Pick<NotificationItemT, 'kind' | 'tournamentId' | 'wishId'>
 ): string | null => {
   switch (type) {
     case 'TOURNAMENT_JOINED':
@@ -22,6 +21,9 @@ export const getNotificationRoute = (
     case 'ITEM_PARSING_FAILED':
       if (extra?.kind === 'TOURNAMENT' && extra.tournamentId) {
         return ROUTES.TOURNAMENT_CREATE(extra.tournamentId);
+      }
+      if (extra?.kind === 'WISH' && extra.wishId) {
+        return ROUTES.WISH_EDIT(extra.wishId);
       }
       return ROUTES.WISHLIST;
     case 'ANNOUNCEMENT':

--- a/apps/web/src/app/notification/_utils/getNotificationRoute.ts
+++ b/apps/web/src/app/notification/_utils/getNotificationRoute.ts
@@ -19,6 +19,7 @@ export const getNotificationRoute = (
     case 'ITEM_PARSING_COMPLETED':
     case 'ITEM_PARSING_INCOMPLETE':
     case 'ITEM_PARSING_FAILED':
+    case 'ITEM_REFRESH_COMPLETED':
       if (extra?.kind === 'TOURNAMENT' && extra.tournamentId) {
         return ROUTES.TOURNAMENT_CREATE(extra.tournamentId);
       }

--- a/apps/web/src/hooks/useNotificationSSE.ts
+++ b/apps/web/src/hooks/useNotificationSSE.ts
@@ -1,5 +1,6 @@
 import { fetchEventSource } from '@microsoft/fetch-event-source';
 import { WEBBRIDGE_MESSAGE_TYPE } from '@piki/core';
+import type { QueryClient } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
 import { usePathname } from 'next/navigation';
 import { useEffect, useRef } from 'react';
@@ -18,6 +19,14 @@ import { WebBridge, isWebview } from '@/utils/webBridge';
 const MAX_RETRY_DELAY_MS = 30_000;
 
 const MAX_AUTH_RETRY_COUNT = 2;
+
+// wishId가 없거나 숫자가 아닌 경우에는 열린 상세가 낡지 않도록 모든 위시 상세 쿼리를 무효화한다
+const invalidateWishQueries = (queryClient: QueryClient, wishId?: number) => {
+  queryClient.invalidateQueries({ queryKey: ['wishlists'] });
+
+  const isValidWishId = typeof wishId === 'number' && Number.isInteger(wishId) && wishId > 0;
+  queryClient.invalidateQueries({ queryKey: isValidWishId ? ['wish', wishId] : ['wish'] });
+};
 
 const buildToastMessage = (payload: NotificationSsePayloadT) =>
   payload.body ? `${payload.title} ${payload.body}` : payload.title;
@@ -154,10 +163,7 @@ export const useNotificationSSE = (enabled: boolean) => {
                       queryKey: ['tournament', payload.tournamentId],
                     });
                   } else if (payload.kind === 'WISH') {
-                    queryClient.invalidateQueries({ queryKey: ['wishlists'] });
-                    if (payload.wishId != null) {
-                      queryClient.invalidateQueries({ queryKey: ['wish', payload.wishId] });
-                    }
+                    invalidateWishQueries(queryClient, payload.wishId);
                   }
                   toast.success(message);
                   break;
@@ -169,10 +175,7 @@ export const useNotificationSSE = (enabled: boolean) => {
                       queryKey: ['tournament', payload.tournamentId],
                     });
                   } else if (payload.kind === 'WISH') {
-                    queryClient.invalidateQueries({ queryKey: ['wishlists'] });
-                    if (payload.wishId != null) {
-                      queryClient.invalidateQueries({ queryKey: ['wish', payload.wishId] });
-                    }
+                    invalidateWishQueries(queryClient, payload.wishId);
                   }
                   if (payload.type === 'ITEM_PARSING_INCOMPLETE') {
                     toast.info(message, { duration: 5000 });

--- a/apps/web/src/hooks/useNotificationSSE.ts
+++ b/apps/web/src/hooks/useNotificationSSE.ts
@@ -147,6 +147,7 @@ export const useNotificationSSE = (enabled: boolean) => {
               const message = buildToastMessage(payload);
 
               switch (payload.type) {
+                case 'ITEM_REFRESH_COMPLETED':
                 case 'ITEM_PARSING_COMPLETED':
                   if (payload.kind === 'TOURNAMENT' && payload.tournamentId != null) {
                     queryClient.invalidateQueries({

--- a/apps/web/src/hooks/useNotificationSSE.ts
+++ b/apps/web/src/hooks/useNotificationSSE.ts
@@ -1,6 +1,5 @@
 import { fetchEventSource } from '@microsoft/fetch-event-source';
 import { WEBBRIDGE_MESSAGE_TYPE } from '@piki/core';
-import type { Query } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
 import { usePathname } from 'next/navigation';
 import { useEffect, useRef } from 'react';
@@ -19,12 +18,6 @@ import { WebBridge, isWebview } from '@/utils/webBridge';
 const MAX_RETRY_DELAY_MS = 30_000;
 
 const MAX_AUTH_RETRY_COUNT = 2;
-
-/** 아이템 파싱 알림의 refId 는 itemId 라서, 위시 상세 캐시(`['wish', wishId]`)는 item.id 로 찾는다 */
-// TODO: payload 에 wishId 가 추가되면 `['wish', payload.wishId]` 무효화로 대체 (tournamentId 와 동일한 형태로 요청해둠)
-const isWishQueryOfItem = (query: Query, itemId: number) =>
-  query.queryKey[0] === 'wish' &&
-  (query.state.data as { item?: { id: number } } | undefined)?.item?.id === itemId;
 
 const buildToastMessage = (payload: NotificationSsePayloadT) =>
   payload.body ? `${payload.title} ${payload.body}` : payload.title;
@@ -161,9 +154,9 @@ export const useNotificationSSE = (enabled: boolean) => {
                     });
                   } else if (payload.kind === 'WISH') {
                     queryClient.invalidateQueries({ queryKey: ['wishlists'] });
-                    queryClient.invalidateQueries({
-                      predicate: query => isWishQueryOfItem(query, payload.refId),
-                    });
+                    if (payload.wishId != null) {
+                      queryClient.invalidateQueries({ queryKey: ['wish', payload.wishId] });
+                    }
                   }
                   toast.success(message);
                   break;
@@ -176,9 +169,9 @@ export const useNotificationSSE = (enabled: boolean) => {
                     });
                   } else if (payload.kind === 'WISH') {
                     queryClient.invalidateQueries({ queryKey: ['wishlists'] });
-                    queryClient.invalidateQueries({
-                      predicate: query => isWishQueryOfItem(query, payload.refId),
-                    });
+                    if (payload.wishId != null) {
+                      queryClient.invalidateQueries({ queryKey: ['wish', payload.wishId] });
+                    }
                   }
                   if (payload.type === 'ITEM_PARSING_INCOMPLETE') {
                     toast.info(message, { duration: 5000 });

--- a/apps/web/src/types/notification.ts
+++ b/apps/web/src/types/notification.ts
@@ -11,6 +11,7 @@ export type NotificationTypeT =
   | 'ITEM_PARSING_COMPLETED'
   | 'ITEM_PARSING_INCOMPLETE'
   | 'ITEM_PARSING_FAILED'
+  | 'ITEM_REFRESH_COMPLETED'
   | 'ANNOUNCEMENT';
 
 export type NotificationKindT = 'WISH' | 'TOURNAMENT' | 'SYSTEM';

--- a/apps/web/src/types/notification.ts
+++ b/apps/web/src/types/notification.ts
@@ -28,6 +28,7 @@ export type NotificationItemT = {
   isRead: boolean;
   createdAt: string;
   kind: NotificationKindT;
+  wishId?: number;
   tournamentId?: number;
   tournamentItemId?: number;
 };
@@ -64,8 +65,7 @@ export type NotificationSsePayloadT = {
   isRead: boolean;
   createdAt: string;
   kind: NotificationKindT;
-  /** kind === 'TOURNAMENT' 일 때만 존재 */
+  wishId?: number;
   tournamentId?: number;
-  /** kind === 'TOURNAMENT' 일 때만 존재 */
   tournamentItemId?: number;
 };


### PR DESCRIPTION


## 작업 요약
- `kind === 'WISH'` 파싱 알림 클릭 시 위시함 목록이 아닌 위시 상세로 직행하도록 변경
- 새로고침 완료 알림에서 화면이 갱신되지 않던 버그 함께 수정

## 작업 내용

### 위시 파싱 알림 → 위시 상세 직행

- `kind === 'WISH'`인 아이템 파싱 알림을 누르면 위시함 목록(`/archive/wish`)으로만 이동
- 알림이 가리키는 상품이 목록 어디에 있는지 알 수 없고, 위시함은 커서 페이지네이션이라 아직 불러오지 않은 페이지에 있을 수도 있음.

서버는 알림 payload에 `wishId`를 내려주고 있었으나 프론트 타입에 반영되지 않아 쓰이지 못하고 있었습니다. 이를 반영해 `ROUTES.WISH_EDIT(wishId)`로 바로 이동하도록 변경하였습니다.

**변경 사항**
- `NotificationItemT` · `NotificationSsePayloadT`에 `wishId` 추가
- `getNotificationRoute`가 `wishId`로 위시 상세 반환, 없으면 기존 위시함 목록으로 fallback (구버전 알림 레코드 대비)
- SSE 캐시 무효화도 `wishId`로 정리 — `refId`가 itemId라서 캐시를 순회하며 `item.id`를 대조하던 `isWishQueryOfItem` 프레디케이트와 TODO 주석 제거
- `getNotificationRoute.test.ts`에 위시 케이스 추가 (wishId 있음 → 상세 / 없음 → fallback)

**목록 강조가 아닌 상세 직행인 이유**
목록에서 대상 카드를 스크롤·강조하는 방식은 대상이 미로드 페이지에 있으면 조용히 실패 (상세로 직행하면 이 문제가 없음)

**라우팅에 status 분기를 두지 않은 이유**
도착 화면이 이미 방어하고 있음.
- `archive/wish/[id]/layout.tsx`가 404·PENDING·PROCESSING을 위시함으로 리다이렉트
- `ItemInfoScreen`이 status로 분기해 FAILED/INCOMPLETE는 수기 입력 폼, READY는 조회 뷰 표시

→ 실패 알림을 눌렀는데 그 사이 정보가 채워진 경우에도 자연스럽게 성립.

---

### 새로고침 완료 알림에서 화면이 갱신되지 않던 문제

상품 정보 새로고침 후 `최신 상품 정보로 새로고침했어요` 토스트는 뜨는데 화면은 그대로였습니다.

**원인**
서버가 보내는 `ITEM_REFRESH_COMPLETED`가 `NotificationTypeT`에 없어 SSE switch의 `default`로 떨어지고 있었음.
토스트만 실행되고, 캐시 무효화는 `ITEM_PARSING_*` 케이스 안에만 있어 한 번도 돌지 않음.

**수정**
- 타입에 `ITEM_REFRESH_COMPLETED` 추가하고 `ITEM_PARSING_COMPLETED`와 같은 case로 통일
  - 새로고침 완료도 결국 상품 정보가 새로 채워진 것이라 갱신 대상과 토스트가 동일
- 알림 목록에서 눌렀을 때의 이동 경로도 파싱 알림과 같게 맞춤

## 스크린샷

https://github.com/user-attachments/assets/b77e6dbb-1221-474b-92d3-2b84e26908e3



## 관련 이슈
- close #601


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 위시 관련 알림을 선택하면 올바른 위시 상세 화면으로 이동합니다.
  * 위시 아이템 새로고침 완료 알림이 해당 위시의 최신 정보로 반영됩니다.
  * 관련 식별자가 없는 기존 알림은 위시함 목록으로 이동합니다.

* **테스트**
  * 위시 상세 및 목록 이동 경로에 대한 테스트를 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->