### PR TITLE
chore: 앱 승격 워크플로우 도입 및 배포 알림 양 플랫폼 통합

### DIFF
--- a/.github/workflows/app-promote.yml
+++ b/.github/workflows/app-promote.yml
@@ -1,0 +1,195 @@
+# 앱 승격 — apps/app/app.json 의 버전을 올려 EAS 빌드 3건(production iOS·Android, production-dev iOS)을
+# 트리거하고, 트리거가 다 성공한 뒤에 버전 커밋과 app-v* 태그를 dev 에 올린다.
+# 빌드 진행·완료·실패는 apps/hooks 웹훅이 Discord 스레드로 보고하므로 --no-wait 로 러너를 붙잡지 않는다.
+# 실행: Actions → App Promote → Run workflow (bump 선택 또는 version 직접 입력)
+#
+# 순서가 계약이다: 빌드 트리거가 먼저다. --no-wait 의 성공은 "큐에 들어갔다"(인증·설정·업로드 통과)까지고
+# 컴파일 성공은 아니지만, 그 구간에서 실패하면 아무 빌드도 안 돈 상태라 git 이 깨끗해야 재실행이 된다.
+# 컴파일 실패는 버전을 올리지 않는다 — 목표 버전은 그대로고 빌드 번호만 다시 올라간다.
+# 그 재시도는 skip_bump 로 하고, 이때 태그는 실제로 빌드된 커밋으로 옮긴다.
+#
+# 전제:
+# - secrets.EXPO_TOKEN — EAS robot token
+# - EAS 에 App Store Connect API Key 가 등록돼 있어야 --auto-submit 이 비대화형으로 통과한다
+#   (expo.dev → Project → Credentials 에서 확인. 로컬 `eas credentials` 는 GoogleService-Info.plist
+#    가 EAS 파일 시크릿에만 있어 app config introspect 단계에서 실패한다)
+# - 네이티브 설정 파일(GoogleService-Info.plist·google-services.json)은 EAS 파일 시크릿에 있어
+#   러너 체크아웃에 없어도 무방하다 — 빌드는 EAS 서버에서 돌며 거기서 주입된다
+name: App Promote
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: '버전 증가 단위'
+        type: choice
+        options:
+          - minor
+          - patch
+          - major
+        default: minor
+      version:
+        description: '버전 직접 지정 (예: 1.3.0) — 입력 시 bump 무시'
+        required: false
+      skip_bump:
+        description: '버전 범프 없이 재빌드 — 태그를 지금 커밋으로 옮긴다 (빌드 실패 재시도용)'
+        type: boolean
+        default: false
+
+permissions: {}
+
+# 승격 동시 실행 방지 — 버전 계산과 푸시 사이의 레이스를 차단한다.
+concurrency:
+  group: app-promote
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # 어느 ref 에서 dispatch 하든 승격 대상은 항상 dev
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: 버전 계산
+        id: version
+        env:
+          BUMP: ${{ inputs.bump }}
+          INPUT_VERSION: ${{ inputs.version }}
+          SKIP_BUMP: ${{ inputs.skip_bump }}
+        run: |
+          set -euo pipefail
+          # app.json 은 주석이 섞인 JSONC 라 jq 로 파싱할 수 없다 — version 줄만 정규식으로 다룬다
+          CURRENT=$(sed -n 's/.*"version": "\([0-9][0-9.]*\)".*/\1/p' apps/app/app.json | head -1)
+          if [ -z "$CURRENT" ]; then
+            echo "::error::apps/app/app.json 에서 version 을 읽지 못했습니다"
+            exit 1
+          fi
+
+          if [ "$SKIP_BUMP" = "true" ]; then
+            echo "bump=false" >> "$GITHUB_OUTPUT"
+            echo "next=$CURRENT" >> "$GITHUB_OUTPUT"
+            echo "### 앱 재빌드 v$CURRENT (버전 범프 없음)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [ -n "$INPUT_VERSION" ]; then
+            if ! printf '%s' "$INPUT_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "::error::version 형식이 올바르지 않습니다: $INPUT_VERSION"
+              exit 1
+            fi
+            NEXT="$INPUT_VERSION"
+          else
+            IFS=. read -r MAJOR MINOR PATCH <<< "$CURRENT"
+            case "$BUMP" in
+              major) NEXT="$((MAJOR + 1)).0.0" ;;
+              minor) NEXT="$MAJOR.$((MINOR + 1)).0" ;;
+              patch) NEXT="$MAJOR.$MINOR.$((PATCH + 1))" ;;
+              *) echo "::error::알 수 없는 bump: $BUMP"; exit 1 ;;
+            esac
+          fi
+
+          # 빌드를 돌리기 전에 막는다 — 태그가 겹치면 승격 자체가 성립하지 않는다
+          if git rev-parse -q --verify "refs/tags/app-v$NEXT" >/dev/null; then
+            echo "::error::태그 app-v$NEXT 가 이미 있습니다 (재빌드라면 skip_bump 를 켜세요)"
+            exit 1
+          fi
+
+          echo "bump=true" >> "$GITHUB_OUTPUT"
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "### 앱 승격 v$CURRENT → v$NEXT" >> "$GITHUB_STEP_SUMMARY"
+
+      # 빌드가 러너의 워킹 트리를 올리므로, 커밋 전이라도 여기서 바꾼 버전이 빌드에 들어간다
+      - name: app.json 버전 갱신
+        if: steps.version.outputs.bump == 'true'
+        env:
+          NEXT: ${{ steps.version.outputs.next }}
+        run: |
+          set -euo pipefail
+          # 0,/re/ 는 첫 일치만 바꾼다 — 뒤쪽 url·extraMavenRepos 줄을 건드리지 않는다
+          sed -i "0,/\"version\": \"[0-9][0-9.]*\"/s//\"version\": \"$NEXT\"/" apps/app/app.json
+          git diff --quiet apps/app/app.json && { echo "::error::버전이 갱신되지 않았습니다"; exit 1; }
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      # iOS 2건만 --auto-submit — Android 는 Play 제출이 수동이라 빌드까지만 돌린다
+      # (--platform all 로 묶으면 Android 까지 Play 에 올리려 해서 submit 설정이 없어 실패한다)
+      - name: EAS 빌드 트리거 (production)
+        working-directory: apps/app
+        run: |
+          set -euo pipefail
+          eas build --profile production --platform ios --auto-submit --non-interactive --no-wait
+          eas build --profile production --platform android --non-interactive --no-wait
+
+      - name: EAS 빌드 트리거 (production-dev)
+        working-directory: apps/app
+        run: eas build --profile production-dev --platform ios --auto-submit --non-interactive --no-wait
+
+      # 트리거가 다 통과한 뒤에 기록을 남긴다.
+      # 태그는 BRIDGE_GATE 의 minAppVersion 판단 근거이므로 (`git tag --contains <sha>`)
+      # 반드시 "실제로 빌드된 커밋"을 가리켜야 한다. 재빌드면 태그를 그 커밋으로 옮긴다 —
+      # 옛 커밋에 남아 있으면 그 사이 들어간 브릿지 핸들러가 미포함으로 판정돼 게이트가 잘못 막는다.
+      # dev 는 PR 필수 보호가 걸려 있어 이 푸시가 거부될 수 있다 (봇은 admin 이 아니라 우회 못 한다).
+      # 그때는 빌드가 이미 도는 중이니 아래를 로컬에서 직접 밀면 된다 — admin 은 통과한다.
+      #   git commit -am "chore: 앱 버전 v{버전}" && git tag app-v{버전} && git push origin dev --follow-tags
+      - name: 버전 커밋·태그 푸시
+        env:
+          NEXT: ${{ steps.version.outputs.next }}
+          BUMPED: ${{ steps.version.outputs.bump }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          if [ "$BUMPED" = "true" ]; then
+            git add apps/app/app.json
+            git commit -m "chore: 앱 버전 v$NEXT"
+            git tag "app-v$NEXT"
+            git push origin dev
+            git push origin "app-v$NEXT"
+            exit 0
+          fi
+
+          # 재빌드 — 새 커밋은 만들지 않고 태그만 지금 빌드한 커밋으로 옮긴다
+          TAG="app-v$NEXT"
+          if [ "$(git rev-parse -q --verify "refs/tags/$TAG" || true)" = "$(git rev-parse HEAD)" ]; then
+            echo "태그 $TAG 가 이미 이 커밋을 가리킵니다 — 그대로 둡니다"
+            exit 0
+          fi
+          git tag -f "$TAG"
+          git push -f origin "refs/tags/$TAG"
+          echo "태그 $TAG 를 $(git rev-parse --short HEAD) 로 옮겼습니다"
+
+      - name: 요약
+        if: always()
+        env:
+          NEXT: ${{ steps.version.outputs.next }}
+          BUMPED: ${{ steps.version.outputs.bump }}
+        run: |
+          {
+            echo "빌드 3건을 트리거했습니다. 진행 상황은 Discord 배포알림 스레드에서 확인하세요."
+            echo ""
+            if [ "$BUMPED" = "true" ]; then
+              echo "- 태그: \`app-v$NEXT\`"
+            else
+              echo "- 버전 범프 없이 v$NEXT 로 재빌드 — 태그 \`app-v$NEXT\` 를 이 커밋으로 옮김"
+            fi
+            echo "- iOS 2건은 완료 시 ASC 업로드까지 자동, 심사 제출은 ASC 에서 사람이 누릅니다"
+            echo "- Android 는 빌드만 — 스레드에서 Play 제출 담당자를 멘션합니다"
+            echo "- 빌드 실패로 다시 돌릴 때는 \`skip_bump\` 를 켜세요 (태그가 재빌드 커밋으로 따라옵니다)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/app-promote.yml
+++ b/.github/workflows/app-promote.yml
@@ -50,10 +50,14 @@ jobs:
       contents: write
     steps:
       # 어느 ref 에서 dispatch 하든 승격 대상은 항상 dev
+      # persist-credentials: false — 기본값이면 git 자격증명이 러너에 남아
+      # 뒤따르는 pnpm install·eas build(서드파티 코드)가 dev·릴리즈 태그를 밀 수 있다.
+      # 토큰은 마지막 푸시 스텝에서만 명시적으로 넣는다.
       - uses: actions/checkout@v4
         with:
           ref: dev
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 버전 계산
         id: version
@@ -83,6 +87,12 @@ jobs:
               exit 1
             fi
             NEXT="$INPUT_VERSION"
+            # 오타 한 번에 app.json 이 역행하는 것을 막는다 (태그 없는 낮은 버전은 중복 검사로 안 걸린다)
+            if [ "$NEXT" = "$CURRENT" ] || \
+               [ "$(printf '%s\n%s\n' "$CURRENT" "$NEXT" | sort -V | tail -1)" != "$NEXT" ]; then
+              echo "::error::입력 버전 $NEXT 이 현재 $CURRENT 보다 높지 않습니다"
+              exit 1
+            fi
           else
             IFS=. read -r MAJOR MINOR PATCH <<< "$CURRENT"
             case "$BUMP" in
@@ -151,17 +161,19 @@ jobs:
         env:
           NEXT: ${{ steps.version.outputs.next }}
           BUMPED: ${{ steps.version.outputs.bump }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          REMOTE="https://x-access-token:$GH_TOKEN@github.com/${{ github.repository }}.git"
 
           if [ "$BUMPED" = "true" ]; then
             git add apps/app/app.json
             git commit -m "chore: 앱 버전 v$NEXT"
             git tag "app-v$NEXT"
-            git push origin dev
-            git push origin "app-v$NEXT"
+            git push "$REMOTE" HEAD:dev
+            git push "$REMOTE" "refs/tags/app-v$NEXT"
             exit 0
           fi
 
@@ -172,7 +184,7 @@ jobs:
             exit 0
           fi
           git tag -f "$TAG"
-          git push -f origin "refs/tags/$TAG"
+          git push -f "$REMOTE" "refs/tags/$TAG"
           echo "태그 $TAG 를 $(git rev-parse --short HEAD) 로 옮겼습니다"
 
       - name: 요약

--- a/apps/hooks/README.md
+++ b/apps/hooks/README.md
@@ -3,26 +3,32 @@
 iOS 앱 배포 이벤트(EAS Build·Submit, App Store Connect)를 받아 허거덩 봇으로 Discord에 알리는 웹훅 수신기.
 `apps/web`과 분리된 **별도 Vercel 프로젝트**로 배포한다 — 봇 토큰을 서비스 런타임과 격리하고, 알림 코드가 프로덕트 배포에 묶이지 않게 하기 위함. (#618)
 
-## 동작 방식 — 버전당 스레드 1개
+## 동작 방식 — 버전당 스레드 1개 (양 플랫폼)
 
 첫 빌드 완료 이벤트가 배포알림 채널에 **루트 상태판**을 올리고 스레드를 연다.
 이후 이벤트는 최근 메시지에서 진행 중(`📦`로 시작) 루트를 찾아 상태판을 수정하고 스레드에 로그를 쌓는다.
 별도 DB 없이 Discord 메시지 자체가 상태 저장소다. 출시·반려 시 제목이 `🎉`/`❌`로 바뀌고 **스레드도 닫힌다(archive)**.
 
+한 사이클에서 iOS·Android 를 같이 빌드하므로(`app-promote.yml` 이 빌드 3건을 돌린다) 상태판이 양 플랫폼을 함께 담는다.
+
 ```
-📦 [iOS] PiKi v1.2.0 배포 진행 중          ← 이벤트마다 수정되는 상태판
-• 심사용: 빌드 42 심사 제출 완료
-• 팀 테스트용: 빌드 42 완료
-• TestFlight 처리: 2건 완료
-• 심사: ✅ 통과
-  └ 스레드: 🛠 빌드 완료 → ✅ 제출 완료 → … → 🎉 출시 완료!   ← append-only 로그
+📦 PiKi v1.3.0 배포 진행 중                 ← 이벤트마다 수정되는 상태판
+• iOS 심사용: 빌드 45 TestFlight 준비 완료
+• Android 심사용: 빌드 46 완료 — Play 제출 대기
+• iOS 팀 테스트용: 빌드 47 TestFlight 준비 완료
+• iOS 심사: 🎉 출시 완료
+  └ 스레드: 🛠 빌드 완료 ×3 → ✅ ASC 업로드 완료 → ✅ TestFlight 준비 완료 → … → 🎉 출시 완료!
 ```
 
-- **TestFlight 업로드 성공은 알리지 않는다** — 뒤따르는 ASC `TestFlight 처리 완료` 가 같은 얘기를 더 정확히 한다 (업로드 실패는 알린다)
+- **모든 줄은 `{플랫폼} {항목}`** — `production` 을 양 플랫폼으로 빌드하므로 프로필만으로 키를 잡으면 서로 덮어쓴다
+- **빌드 줄이 단계를 따라 진행한다** — `빌드 완료` → `ASC 업로드 완료` → `TestFlight 준비 완료`. 별도 집계 줄을 두지 않는다
+- **TestFlight 완료는 ASC API 로 빌드를 특정한다** — ASC 이벤트에는 빌드 식별 정보가 없어 `GET /v1/builds?filter[app]=…` 로 `VALID` 가 된 빌드 번호를 읽고 상태판의 `빌드 {번호}` 와 맞춘다. 키가 없거나 조회가 실패하면 중립 문구만 남긴다
+- **`eas submit` 은 ASC 업로드까지다** — 심사 제출은 ASC 에서 사람이 눌러야 하므로, 심사용 빌드가 준비되면 담당자를 멘션한다
+- **Android 는 빌드까지만** — Play 제출이 수동이라 빌드 완료 시 담당자를 멘션하고 aab 직접 다운로드 링크를 붙인다
+- **멘션은 스레드 로그에만 실린다** — 상태판은 메시지 수정이라 Discord 가 알림을 보내지 않는다
 - **심사 표시는 통과·출시·반려만** — 심사 대기는 알리지 않고, 수동/자동 출시 구분은 통과 후 전이 상태로 드러난다
 - **원시 상태값은 노출하지 않는다** — `PREPARE_FOR_SUBMISSION` 같은 ASC 내부 코드는 로그에 남기지 않는다
-- **TestFlight 처리는 건수 집계 + 빌드 번호 되짚기** — ASC 페이로드에는 `buildUploads` id 뿐이라 어느 빌드인지 알 수 없다. 상태판에 남은 이 사이클의 `빌드 {번호}` 를 읽어 붙이고, 번호가 둘 이상이면 `빌드 42·43 중 1건` 으로 적는다
-- **무시 케이스** — 제출 취소·미매핑 상태·테스트 ping·미구독 이벤트는 200으로 조용히 응답 (재시도 유발 금지)
+- **무시 케이스** — 개발 빌드·취소·미매핑 상태·테스트 ping·미구독 이벤트는 200으로 조용히 응답 (재시도 유발 금지)
 
 ## 엔드포인트
 
@@ -43,6 +49,11 @@ iOS 앱 배포 이벤트(EAS Build·Submit, App Store Connect)를 받아 허거�
 | `EAS_WEBHOOK_SECRET` | EAS 웹훅 서명 검증 키 (`eas webhook:create`에 넣은 값) |
 | `ASC_WEBHOOK_SECRET` | ASC 웹훅 서명 검증 키 (ASC 웹훅 등록 시 입력한 Secret) |
 | `EXPO_TOKEN` (선택) | EAS API로 빌드 프로필(심사용/팀 테스트용)·버전 조회. 없으면 해당 줄만 생략 |
+| `ASC_API_ISSUER_ID` (선택) | ASC API — TestFlight 처리 완료를 어느 빌드인지 특정하는 데 쓴다 |
+| `ASC_API_KEY_ID` (선택) | 같은 용도. 셋 중 하나라도 없으면 조회를 건너뛰고 중립 문구를 남긴다 |
+| `ASC_API_PRIVATE_KEY_B64` (선택) | `.p8` 을 base64 로 넣는다 (`base64 -i AuthKey_*.p8`) |
+| `DISCORD_PLAY_SUBMITTER_ID` (선택) | Android 빌드 완료 시 멘션할 Play 제출 담당자 |
+| `DISCORD_APPSTORE_SUBMITTER_ID` (선택) | 심사용 빌드 TestFlight 준비 시 멘션할 심사 제출 담당자 |
 
 봇에게 배포알림 채널의 **View Channel / Send Messages / Read Message History /
 Create Public Threads / Send Messages in Threads** 권한이 필요하다 (루트 검색·스레드 기록).
@@ -63,4 +74,4 @@ Create Public Threads / Send Messages in Threads** 권한이 필요하다 (루�
 
 tsconfig 에 `noEmit` 을 두지 않는다 — Vercel 이 함수를 빌드할 때 이 tsconfig 를 그대로 쓰므로, `noEmit` 이면 JS 가 하나도 나오지 않아 모든 함수가 `FUNCTION_INVOCATION_FAILED` 로 죽는다 (`check-types` 는 `tsc --noEmit` 플래그로 검사한다). NodeNext ESM 이라 상대 import 에는 `.js` 확장자가 필요하다.
 
-웹훅·Vercel 프로젝트 등록 등 1회성 셋업 진행 상황은 #618 체크리스트에서 관리한다.
+웹훅·Vercel 프로젝트 등록 등 1회성 셋업 진행 상황은 #618, 앱 승격 워크플로우는 #625 에서 관리한다.

--- a/apps/hooks/api/webhooks/asc.ts
+++ b/apps/hooks/api/webhooks/asc.ts
@@ -1,5 +1,6 @@
-import type { RootStateT } from '../../lib/release.js';
-import { updateReleaseThread } from '../../lib/release.js';
+import { listValidIosBuildNumbers } from '../../lib/asc.js';
+import type { ReleaseLineT, ReleaseUpdateT, RootStateT } from '../../lib/release.js';
+import { PROFILE_LABEL, buildOfLine, lineKey, parseLines, updateReleaseThread } from '../../lib/release.js';
 import { verifySignature } from '../../lib/verify.js';
 
 type AscWebhookPayloadT = {
@@ -17,6 +18,10 @@ type VersionStateT = {
   log: string;
   final?: { emoji: string; text: string };
 };
+
+const REVIEW_KEY = 'iOS 심사';
+const READY_TEXT = 'TestFlight 준비 완료';
+const SUBMIT_WAIT = ' — 심사 제출 대기';
 
 /** 심사 통과·출시·반려만 기록 — 수동/자동 출시는 통과 후 전이로 드러난다 */
 const VERSION_STATE: Record<string, VersionStateT> = {
@@ -44,23 +49,18 @@ const VERSION_STATE: Record<string, VersionStateT> = {
   },
 };
 
-const TESTFLIGHT_KEY = 'TestFlight 처리';
+const IOS_PROFILE_KEYS = Object.keys(PROFILE_LABEL).map(profile => lineKey('ios', profile));
+const REVIEW_PROFILE_KEY = lineKey('ios', 'production');
 
-/** 두 번째부터는 상태판 카운터만 올린다 — 어느 빌드인지 모르는 같은 줄이 반복되지 않도록 */
-const isFirstTestFlight = (lines: string[]) =>
-  !lines.some(line => line.startsWith(`• ${TESTFLIGHT_KEY}:`));
-
-/** ASC 페이로드에는 빌드 식별 정보가 없어, 상태판에 남은 이 사이클의 빌드 번호로 되짚는다 */
-const testFlightBuild = ({ title, lines }: RootStateT) => {
-  const version = /v[\d.]+/.exec(title)?.[0] ?? '';
-  const builds = [
-    ...new Set(lines.flatMap(line => (line.match(/빌드 [\d.]+/g) ?? []).map(tag => tag.slice(3)))),
-  ];
-  const buildText =
-    builds.length > 1 ? `빌드 ${builds.join('·')} 중 1건` : builds[0] && `빌드 ${builds[0]}`;
-  const detail = [version, buildText].filter(Boolean).join(' ');
-  return detail ? ` — ${detail}` : '';
-};
+/** ASC 이벤트에는 빌드 식별 정보가 없어, VALID 가 된 빌드 번호로 상태판 줄을 되짚는다 */
+const readyLines = (root: RootStateT, validBuilds: Set<string>) =>
+  parseLines(root).flatMap(line => {
+    if (!IOS_PROFILE_KEYS.includes(line.key)) return [];
+    if (line.value.includes(READY_TEXT)) return [];
+    const build = buildOfLine(line.value);
+    if (!build || !validBuilds.has(build)) return [];
+    return [{ key: line.key, build }];
+  });
 
 /** App Store Connect 웹훅 — TestFlight 빌드 처리·심사 상태 전이를 배포 스레드에 기록 */
 export async function POST(request: Request) {
@@ -87,28 +87,64 @@ export async function POST(request: Request) {
   /** 이벤트별로 attributes 키가 다르다 (build: newState, version: newValue) */
   const newState = attributes.newState ?? attributes.newValue ?? '';
 
-  let update: Parameters<typeof updateReleaseThread>[0] | null = null;
+  /** buildUploads id 로 단건 조회가 가능한지 판단하려면 실물 페이로드가 필요하다 (#625) */
+  console.warn(`ASC 웹훅 수신 ${eventType}:${newState} ${rawBody}`);
+
+  let update: ReleaseUpdateT | null = null;
   if (eventType === 'buildUploadStateUpdated') {
     if (newState === 'COMPLETE') {
-      update = {
-        log: root =>
-          isFirstTestFlight(root.lines)
-            ? `✅ TestFlight 처리 완료${testFlightBuild(root)} · 테스트 배포 가능`
-            : '',
-        line: {
-          key: TESTFLIGHT_KEY,
-          value: prev => `${(parseInt(prev ?? '', 10) || 0) + 1}건 완료`,
-        },
-      };
+      const validBuilds = await listValidIosBuildNumbers();
+      /** 조회 불가(키 없음·장애)면 어느 빌드인지 특정할 수 없어 중립 문구만 남긴다 */
+      if (!validBuilds) {
+        update = { log: '✅ TestFlight 처리 완료 — 테스트 배포 가능' };
+      } else {
+        const submitterId = process.env.DISCORD_APPSTORE_SUBMITTER_ID;
+        /** 심사용 빌드가 준비된 순간이 ASC 에서 심사 제출을 누를 시점이다 */
+        const isReviewReady = (root: RootStateT) =>
+          readyLines(root, validBuilds).some(line => line.key === REVIEW_PROFILE_KEY);
+
+        update = {
+          log: root =>
+            readyLines(root, validBuilds)
+              .map(line => {
+                const base = `✅ ${line.key} 빌드 ${line.build} ${READY_TEXT}`;
+                /** 멘션 문자열이 본문에 있어야 핑이 울린다 (allowed_mentions 만으로는 안 된다) */
+                return line.key === REVIEW_PROFILE_KEY && submitterId
+                  ? `${base} — <@${submitterId}> 심사 제출 필요`
+                  : base;
+              })
+              .join('\n'),
+          lines: root =>
+            readyLines(root, validBuilds).map(
+              (line): ReleaseLineT => ({
+                key: line.key,
+                value:
+                  line.key === REVIEW_PROFILE_KEY
+                    ? `빌드 ${line.build} ${READY_TEXT}${SUBMIT_WAIT}`
+                    : `빌드 ${line.build} ${READY_TEXT}`,
+              })
+            ),
+          mentionUserIds: root => (submitterId && isReviewReady(root) ? [submitterId] : []),
+        };
+      }
     } else if (newState === 'FAILED') {
-      update = { log: root => `❌ TestFlight 처리 실패${testFlightBuild(root)}` };
+      update = { log: '❌ TestFlight 처리 실패' };
     }
   } else if (eventType === 'appStoreVersionAppVersionStateUpdated') {
     const state = VERSION_STATE[newState];
     if (state) {
       update = {
         log: state.log,
-        line: { key: '심사', value: state.status },
+        lines: root => {
+          const reviewLine = parseLines(root).find(line => line.key === REVIEW_PROFILE_KEY);
+          return [
+            { key: REVIEW_KEY, value: state.status },
+            /** 심사가 돌기 시작했으면 제출 대기 안내는 지난 얘기다 (줄이 있을 때만 손댄다) */
+            ...(reviewLine?.value.includes(SUBMIT_WAIT)
+              ? [{ key: REVIEW_PROFILE_KEY, value: reviewLine.value.replace(SUBMIT_WAIT, '') }]
+              : []),
+          ];
+        },
         final: state.final,
       };
     }

--- a/apps/hooks/api/webhooks/eas-build.ts
+++ b/apps/hooks/api/webhooks/eas-build.ts
@@ -1,11 +1,18 @@
 import { escapeMarkdown } from '../../lib/discord.js';
-import { PROFILE_LABEL, buildTag, updateReleaseThread } from '../../lib/release.js';
+import {
+  PLATFORM_LABEL,
+  PROFILE_LABEL,
+  buildTag,
+  lineKey,
+  updateReleaseThread,
+} from '../../lib/release.js';
 import { verifySignature } from '../../lib/verify.js';
 
 type EasBuildPayloadT = {
   platform?: 'ios' | 'android';
   status?: 'finished' | 'errored' | 'canceled';
   buildDetailsPageUrl?: string;
+  artifacts?: { buildUrl?: string | null } | null;
   metadata?: {
     appVersion?: string | null;
     appBuildVersion?: string | null;
@@ -34,13 +41,14 @@ export async function POST(request: Request) {
     return Response.json({ error: 'invalid json' }, { status: 400 });
   }
 
-  /** iOS 스토어 파이프라인 외(안드로이드·취소·개발 빌드)는 스레드 대상이 아니다 */
+  /** 스토어 파이프라인 외(개발 빌드·취소)는 스레드 대상이 아니다 */
+  const platform = payload.platform ?? '';
   const profile = payload.metadata?.buildProfile ?? '';
-  if (payload.platform !== 'ios' || !PROFILE_LABEL[profile] || payload.status === 'canceled') {
-    return Response.json({ ok: true, skipped: `${payload.platform}:${profile}:${payload.status}` });
+  if (!PLATFORM_LABEL[platform] || !PROFILE_LABEL[profile] || payload.status === 'canceled') {
+    return Response.json({ ok: true, skipped: `${platform}:${profile}:${payload.status}` });
   }
 
-  const label = PROFILE_LABEL[profile];
+  const label = `${PLATFORM_LABEL[platform]} ${PROFILE_LABEL[profile]}`;
   const version = payload.metadata?.appVersion ?? null;
   const versionText = version
     ? ` v${version}${payload.metadata?.appBuildVersion ? ` (${payload.metadata.appBuildVersion})` : ''}`
@@ -50,21 +58,41 @@ export async function POST(request: Request) {
 
   const logLines: string[] = [];
   let lineValue: string;
+  const mentionUserIds: string[] = [];
   if (payload.status === 'finished') {
     lineValue = tag ? `${tag}완료` : '빌드 완료';
     logLines.push(`🛠 ${label}${versionText} 빌드 완료`);
+
+    /** Android 는 Play 제출이 수동이라 빌드 완료가 곧 담당자 호출 시점이다 */
+    if (platform === 'android') {
+      const submitterId = process.env.DISCORD_PLAY_SUBMITTER_ID;
+      if (submitterId) {
+        mentionUserIds.push(submitterId);
+        logLines[0] += ` — <@${submitterId}> Play 제출 필요`;
+      }
+      lineValue = `${lineValue} — Play 제출 대기`;
+    }
   } else {
     lineValue = tag ? `${tag}실패` : '빌드 실패';
     logLines.push(`❌ ${label}${versionText} 빌드 실패`);
     if (payload.error?.message) logLines.push(`• 원인: ${escapeMarkdown(payload.error.message)}`);
   }
-  if (payload.buildDetailsPageUrl) logLines.push(`• [빌드 상세](<${payload.buildDetailsPageUrl}>)`);
+
+  /** aab/ipa 직접 다운로드 — Play 제출은 파일을 사람이 올려야 해서 Android 만 붙인다 */
+  const artifactUrl = payload.artifacts?.buildUrl;
+  const links: string[] = [];
+  if (platform === 'android' && payload.status === 'finished' && artifactUrl) {
+    links.push(`[aab 다운로드](<${artifactUrl}>)`);
+  }
+  if (payload.buildDetailsPageUrl) links.push(`[빌드 상세](<${payload.buildDetailsPageUrl}>)`);
+  if (links.length) logLines.push(`• ${links.join(' · ')}`);
 
   try {
     await updateReleaseThread({
       log: logLines.join('\n'),
-      line: { key: label, value: lineValue },
+      lines: [{ key: lineKey(platform, profile), value: lineValue }],
       version,
+      mentionUserIds,
     });
   } catch (error) {
     console.error(error);

--- a/apps/hooks/api/webhooks/eas.ts
+++ b/apps/hooks/api/webhooks/eas.ts
@@ -1,7 +1,6 @@
-import { escapeMarkdown, sendDiscordMessage } from '../../lib/discord.js';
+import { escapeMarkdown } from '../../lib/discord.js';
 import { getEasBuildInfo } from '../../lib/eas.js';
-import type { ReleaseUpdateT } from '../../lib/release.js';
-import { PROFILE_LABEL, buildTag, updateReleaseThread } from '../../lib/release.js';
+import { PLATFORM_LABEL, PROFILE_LABEL, buildTag, lineKey, updateReleaseThread } from '../../lib/release.js';
 import { verifySignature } from '../../lib/verify.js';
 
 type EasSubmitPayloadT = {
@@ -15,7 +14,7 @@ type EasSubmitPayloadT = {
   } | null;
 };
 
-/** EAS Submit 웹훅 (eas webhook:create --event SUBMIT) — 배포 스레드에 제출 결과를 기록 */
+/** EAS Submit 웹훅 (eas webhook:create --event SUBMIT) — 배포 스레드에 업로드 결과를 기록 */
 export async function POST(request: Request) {
   const secret = process.env.EAS_WEBHOOK_SECRET;
   if (!secret) {
@@ -40,13 +39,10 @@ export async function POST(request: Request) {
   }
 
   const buildInfo = payload.turtleBuildId ? await getEasBuildInfo(payload.turtleBuildId) : null;
+  const platform = payload.platform ?? '';
   const profile = buildInfo?.buildProfile ?? '';
-  const label = PROFILE_LABEL[profile] ?? '';
+  const label = [PLATFORM_LABEL[platform], PROFILE_LABEL[profile]].filter(Boolean).join(' ');
 
-  /** iOS TestFlight 업로드 성공은 알리지 않는다 — 뒤따르는 ASC "처리 완료" 가 같은 얘기를 더 정확히 한다 */
-  if (payload.platform === 'ios' && payload.status === 'finished' && profile === 'production-dev') {
-    return Response.json({ ok: true, skipped: 'testflight-upload' });
-  }
   const versionText = buildInfo?.appVersion
     ? ` v${buildInfo.appVersion}${buildInfo.appBuildVersion ? ` (${buildInfo.appBuildVersion})` : ''}`
     : '';
@@ -58,13 +54,13 @@ export async function POST(request: Request) {
   const logLines: string[] = [];
   let lineValue: string;
   if (payload.status === 'finished') {
-    /** 프로필을 모르면 심사인지 TestFlight 인지 단정할 수 없어 중립 문구로 남긴다 */
-    const doneText = profile === 'production' ? '심사 제출 완료' : '제출 완료';
+    /** eas submit 은 스토어 업로드까지다 — 심사 제출은 ASC 에서 사람이 따로 눌러야 한다 */
+    const doneText = platform === 'ios' ? 'ASC 업로드 완료' : '스토어 업로드 완료';
     lineValue = `${tag}${doneText}`;
     logLines.push(['✅', subject, doneText].filter(Boolean).join(' '));
   } else {
-    lineValue = `${tag}제출 실패`;
-    logLines.push(['❌', subject, '스토어 제출 실패'].filter(Boolean).join(' '));
+    lineValue = `${tag}업로드 실패`;
+    logLines.push(['❌', subject, '스토어 업로드 실패'].filter(Boolean).join(' '));
     const errorMessage = payload.submissionInfo?.error?.message;
     if (errorMessage) logLines.push(`• 원인: ${escapeMarkdown(errorMessage)}`);
   }
@@ -74,18 +70,17 @@ export async function POST(request: Request) {
   if (payload.status === 'errored' && payload.submissionInfo?.logsUrl) {
     logLines.push(`• [제출 로그](<${payload.submissionInfo.logsUrl}>)`);
   }
-  const log = logLines.join('\n');
 
   try {
-    if (payload.platform === 'ios') {
-      const update: ReleaseUpdateT = { log, version: buildInfo?.appVersion ?? null };
-      /** 프로필을 모르면(EXPO_TOKEN 없음 등) 상태판 줄은 건드리지 않고 로그만 남긴다 */
-      if (PROFILE_LABEL[profile]) update.line = { key: label, value: lineValue };
-      await updateReleaseThread(update);
-    } else {
-      /** Android 는 스레드 사이클 밖 — 단건 알림으로 전송 */
-      await sendDiscordMessage(`[AND] PiKi ${log}`);
-    }
+    await updateReleaseThread({
+      log: logLines.join('\n'),
+      /** 프로필·플랫폼을 모르면(EXPO_TOKEN 없음 등) 상태판 줄은 건드리지 않고 로그만 남긴다 */
+      lines:
+        PLATFORM_LABEL[platform] && PROFILE_LABEL[profile]
+          ? [{ key: lineKey(platform, profile), value: lineValue }]
+          : [],
+      version: buildInfo?.appVersion ?? null,
+    });
   } catch (error) {
     console.error(error);
     return Response.json({ error: 'discord update failed' }, { status: 502 });

--- a/apps/hooks/lib/asc.ts
+++ b/apps/hooks/lib/asc.ts
@@ -1,0 +1,95 @@
+import { createSign } from 'node:crypto';
+
+const API_BASE = 'https://api.appstoreconnect.apple.com';
+const REQUEST_TIMEOUT_MS = 10_000;
+/** PiKi — filter[app] 를 빼면 계정의 다른 앱 빌드가 섞여 나온다 */
+const APP_ID = '6777101805';
+
+export type AscBuildT = { buildVersion: string; appVersion: string | null; processingState: string };
+
+const b64url = (input: Buffer | string) => Buffer.from(input).toString('base64url');
+
+/** ASC API 용 ES256 JWT — 키 3종 중 하나라도 없으면 null (조회를 건너뛴다) */
+const createToken = () => {
+  const issuerId = process.env.ASC_API_ISSUER_ID;
+  const keyId = process.env.ASC_API_KEY_ID;
+  const privateKeyB64 = process.env.ASC_API_PRIVATE_KEY_B64;
+  if (!issuerId || !keyId || !privateKeyB64) return null;
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = b64url(JSON.stringify({ alg: 'ES256', kid: keyId, typ: 'JWT' }));
+  const payload = b64url(
+    JSON.stringify({ iss: issuerId, iat: now, exp: now + 600, aud: 'appstoreconnect-v1' })
+  );
+
+  const signer = createSign('SHA256');
+  signer.update(`${header}.${payload}`);
+  /** JWT 는 DER 이 아니라 r||s raw 서명을 요구한다 */
+  const signature = signer.sign({
+    key: Buffer.from(privateKeyB64, 'base64'),
+    dsaEncoding: 'ieee-p1363',
+  });
+  return `${header}.${payload}.${b64url(signature)}`;
+};
+
+type BuildsResponseT = {
+  data?: {
+    attributes?: { version?: string | null; processingState?: string | null };
+    relationships?: { preReleaseVersion?: { data?: { id?: string } | null } };
+  }[];
+  included?: { id?: string; attributes?: { version?: string | null; platform?: string | null } }[];
+};
+
+/** iOS 빌드 목록 (최신 업로드순) — 키 없음·조회 실패 시 null */
+export const listAscIosBuilds = async (limit = 10): Promise<AscBuildT[] | null> => {
+  const token = createToken();
+  if (!token) return null;
+
+  const query = new URLSearchParams({
+    'filter[app]': APP_ID,
+    include: 'preReleaseVersion',
+    sort: '-uploadedDate',
+    limit: String(limit),
+  });
+
+  try {
+    const response = await fetch(`${API_BASE}/v1/builds?${query}`, {
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) {
+      console.error(`ASC 빌드 조회 실패 (HTTP ${response.status}) ${await response.text()}`);
+      return null;
+    }
+
+    const result = (await response.json()) as BuildsResponseT;
+    const preRelease = new Map(
+      (result.included ?? []).filter(item => item.id).map(item => [item.id, item.attributes ?? {}])
+    );
+
+    /** 플랫폼 필터는 서버에 걸지 않고 여기서 가린다 — 필터 키가 바뀌면 400 으로 조회 전체가 죽는다 */
+    return (result.data ?? []).flatMap(build => {
+      const version = build.attributes?.version;
+      if (!version) return [];
+      const pre = preRelease.get(build.relationships?.preReleaseVersion?.data?.id);
+      if (pre?.platform !== 'IOS') return [];
+      return [
+        {
+          buildVersion: version,
+          appVersion: pre?.version ?? null,
+          processingState: build.attributes?.processingState ?? '',
+        },
+      ];
+    });
+  } catch (error) {
+    console.error('ASC 빌드 조회 실패:', error);
+    return null;
+  }
+};
+
+/** TestFlight 처리가 끝난(VALID) iOS 빌드 번호 집합 — 조회 불가 시 null */
+export const listValidIosBuildNumbers = async () => {
+  const builds = await listAscIosBuilds();
+  if (!builds) return null;
+  return new Set(builds.filter(b => b.processingState === 'VALID').map(b => b.buildVersion));
+};

--- a/apps/hooks/lib/discord.ts
+++ b/apps/hooks/lib/discord.ts
@@ -40,8 +40,12 @@ const requireChannelId = () => {
   return channelId;
 };
 
-/** 외부 텍스트가 섞여도 멘션이 울리지 않도록 파싱 차단 */
-const messageBody = (content: string) => JSON.stringify({ content, allowed_mentions: { parse: [] } });
+/** 외부 텍스트가 섞여도 멘션이 울리지 않도록 파싱 차단 — 지정한 유저만 예외로 허용 */
+const messageBody = (content: string, mentionUserIds?: string[]) =>
+  JSON.stringify({
+    content,
+    allowed_mentions: mentionUserIds?.length ? { parse: [], users: mentionUserIds } : { parse: [] },
+  });
 
 export const sendDiscordMessage = async (content: string) => {
   await discordRequest(`/channels/${requireChannelId()}/messages`, {
@@ -91,8 +95,16 @@ export const archiveThread = async (threadId: string) => {
   });
 };
 
-export const postThreadMessage = async (threadId: string, content: string) => {
-  await discordRequest(`/channels/${threadId}/messages`, { method: 'POST', body: messageBody(content) });
+/** 멘션은 이 경로에만 실린다 — 상태판은 수정이라 Discord 가 알림을 보내지 않는다 */
+export const postThreadMessage = async (
+  threadId: string,
+  content: string,
+  mentionUserIds?: string[]
+) => {
+  await discordRequest(`/channels/${threadId}/messages`, {
+    method: 'POST',
+    body: messageBody(content, mentionUserIds),
+  });
 };
 
 /** 링크 라벨 인젝션(](url)) 차단용 Markdown 특수문자 이스케이프 */

--- a/apps/hooks/lib/release.ts
+++ b/apps/hooks/lib/release.ts
@@ -8,7 +8,7 @@ import {
 } from './discord.js';
 
 /** 진행 중 사이클 판별 마커 — 출시/반려 시 제목이 🎉/❌로 바뀌며 다음 사이클과 분리된다 */
-const OPEN_PREFIX = '📦 [iOS] PiKi';
+const OPEN_PREFIX = '📦 PiKi';
 const MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
 
 export const PROFILE_LABEL: Record<string, string> = {
@@ -16,21 +16,44 @@ export const PROFILE_LABEL: Record<string, string> = {
   'production-dev': '팀 테스트용',
 };
 
-/** 상태판 줄에 남기는 빌드 번호 — 빌드 식별 정보가 없는 ASC 이벤트가 되짚는 유일한 단서 */
+export const PLATFORM_LABEL: Record<string, string> = {
+  ios: 'iOS',
+  android: 'Android',
+};
+
+/** 상태판 줄 키 — 한 사이클에서 양 플랫폼을 같이 빌드하므로 프로필만으로는 서로 덮어쓴다 */
+export const lineKey = (platform: string, profile: string) =>
+  `${PLATFORM_LABEL[platform] ?? platform} ${PROFILE_LABEL[profile] ?? profile}`;
+
+/** 상태판 줄에 남기는 빌드 번호 — 빌드 식별 정보가 없는 ASC 이벤트가 되짚는 단서 */
 export const buildTag = (buildVersion?: string | null) => (buildVersion ? `빌드 ${buildVersion} ` : '');
 
+/** 줄 값에 적힌 빌드 번호 (`빌드 36 …` → `36`) */
+export const buildOfLine = (value: string) => /^빌드 (\d+)/.exec(value)?.[1] ?? null;
+
 export type RootStateT = { title: string; lines: string[] };
+
+export type ReleaseLineT = { key: string; value: string | ((prev: string | null) => string) };
 
 export type ReleaseUpdateT = {
   /** 스레드에 남길 로그 — 함수면 갱신 전 상태판 기반으로 계산 */
   log: string | ((root: RootStateT) => string);
-  /** 루트 상태판에서 갱신할 줄 — 함수면 기존 값 기반으로 계산 (카운터 등) */
-  line?: { key: string; value: string | ((prev: string | null) => string) };
+  /** 루트 상태판에서 갱신할 줄 — 함수면 갱신 전 상태판 기반으로 계산 */
+  lines?: ReleaseLineT[] | ((root: RootStateT) => ReleaseLineT[]);
   /** 알게 된 시점에 제목·스레드명에 1회 채워지는 버전 */
   version?: string | null;
   /** 사이클 종료 (출시·반려) 시 제목 교체 */
   final?: { emoji: string; text: string };
+  /** 스레드 로그에서 핑을 허용할 유저 — 상태판 수정으로는 알림이 가지 않는다 */
+  mentionUserIds?: string[] | ((root: RootStateT) => string[]);
 };
+
+/** `• 키: 값` 형태의 상태판 줄을 파싱 */
+export const parseLines = ({ lines }: RootStateT) =>
+  lines.flatMap(line => {
+    const matched = /^• ([^:]+): (.*)$/.exec(line);
+    return matched ? [{ key: matched[1] ?? '', value: matched[2] ?? '' }] : [];
+  });
 
 /** 진행 중 루트 상태판을 찾아(없으면 새로 열어) 갱신하고 스레드에 로그를 남긴다 */
 export const updateReleaseThread = async (update: ReleaseUpdateT) => {
@@ -49,22 +72,29 @@ export const updateReleaseThread = async (update: ReleaseUpdateT) => {
   if (!root) {
     root = await postChannelMessage(`${OPEN_PREFIX}${versionSuffix} 배포 진행 중`);
   }
-  await ensureThreadOnMessage(root.id, `iOS${versionSuffix} 배포`);
+  await ensureThreadOnMessage(root.id, `${versionSuffix.trim() || '앱'} 배포`);
 
   const [title = '', ...lines] = root.content.split('\n');
-  const log = typeof update.log === 'function' ? update.log({ title, lines }) : update.log;
+  const state: RootStateT = { title, lines };
+  const log = typeof update.log === 'function' ? update.log(state) : update.log;
+  const mentionUserIds =
+    typeof update.mentionUserIds === 'function'
+      ? update.mentionUserIds(state)
+      : update.mentionUserIds;
 
   let nextTitle = title;
   if (update.final) {
     const version = / v[\d.]+/.exec(nextTitle)?.[0] ?? '';
-    nextTitle = `${update.final.emoji} [iOS] PiKi${version} ${update.final.text}`;
+    nextTitle = `${update.final.emoji} PiKi${version} ${update.final.text}`;
   }
 
-  if (update.line) {
-    const prefix = `• ${update.line.key}:`;
+  const lineUpdates = typeof update.lines === 'function' ? update.lines(state) : (update.lines ?? []);
+  for (const lineUpdate of lineUpdates) {
+    const prefix = `• ${lineUpdate.key}:`;
     const index = lines.findIndex(line => line.startsWith(prefix));
     const prev = index >= 0 ? (lines[index]?.slice(prefix.length).trim() ?? null) : null;
-    const value = typeof update.line.value === 'function' ? update.line.value(prev) : update.line.value;
+    const value =
+      typeof lineUpdate.value === 'function' ? lineUpdate.value(prev) : lineUpdate.value;
     const nextLine = `${prefix} ${value}`;
     if (index >= 0) lines[index] = nextLine;
     else lines.push(nextLine);
@@ -72,7 +102,7 @@ export const updateReleaseThread = async (update: ReleaseUpdateT) => {
 
   await editChannelMessage(root.id, [nextTitle, ...lines].join('\n'));
   /** 빈 로그는 상태판만 갱신하라는 뜻 (중복 알림 억제) */
-  if (log) await postThreadMessage(root.id, log);
+  if (log) await postThreadMessage(root.id, log, mentionUserIds);
   /** 사이클이 끝났으면 스레드를 닫는다 — 글을 올린 뒤여야 다시 열리지 않는다 */
   if (update.final) {
     try {

--- a/apps/hooks/turbo.json
+++ b/apps/hooks/turbo.json
@@ -8,7 +8,12 @@
         "DISCORD_DEPLOY_CHANNEL_ID",
         "EAS_WEBHOOK_SECRET",
         "ASC_WEBHOOK_SECRET",
-        "EXPO_TOKEN"
+        "EXPO_TOKEN",
+        "ASC_API_ISSUER_ID",
+        "ASC_API_KEY_ID",
+        "ASC_API_PRIVATE_KEY_B64",
+        "DISCORD_PLAY_SUBMITTER_ID",
+        "DISCORD_APPSTORE_SUBMITTER_ID"
       ]
     }
   }


### PR DESCRIPTION
## 작업 요약

- 버전만 정해 워크플로우를 실행하면 태그가 찍히고 EAS 빌드 3건(production iOS·Android, production-dev iOS)이 돌도록 자동화합니다
- iOS 전용이던 배포 알림을 양 플랫폼 한 스레드로 통합합니다
- TestFlight 처리 완료를 ASC API로 빌드를 특정해 프로필별 줄에 기록합니다 (기존 건수 집계 제거)
- Android 빌드 완료 시 aab 다운로드 링크를 붙이고 Play 제출 담당자를, iOS 심사용 빌드가 준비되면 심사 제출 담당자를 멘션합니다
- `eas submit` 결과 문구를 `심사 제출 완료`에서 `ASC 업로드 완료`로 정정합니다

## 작업 세부 내용

앱 릴리즈가 전부 로컬 CLI였습니다. `app.json` 버전 수정·커밋·`app-v*` 태그·빌드 3건·제출을 사람이 순서대로 지켜야 했고, `app-v*` 태그는 BRIDGE_GATE의 `minAppVersion` 판단 근거라 빠뜨리면 안 되는데 태그를 잊거나 `app.json` 버전과 어긋나는 사고가 가능한 구조였습니다.

#618에서 배포 알림을 붙였지만 iOS 전용이었습니다. 실제로는 양 플랫폼을 항상 같이 빌드하므로 스레드 하나가 사이클 전체를 보여줘야 합니다.

### 상태판을 플랫폼 중립으로

기존 상태판은 제목이 `[iOS]` 로 고정이고 줄 키가 프로필 라벨뿐이었습니다. 그대로 Android를 받으면 **production iOS와 production Android가 같은 줄을 서로 덮어씁니다.** 모든 줄을 `{플랫폼} {항목}` 으로 바꿨습니다.

```
📦 PiKi v1.3.0 배포 진행 중
• iOS 심사용: 빌드 45 TestFlight 준비 완료
• Android 심사용: 빌드 46 완료 — Play 제출 대기
• iOS 팀 테스트용: 빌드 47 TestFlight 준비 완료
• iOS 심사: 🎉 출시 완료
```

- **빌드 줄이 단계를 따라 진행합니다** — `빌드 완료` → `ASC 업로드 완료` → `TestFlight 준비 완료`. 별도 집계 줄(`TestFlight 처리: 2건 완료`)을 없앴습니다
- **Android를 수용했습니다** — `eas-build.ts`가 `platform !== 'ios'`를 전부 skip 했고, `eas.ts`는 Android를 스레드 밖 단건 메시지(`[AND] PiKi …`)로 던지고 있었습니다. 둘 다 스레드 안으로 들였습니다
- **`updateReleaseThread`가 여러 줄 갱신과 멘션을 받습니다** — `line` 단건에서 `lines` 배열로 넓히고, 갱신 전 상태판을 받아 계산하는 함수형도 허용합니다 (ASC 이벤트가 상태판을 읽어 어느 줄을 고칠지 정해야 하므로)

### TestFlight 완료를 어느 빌드인지 특정

기존 구현은 "ASC 페이로드에 빌드 식별 정보가 없다"는 전제로 건수 카운터로 우회하고 있었습니다. 확인해 보니 **그 전제가 실물 페이로드로 검증된 적이 없었고**, 두 프로필의 빌드 번호는 항상 다릅니다 (`autoIncrement`가 앱 전체로 증가: v1.2.2는 production 36, production-dev 37). 번호만 알면 프로필이 특정됩니다.

ASC API 키를 발급해 조회가 되는 것을 실측했습니다.

```
GET /v1/builds?filter[app]=…&include=preReleaseVersion&sort=-uploadedDate
  빌드 37  v1.2.2  IOS  processingState=VALID
  빌드 36  v1.2.2  IOS  processingState=VALID
```

- ASC 이벤트가 처리 완료를 알리면 위 조회로 지금 `VALID`가 된 빌드 번호를 얻고, 상태판에 적힌 `빌드 {번호}`와 맞춰 프로필 줄을 갱신합니다
- **`filter[app]`은 필수입니다** — 붙이지 않으면 계정 전체를 반환해 다른 앱 빌드를 집습니다 (확인 중 실제로 섞여 나왔습니다)
- 키 3종 중 하나라도 없거나 조회가 실패하면 중립 문구만 남기고 진행합니다. 알림 자체가 죽지 않는 쪽을 택했습니다

### 제출 담당자 멘션

| 시점 | 대상 | 문구 |
| --- | --- | --- |
| Android 빌드 완료 | Play 제출 담당자 | `Play 제출 필요` |
| iOS 심사용 TestFlight 준비 완료 | App Store 심사 제출 담당자 | `심사 제출 필요` |

iOS 멘션을 업로드 완료가 아니라 **처리 완료 시점**에 두는 이유: 애플이 처리를 끝내기 전에는 ASC에서 버전에 빌드를 붙일 수 없어, 업로드 시점에 부르면 가서 할 게 없습니다.

작업 중 발견해 같이 고친 것 두 가지입니다.

- **멘션은 스레드 로그에만 싣습니다** — 상태판은 `editChannelMessage`로 수정되는 메시지고, Discord는 메시지 수정으로 알림을 보내지 않습니다. 상태판에 넣으면 핑이 안 울립니다
- **`allowed_mentions`만으로는 부족합니다** — 본문에 `<@id>` 문자열이 있어야 핑이 울립니다. `messageBody`가 `parse: []`로 모든 멘션을 무력화하고 있어 지정 유저만 허용하는 인자를 더했습니다

### `eas submit` 결과 문구 정정

`profile === 'production'`일 때 결과를 `심사 제출 완료`로 적고 있었습니다. `eas submit`은 **App Store Connect 업로드까지**고 심사 제출 기능이 없습니다 (`eas.json`의 `submit` 설정에도 걸 옵션이 없습니다). `ASC 업로드 완료`로 바꿨습니다.

두 iOS 프로필 모두 같은 경로(업로드 → TestFlight 처리)로 가고, 차이는 나중에 어느 빌드를 심사에 붙이느냐뿐입니다. #618 실배포에서 `TestFlight 처리: 2건`이 찍힌 게 그 증거입니다.

### 승격 워크플로우 (`app-promote.yml`)

`workflow_dispatch`로 bump(minor/patch/major) 선택 또는 버전 직접 입력.

```
버전 계산 · 태그 중복 검사 → app.json 갱신 → 빌드 3건 트리거 → 버전 커밋 · 태그 푸시
```

- **iOS 2건만 `--auto-submit`** — `--platform all` 한 커맨드로 묶지 못한 이유: 자동 제출이 빌드된 모든 플랫폼을 제출하므로 Android까지 Play에 올리려 하고, `submit` 설정이 없어 실패합니다. 빌드 3건이라는 결과는 같습니다
- **`--no-wait`** — 빌드는 EAS 서버에서 20-30분 돌고 진행 상황은 이 PR이 고친 알림이 보고합니다. 러너를 붙잡을 이유가 없습니다
- **`app.json`은 정규식으로 다룹니다** — 주석이 섞인 JSONC라 `jq` 파싱이 실패하는 것을 확인했습니다. `0,/re/`로 첫 일치(버전 줄)만 치환합니다
- **네이티브 설정 파일은 러너에 없어도 됩니다** — `GoogleService-Info.plist` 등이 EAS 파일 시크릿에 있어 빌드 서버에서 주입됩니다 (로컬 `eas credentials`가 introspect 단계에서 실패하는 것도 같은 이유)

**순서 결정: 빌드 트리거를 먼저 둡니다.**

| | 트리거 실패 시 | 컴파일 실패 시 |
| --- | --- | --- |
| 태그 먼저 (채택 안 함) | 태그만 남고 빌드 없음, 같은 버전 재실행이 중복 검사에 막힘 | 태그 유지 |
| 빌드 먼저 (채택) | git이 깨끗해 그대로 재실행 | 태그 유지, `skip_bump`로 재시도 |

트리거 성공은 "큐에 들어갔다"(인증·설정·업로드 통과)까지고 컴파일 성공이 아닙니다. 그런데 막고 싶었던 실패가 정확히 그 구간이고, 그 실패는 아무 빌드도 안 돈 상태라 git이 깨끗해야 재실행이 됩니다. 앱은 웹과 달리 빌드 시점에 태그를 읽는 것이 없어 태그가 먼저일 이유도 없습니다.

**`skip_bump` 입력 — 재빌드 시 태그를 실제로 빌드된 커밋으로 옮깁니다.** 컴파일 실패를 고치면 그 수정이 새 커밋으로 올라가는데, 태그가 옛 버전 범프 커밋에 남아 있으면 그 사이 들어간 브릿지 핸들러가 `git tag --contains`에서 미포함으로 판정돼 게이트가 잘못 막습니다. 커밋은 지우지 않습니다 (공유 브랜치 히스토리를 되돌릴 수 없고 `app.json` 내용 자체는 맞습니다). 태그만 이동합니다.

### 검토 후 채택하지 않은 안

`dev`는 PR 필수 보호가 걸려 있어 워크플로우의 버전 커밋 푸시가 거부될 수 있습니다 (봇은 admin이 아니라 우회하지 못합니다). 태그 푸시는 보호가 없어 문제없습니다.

| 안 | 비용 | 판단 |
| --- | --- | --- |
| admin PAT 발급 | 토큰 만료 관리 | 버튼 한 번 UX는 지키지만 관리 부담 |
| 버전 범프를 별도 PR로 | 어느 PR이 마지막일지 미리 알 수 없음 | 성립하지 않음 |
| `dev` 보호 완화 | PR 필수와 필수 검사를 둘 다 꺼야 함 | 워크플로우 하나 때문에 레포 규칙을 끄는 것 |
| 실패 시 수동 푸시 (채택) | 거부되면 명령 한 줄 | 빌드는 이미 돌아 릴리즈는 진행됨 |

빌드가 푸시보다 먼저라 푸시가 거부돼도 릴리즈 자체는 진행됩니다. 남는 일은 커밋과 태그를 미는 것뿐이라 그 명령을 워크플로우 주석에 적어 두고 기본 토큰으로 갑니다.

### 검증

핸들러를 실제로 실행해 확인했습니다. Discord API와 ASC API를 `fetch` 가로채기로 대역하고 실제 P-256 키로 서명해, 빌드 3건에서 출시까지 10개 이벤트를 순서대로 흘려 최종 상태판과 스레드 로그를 대조했습니다.

- 같은 ASC 이벤트를 재전송해도 스레드 로그가 중복으로 남지 않는 것 (멱등)
- 개발 빌드(`development` 프로필)와 심사 대기(`WAITING_FOR_REVIEW`)가 200으로 조용히 무시되는 것
- 빌드 45는 심사용 줄, 47은 팀 테스트용 줄로 각각 정확히 귀속되는 것

이 과정에서 출시 완료 후에도 `심사 제출 대기` 문구가 남는 것을 발견해, 심사 상태가 전이될 때 지우도록 고쳤습니다.

### 남은 것과 한계

- **머지 후 Vercel 재배포 시점부터 적용됩니다.** 머지 전에 빌드를 돌리면 옛 핸들러가 처리해 Android가 버려집니다
- 환경변수는 등록 완료 (Vercel `apps/hooks` ASC API 키 3건·담당자 Discord ID 2건, GitHub `EXPO_TOKEN`). 남은 확인은 EAS에 App Store Connect API 키가 등록돼 있는지입니다
- ASC API 키를 특정 앱으로 제한할 수 없어 계정의 앱 전체에 접근됩니다
- 심사 제출 자동화(`appStoreVersionSubmissions`)는 되돌리기가 비싼 동작이라 넣지 않았습니다. 첫 승격에서 키 권한(`App Manager` 여부)을 확인한 뒤 후속으로 검토합니다
- 심사 반려 후 같은 버전으로 재빌드하면 사이클이 종료된 상태라 새 스레드가 생깁니다

## 스크린샷

<!-- 첫 승격 후 Discord 배포 스레드 캡처 -->

## 연관 이슈

closes #625


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - iOS와 Android 앱 배포 상태를 하나의 릴리스 스레드에서 확인할 수 있습니다.
  - 플랫폼별 빌드 진행 상황, 스토어 업로드 결과, 심사 제출 대기 상태가 상태판에 표시됩니다.
  - Android 빌드 완료 시 담당자 알림과 AAB 다운로드 링크가 제공됩니다.
  - 릴리스 알림에서 필요한 담당자만 선택적으로 멘션됩니다.

- **문서**
  - 양 플랫폼을 포함한 배포 절차와 상태판 사용 방법을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->