### PR TITLE
feat: 토너먼트 파싱 알림 클릭 시 대상 바구니로 이동 및 카드 강조

### DIFF
--- a/apps/web/src/app/notification/_components/NotificationContent.tsx
+++ b/apps/web/src/app/notification/_components/NotificationContent.tsx
@@ -50,6 +50,7 @@ function NotificationContent() {
     const route = getNotificationRoute(notification.type, notification.refId, {
       kind: notification.kind,
       tournamentId: notification.tournamentId,
+      tournamentItemId: notification.tournamentItemId,
       wishId: notification.wishId,
     });
     postNotificationsReadMutation({ ids: [notification.id] });

--- a/apps/web/src/app/notification/_utils/getNotificationRoute.test.ts
+++ b/apps/web/src/app/notification/_utils/getNotificationRoute.test.ts
@@ -34,6 +34,19 @@ describe('getNotificationRoute', () => {
     }
   );
 
+  it.each([0, -1, 1.5, Number.NaN, '1&action=welcome-join'])(
+    'payload 는 런타임 검증이 없어 tournamentItemId 가 %s 로 오면 강조 쿼리 없이 담기 화면으로만 이동한다',
+    invalidId => {
+      expect(
+        getNotificationRoute('ITEM_PARSING_FAILED', 99, {
+          kind: 'TOURNAMENT',
+          tournamentId: 7,
+          tournamentItemId: invalidId as number,
+        })
+      ).toBe('/tournament/7/create');
+    }
+  );
+
   it.each(ITEM_TYPES)(
     '%s — 위시에서 담은 아이템은 refId 가 아니라 wishId 로 위시 상세로 이동한다',
     type => {

--- a/apps/web/src/app/notification/_utils/getNotificationRoute.test.ts
+++ b/apps/web/src/app/notification/_utils/getNotificationRoute.test.ts
@@ -22,6 +22,19 @@ describe('getNotificationRoute', () => {
   );
 
   it.each(ITEM_TYPES)(
+    '%s — 토너먼트 아이템은 담기 화면에서 강조하도록 tournamentItemId 를 쿼리로 싣는다',
+    type => {
+      expect(
+        getNotificationRoute(type, 99, {
+          kind: 'TOURNAMENT',
+          tournamentId: 7,
+          tournamentItemId: 42,
+        })
+      ).toBe('/tournament/7/create?highlightItem=42');
+    }
+  );
+
+  it.each(ITEM_TYPES)(
     '%s — 위시에서 담은 아이템은 refId 가 아니라 wishId 로 위시 상세로 이동한다',
     type => {
       expect(getNotificationRoute(type, 99, { kind: 'WISH', wishId: 12 })).toBe('/archive/wish/12');

--- a/apps/web/src/app/notification/_utils/getNotificationRoute.ts
+++ b/apps/web/src/app/notification/_utils/getNotificationRoute.ts
@@ -4,7 +4,7 @@ import type { NotificationItemT, NotificationTypeT } from '@/types/notification'
 export const getNotificationRoute = (
   type: NotificationTypeT,
   refId: number,
-  extra?: Pick<NotificationItemT, 'kind' | 'tournamentId' | 'wishId'>
+  extra?: Pick<NotificationItemT, 'kind' | 'tournamentId' | 'tournamentItemId' | 'wishId'>
 ): string | null => {
   switch (type) {
     case 'TOURNAMENT_JOINED':
@@ -21,7 +21,7 @@ export const getNotificationRoute = (
     case 'ITEM_PARSING_FAILED':
     case 'ITEM_REFRESH_COMPLETED':
       if (extra?.kind === 'TOURNAMENT' && extra.tournamentId) {
-        return ROUTES.TOURNAMENT_CREATE(extra.tournamentId);
+        return ROUTES.TOURNAMENT_CREATE(extra.tournamentId, extra.tournamentItemId);
       }
       if (extra?.kind === 'WISH' && extra.wishId) {
         return ROUTES.WISH_EDIT(extra.wishId);

--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -6,12 +6,14 @@ import BottomCta from '@/components/bottom-cta';
 import { Dialog } from '@/components/dialog';
 import GetItemDialogContent from '@/components/get-item-dialog';
 import { ITEM_STATUS } from '@/consts/item';
-import { QUERY_ACTION } from '@/consts/queryAction';
+import { QUERY_ACTION, QUERY_PARAM } from '@/consts/queryAction';
 import { useGetMe } from '@/hooks/useGetMe';
 import { useQueryAction } from '@/hooks/useQueryAction';
+import { useQueryParamOnce } from '@/hooks/useQueryParamOnce';
 import { useSSEFallback } from '@/hooks/useSSEFallback';
 import { hasSentInvite } from '@/utils/inviteSentSession';
 import { hasParsingItems } from '@/utils/item';
+import { parseIdParam } from '@/utils/parseIdParam';
 
 import { useGetTournament } from '../../_common/_hooks/useGetTournament';
 import { PREV_ITEM_COUNT_KEY } from '../_consts/tournamentItemBasket';
@@ -55,6 +57,10 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
   });
 
   const scrollToLast = isScrollToLastQuery || isScrollToLastSession;
+
+  /** 알림에서 진입한 경우 */
+  const highlightItemIdParam = useQueryParamOnce(QUERY_PARAM.HIGHLIGHT_TOURNAMENT_ITEM);
+  const highlightItemId = highlightItemIdParam ? parseIdParam(highlightItemIdParam) : null;
 
   useEffect(() => {
     sessionStorage.removeItem(scrollToLastKey);
@@ -210,6 +216,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
           items={pending?.items}
           scrollToLast={scrollToLast}
           previousItemCount={previousItemCount}
+          highlightItemId={highlightItemId}
           isAddItemBlocked={isAddItemBlocked}
           participantImageMap={participantImageMap}
           bottomSlot={

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/ProductImage.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/ProductImage.tsx
@@ -11,6 +11,7 @@ type ProductImageProps = {
   src?: string;
   alt: string;
   status?: ItemStatusT;
+  className?: string;
 };
 
 const loadingFallback = (
@@ -32,12 +33,17 @@ const errorFallback = (status: ItemStatusT<'FAILED' | 'INCOMPLETE'> = 'FAILED') 
   </div>
 );
 
-function ProductImage({ src, alt, status }: ProductImageProps) {
+function ProductImage({ src, alt, status, className }: ProductImageProps) {
   const isProcessing = status === ITEM_STATUS.PENDING || status === ITEM_STATUS.PROCESSING;
   const isError = status === ITEM_STATUS.FAILED || status === ITEM_STATUS.INCOMPLETE;
 
   return (
-    <div className="relative h-full w-full overflow-hidden rounded-[16px] border-[2px] border-white bg-gray-50 shadow-[0_0_8px_rgba(0,0,0,0.16)]">
+    <div
+      className={cn(
+        'relative h-full w-full overflow-hidden rounded-[16px] border-[2px] border-white bg-gray-50 shadow-[0_0_8px_rgba(0,0,0,0.16)]',
+        className
+      )}
+    >
       {isProcessing && loadingFallback}
       {isError && errorFallback(status)}
       {!isProcessing && !isError && src && (

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentBasketItem.css
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentBasketItem.css
@@ -1,0 +1,27 @@
+@keyframes tbi-highlight-border {
+  0%,
+  75% {
+    border-color: var(--color-sky-blue-200);
+  }
+  100% {
+    border-color: var(--color-base-50);
+  }
+}
+
+@keyframes tbi-highlight-ring {
+  0%,
+  75% {
+    box-shadow: 0 0 0 1.5px var(--color-sky-blue-200);
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+
+.tbi-highlight {
+  animation: tbi-highlight-border 2s ease-out forwards;
+}
+
+.tbi-highlight-ring {
+  animation: tbi-highlight-ring 2s ease-out forwards;
+}

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentBasketItem.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentBasketItem.tsx
@@ -5,15 +5,23 @@ import { useGetMe } from '@/hooks/useGetMe';
 
 import type { PendingTournamentItemT } from '../../../_common/_types/tournamentResponse';
 import ProductImage from './ProductImage';
+import './TournamentBasketItem.css';
 
 type TournamentBasketItemProps = {
   item: PendingTournamentItemT;
   index: number;
   participantImageMap?: Map<string, string>;
+  /** 알림에서 진입해 이 카드가 대상인 경우 */
+  isHighlighted?: boolean;
 };
 
 /** 바스켓 타일 — 순수 표시용. 클릭 동작은 감싸는 Link·button 이 담당한다 */
-function TournamentBasketItem({ item, index, participantImageMap }: TournamentBasketItemProps) {
+function TournamentBasketItem({
+  item,
+  index,
+  participantImageMap,
+  isHighlighted = false,
+}: TournamentBasketItemProps) {
   const { userData } = useGetMe();
   const friendImageUrl =
     item.userId && item.userId !== userData.id ? participantImageMap?.get(item.userId) : null;
@@ -25,8 +33,15 @@ function TournamentBasketItem({ item, index, participantImageMap }: TournamentBa
           {...(item.imageUrl ? { src: item.imageUrl } : {})}
           alt={`토너먼트 아이템 ${index + 1}`}
           status={item.status}
+          {...(isHighlighted && { className: 'tbi-highlight' })}
         />
       </div>
+      {isHighlighted && (
+        <span
+          aria-hidden
+          className="tbi-highlight-ring pointer-events-none absolute inset-0 rounded-2xl"
+        />
+      )}
       {friendImageUrl && (
         <div
           className="absolute -right-1 -bottom-0.5 overflow-hidden rounded-full border-2 border-white"

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
@@ -22,6 +22,7 @@ type TournamentItemBasketProps = {
   maxHeight?: number;
   isAddItemBlocked?: boolean;
   participantImageMap?: Map<string, string>;
+  highlightItemId?: number | null;
 };
 
 function TournamentItemBasket({
@@ -30,6 +31,7 @@ function TournamentItemBasket({
   maxHeight,
   isAddItemBlocked = false,
   participantImageMap,
+  highlightItemId = null,
 }: TournamentItemBasketProps) {
   const { id } = useParams<{ id: string }>();
   const tournamentId = Number(id);
@@ -75,6 +77,9 @@ function TournamentItemBasket({
           <div className="grid w-[46.5%] grid-cols-2 gap-3.5 pt-[17%]">
             {addSlot}
             {items.map((item, index) => {
+              const isHighlighted =
+                highlightItemId !== null && item.tournamentItemId === highlightItemId;
+
               /** READY 아이템은 누구나 진입 가능 — 주최자·본인이 아니면 조회 전용으로 열림 */
               if (item.status === ITEM_STATUS.READY) {
                 return (
@@ -86,6 +91,7 @@ function TournamentItemBasket({
                       item={item}
                       index={index}
                       participantImageMap={participantImageMap}
+                      isHighlighted={isHighlighted}
                     />
                   </Link>
                 );
@@ -111,6 +117,7 @@ function TournamentItemBasket({
                           item={item}
                           index={index}
                           participantImageMap={participantImageMap}
+                          isHighlighted={isHighlighted}
                         />
                       </button>
                     </DialogTrigger>
@@ -129,6 +136,7 @@ function TournamentItemBasket({
                   item={item}
                   index={index}
                   participantImageMap={participantImageMap}
+                  isHighlighted={isHighlighted}
                 />
               );
             })}

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
@@ -133,6 +133,7 @@ function TournamentItemBasketCarousel({
             isAddItemBlocked={isAddItemBlocked}
             maxHeight={basketMaxHeight}
             participantImageMap={participantImageMap}
+            highlightItemId={highlightItemId}
           />
         </div>
 
@@ -165,6 +166,7 @@ function TournamentItemBasketCarousel({
                 isAddItemBlocked={isAddItemBlocked}
                 maxHeight={basketMaxHeight}
                 participantImageMap={participantImageMap}
+                highlightItemId={highlightItemId}
               />
             </CarouselItem>
           ))}

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
@@ -21,6 +21,7 @@ type TournamentItemBasketCarouselProps = {
   scrollToLast?: boolean;
   /** 위시 담기 등 재진입 시점의 기존 아이템 개수 */
   previousItemCount?: number | null;
+  highlightItemId?: number | null;
   isAddItemBlocked?: boolean;
   participantImageMap?: Map<string, string>;
   bottomSlot?: React.ReactNode;
@@ -30,6 +31,7 @@ function TournamentItemBasketCarousel({
   items = [],
   scrollToLast = false,
   previousItemCount = null,
+  highlightItemId = null,
   isAddItemBlocked = false,
   participantImageMap,
   bottomSlot,
@@ -76,6 +78,24 @@ function TournamentItemBasketCarousel({
     carouselApi.reInit();
     carouselApi.scrollTo(carouselApi.selectedScrollSnap(), true);
   }, [carouselApi, activeBasketCount, isCarouselEnabled]);
+
+  const highlightIndex = useMemo(
+    () =>
+      highlightItemId === null
+        ? -1
+        : items.findIndex(item => item.tournamentItemId === highlightItemId),
+    [items, highlightItemId]
+  );
+
+  const hasScrolledToHighlightRef = useRef(false);
+
+  useLayoutEffect(() => {
+    if (!carouselApi || !isCarouselEnabled) return;
+    if (highlightIndex < 0 || hasScrolledToHighlightRef.current) return;
+
+    hasScrolledToHighlightRef.current = true;
+    carouselApi.scrollTo(getBasketIndexForItem(highlightIndex), true);
+  }, [carouselApi, isCarouselEnabled, highlightIndex]);
 
   useEffect(() => {
     if (!carouselApi) return;

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasketCarousel.tsx
@@ -13,7 +13,7 @@ import {
   BASKET_STACK_GAP,
   ITEMS_PER_BASKET,
 } from '../../_consts/tournamentItemBasket';
-import { getActiveBasketCount, getBasketIndexForLastItem } from '../../_utils/tournamentItemBasket';
+import { getActiveBasketCount, getBasketIndexForItem } from '../../_utils/tournamentItemBasket';
 import TournamentItemBasket from './TournamentItemBasket';
 
 type TournamentItemBasketCarouselProps = {
@@ -63,7 +63,7 @@ function TournamentItemBasketCarousel({
     if (!carouselApi) return;
 
     if (items.length > prevItemCountRef.current) {
-      carouselApi.scrollTo(getBasketIndexForLastItem(items.length));
+      carouselApi.scrollTo(getBasketIndexForItem(items.length - 1));
     }
 
     prevItemCountRef.current = items.length;

--- a/apps/web/src/app/tournament/[id]/create/_utils/tournamentItemBasket.test.ts
+++ b/apps/web/src/app/tournament/[id]/create/_utils/tournamentItemBasket.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { BASKET_COUNT, ITEMS_PER_BASKET } from '../_consts/tournamentItemBasket';
-import { getActiveBasketCount, getBasketIndexForLastItem } from './tournamentItemBasket';
+import { getActiveBasketCount, getBasketIndexForItem } from './tournamentItemBasket';
 
 const MAX_ITEM_COUNT = ITEMS_PER_BASKET * BASKET_COUNT;
 
@@ -27,17 +27,21 @@ describe('getActiveBasketCount', () => {
   });
 });
 
-describe('getBasketIndexForLastItem', () => {
-  it('아이템이 없으면 첫 번째 바구니를 가리킨다', () => {
-    expect(getBasketIndexForLastItem(0)).toBe(0);
+describe('getBasketIndexForItem', () => {
+  it('첫 아이템은 첫 번째 바구니를 가리킨다', () => {
+    expect(getBasketIndexForItem(0)).toBe(0);
   });
 
   it('바구니 경계에서 다음 바구니로 넘어간다', () => {
-    expect(getBasketIndexForLastItem(ITEMS_PER_BASKET)).toBe(0);
-    expect(getBasketIndexForLastItem(ITEMS_PER_BASKET + 1)).toBe(1);
+    expect(getBasketIndexForItem(ITEMS_PER_BASKET - 1)).toBe(0);
+    expect(getBasketIndexForItem(ITEMS_PER_BASKET)).toBe(1);
+  });
+
+  it('마지막 아이템은 마지막 바구니에 들어간다', () => {
+    expect(getBasketIndexForItem(MAX_ITEM_COUNT - 1)).toBe(BASKET_COUNT - 1);
   });
 
   it('마지막 바구니 인덱스를 넘기지 않는다', () => {
-    expect(getBasketIndexForLastItem(MAX_ITEM_COUNT)).toBe(BASKET_COUNT - 1);
+    expect(getBasketIndexForItem(MAX_ITEM_COUNT)).toBe(BASKET_COUNT - 1);
   });
 });

--- a/apps/web/src/app/tournament/[id]/create/_utils/tournamentItemBasket.ts
+++ b/apps/web/src/app/tournament/[id]/create/_utils/tournamentItemBasket.ts
@@ -12,9 +12,8 @@ export const getActiveBasketCount = (itemCount: number) => {
   return Math.min(BASKET_COUNT, filledBaskets);
 };
 
-/** itemCount개일 때 마지막 아이템이 들어 있는 바구니 인덱스 (0-based) */
-export const getBasketIndexForLastItem = (itemCount: number) => {
-  if (itemCount <= 0) return 0;
+export const getBasketIndexForItem = (itemIndex: number) => {
+  if (itemIndex <= 0) return 0;
 
-  return Math.min(BASKET_COUNT - 1, Math.floor((itemCount - 1) / ITEMS_PER_BASKET));
+  return Math.min(BASKET_COUNT - 1, Math.floor(itemIndex / ITEMS_PER_BASKET));
 };

--- a/apps/web/src/consts/queryAction.ts
+++ b/apps/web/src/consts/queryAction.ts
@@ -17,3 +17,8 @@ export const QUERY_ACTION = {
 } as const;
 
 export type QueryActionValueT = (typeof QUERY_ACTION.VALUE)[keyof typeof QUERY_ACTION.VALUE];
+
+/** `action` 과 달리 값이 고정되지 않은(리소스 id 등) 쿼리 파라미터 키 */
+export const QUERY_PARAM = {
+  HIGHLIGHT_TOURNAMENT_ITEM: 'highlightItem', // 알림 클릭시 강조할 토너먼트 아이템
+} as const;

--- a/apps/web/src/consts/route.ts
+++ b/apps/web/src/consts/route.ts
@@ -29,7 +29,7 @@ export const ROUTES = {
 
   /** 4. Authorized Guest or Member */
   TOURNAMENT_CREATE: (tournamentId: number, highlightItemId?: number) =>
-    highlightItemId
+    Number.isSafeInteger(highlightItemId) && Number(highlightItemId) > 0
       ? `/tournament/${tournamentId}/create?${QUERY_PARAM.HIGHLIGHT_TOURNAMENT_ITEM}=${highlightItemId}`
       : `/tournament/${tournamentId}/create`,
   TOURNAMENT_ADD_ITEM_BY_WISH: (tournamentId: number) =>

--- a/apps/web/src/consts/route.ts
+++ b/apps/web/src/consts/route.ts
@@ -1,3 +1,5 @@
+import { QUERY_PARAM } from './queryAction';
+
 /** NOTE: 수정 시 src/utils/getRouteType.ts 도 함께 수정 필요 */
 export const ROUTES = {
   /** 1. Public (Anonymous) */
@@ -26,7 +28,10 @@ export const ROUTES = {
   MYPAGE_WITHDRAW: '/mypage/withdraw',
 
   /** 4. Authorized Guest or Member */
-  TOURNAMENT_CREATE: (tournamentId: number) => `/tournament/${tournamentId}/create`,
+  TOURNAMENT_CREATE: (tournamentId: number, highlightItemId?: number) =>
+    highlightItemId
+      ? `/tournament/${tournamentId}/create?${QUERY_PARAM.HIGHLIGHT_TOURNAMENT_ITEM}=${highlightItemId}`
+      : `/tournament/${tournamentId}/create`,
   TOURNAMENT_ADD_ITEM_BY_WISH: (tournamentId: number) =>
     `/tournament/${tournamentId}/create/by-wish`,
   TOURNAMENT_ITEM_EDIT: (tournamentId: number, itemId: number) =>

--- a/apps/web/src/hooks/useQueryParamOnce.ts
+++ b/apps/web/src/hooks/useQueryParamOnce.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+export const useQueryParamOnce = (paramKey: string) => {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  /** 진입 시점의 값만 필요하므로 초기화 함수에서 한 번만 읽는다 */
+  const [value] = useState(() => searchParams.get(paramKey));
+
+  useEffect(() => {
+    if (searchParams.get(paramKey) === null) return;
+
+    router.replace(pathname, { scroll: false });
+  }, [searchParams, paramKey, pathname, router]);
+
+  return value;
+};

--- a/apps/web/src/hooks/useQueryParamOnce.ts
+++ b/apps/web/src/hooks/useQueryParamOnce.ts
@@ -11,11 +11,17 @@ export const useQueryParamOnce = (paramKey: string) => {
   /** 진입 시점의 값만 필요하므로 초기화 함수에서 한 번만 읽는다 */
   const [value] = useState(() => searchParams.get(paramKey));
 
+  /** 도착지가 함께 실어 보낸 다른 쿼리까지 지우면 안 된다 */
+  const restParams = new URLSearchParams(searchParams.toString());
+  restParams.delete(paramKey);
+  const rest = restParams.toString();
+  const nextUrl = rest ? `${pathname}?${rest}` : pathname;
+
   useEffect(() => {
     if (searchParams.get(paramKey) === null) return;
 
-    router.replace(pathname, { scroll: false });
-  }, [searchParams, paramKey, pathname, router]);
+    router.replace(nextUrl, { scroll: false });
+  }, [searchParams, paramKey, nextUrl, router]);
 
   return value;
 };


### PR DESCRIPTION


## 작업 요약
토너먼트 아이템 파싱 알림 클릭 시 첫 바구니가 아닌 **대상 아이템이 담긴 바구니로 이동 + 카드 강조**하도록 개선

## 배경

토너먼트 아이템 파싱 알림을 누르면 담기 화면 **첫 바구니**로 진입해, 알림이 가리키는 상품이 어느 것인지 알 수 없었습니다.
> 링크를 여러 개 담아 그중 일부만 실패하는 경우가 잦아, 실패 카드가 여러 개면 화면에서 대상을 찾기 어려웠음

알림 payload에 `tournamentItemId`가 이미 내려오고 있었으나 라우팅에 쓰이지 않고 있어서, 이를 URL로 전달해 대상 바구니 이동 + 카드 강조까지 처리했습니다.

## 작업 내용

### 1. 알림 → URL
`getNotificationRoute`가 `/tournament/7/create?highlightItem=42`를 생성

- `ROUTES.TOURNAMENT_CREATE(tournamentId, highlightItemId?)` — 선택 인자라 기존 호출부는 그대로 동작하고, id가 없으면 예전 경로를 반환해 구버전 알림 레코드가 자연스럽게 fallback
- 쿼리 키는 `QUERY_PARAM.HIGHLIGHT_TOURNAMENT_ITEM` 상수로 관리 — 만드는 쪽(`route.ts`)과 읽는 쪽(`TournamentCreateClient`)이 다른 파일이라 문자열이 어긋나면 조용히 실패
- 기존 `QUERY_ACTION`에 넣지 않은 이유: `action`은 고정 값 집합이고 `useQueryAction`이 일치 비교를 하는 구조라, 임의 id를 담는 파라미터와 성격이 다름

### 2. 유틸 일반화
`getBasketIndexForLastItem(itemCount)` → `getBasketIndexForItem(itemIndex)`
기존 용도는 호출부에서 `getBasketIndexForItem(items.length - 1)`로 표현

### 3. 캐러셀 이동
`items.findIndex`로 대상 위치를 찾아 해당 바구니로 **즉시 점프**(`scrollTo(idx, true)`).

- **즉시 점프인 이유** — 바로 위 reInit effect가 현재 스냅을 다시 고정해서 애니메이션 스크롤과 겹치면 서로 밀어냄. 딥링크 도착은 즉시 점프가 자연스럽기도 함
- **`useLayoutEffect`인 이유** — 그리기 전에 위치를 잡아 첫 바구니가 잠깐 보이는 깜빡임 제거
- **최초 1회만 이동** — `hasScrolledToHighlightRef` 가드. 파싱 중에는 SSE로 계속 리렌더되는데, 가드가 없으면 사용자가 옆으로 넘겨도 계속 끌려옴
- **쿼리는 읽은 직후 URL에서 제거**(`useQueryParamOnce`) — 새로고침·URL 공유 시 재실행 방지. 기존 `useQueryAction`과 같은 방식이지만, 고정 값이 아닌 임의 값을 읽도록 일반화한 훅

### 4. 카드 강조
카드의 흰 테두리가 `sky-blue-200`으로 물들고, 바깥에 같은 색 링이 덧대짐
1.5초 유지 후 0.5초에 걸쳐 원래대로 복귀

- CSS `forwards`로 끝나 **JS 타이머·상태 정리 없음**
- 링을 `border-width`로 키우지 않은 이유 — 안쪽 이미지가 밀림
- 링을 별도 형제 요소로 뺀 이유 — 카드 래퍼의 `overflow-hidden`이 바깥 `box-shadow`를 잘라내서, 같은 요소에 그리면 아무리 굵혀도 보이지 않음

## 엣지 케이스
- **대상 아이템이 이미 삭제된 경우** — `findIndex`가 `-1`이라 이동·강조 모두 건너뛰고 평소처럼 진입 (별도 분기 없음)
- **아이템 8개 이하** — 바구니가 1개라 캐러셀 자체가 없음. 이동은 건너뛰고 강조만 걸림
- **알림 외 경로로 진입** — 쿼리가 없어 기존 동작 그대로

## 스크린샷

https://github.com/user-attachments/assets/52fe657c-c66b-41e0-9e70-cfe35a07ee9f




## 관련 이슈
- close #600


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 토너먼트 아이템 알림을 클릭하면 해당 토너먼트 생성 화면으로 이동합니다.
  - 알림과 연결된 아이템이 자동으로 강조 표시되고, 해당 아이템이 포함된 바구니로 자동 스크롤됩니다.
  - 강조 효과는 잠시 표시된 후 원래 상태로 돌아갑니다.

- **개선 사항**
  - 알림 이동 후 주소에 남아 있던 강조용 쿼리 정보가 자동으로 정리됩니다.
  - 토너먼트 아이템 이미지에 화면별 스타일을 적용할 수 있도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->