### PR TITLE
chore: presigned 발급에 contentLength 를 실어 5MB 상한을 서버가 강제하게 전환

### DIFF
--- a/apps/web/e2e/specs/mypage/profileImageEdit.spec.ts
+++ b/apps/web/e2e/specs/mypage/profileImageEdit.spec.ts
@@ -26,11 +26,20 @@ test('프로필 이미지를 고르면 크롭 에디터가 열리고, 완료하�
   /** S3 직접 PUT — 서명과 어긋나면 실서버가 거부하므로 Content-Type·바이트를 검증한다 */
   let putContentType: string | undefined;
   let putBodyPrefixHex: string | undefined;
+  let putBodyByteLength: number | undefined;
   await page.route(MOCK_UPLOAD_URL, async route => {
     putContentType = route.request().headers()['content-type'];
     putBodyPrefixHex = route.request().postDataBuffer()?.subarray(0, 3).toString('hex');
+    putBodyByteLength = route.request().postDataBuffer()?.byteLength;
     await route.fulfill({ status: 200, body: '' });
   });
+
+  /** presign 요청 body 캡처 — contentLength 는 서명에 묶이므로 PUT 본문 바이트 수와 같아야 한다 */
+  const presignRequestPromise = page.waitForRequest(
+    request =>
+      request.method() === 'POST' &&
+      new URL(request.url()).pathname === ENDPOINTS.USER_PROFILE_IMAGE_PRESIGNED
+  );
 
   await page.goto('/mypage/edit');
 
@@ -57,6 +66,10 @@ test('프로필 이미지를 고르면 크롭 에디터가 열리고, 완료하�
   expect(putContentType).toBe('image/jpeg');
   // JPEG SOI 마커 — presign contentType 과 실제 바이트가 일치해야 서버 USER-011 을 피한다
   expect(putBodyPrefixHex).toBe('ffd8ff');
+  /** 어긋나면 실서버에선 S3 403 이 일반 업로드 실패로만 보이므로, 계약 위반은 여기서 잡는다 */
+  const presignBody = (await presignRequestPromise).postDataJSON() as { contentLength?: number };
+  expect(putBodyByteLength).toBeGreaterThan(0);
+  expect(presignBody.contentLength).toBe(putBodyByteLength);
 });
 
 test.describe('마우스(fine pointer) 환경', () => {

--- a/apps/web/src/apis/postProfileImagePresignedUrl.ts
+++ b/apps/web/src/apis/postProfileImagePresignedUrl.ts
@@ -1,6 +1,6 @@
 import { ENDPOINTS } from '@/consts/api';
 import type { ApiResponseT } from '@/types/api';
-import type { PresignedImageUploadT } from '@/types/image';
+import type { PresignedImageResponseT } from '@/types/image';
 import type { PostProfileImagePresignedUrlRequestT } from '@/types/user';
 
 import { clientApi } from './client';
@@ -11,7 +11,7 @@ import { clientApi } from './client';
  * 위시/토너먼트와 달리 `uploads` 배열이 아닌 단건 flat 응답이다.
  */
 export const postProfileImagePresignedUrl = async (body: PostProfileImagePresignedUrlRequestT) => {
-  const { data } = await clientApi.post<ApiResponseT<PresignedImageUploadT>>(
+  const { data } = await clientApi.post<ApiResponseT<PresignedImageResponseT>>(
     ENDPOINTS.USER_PROFILE_IMAGE_PRESIGNED,
     body
   );

--- a/apps/web/src/apis/putImageToS3.ts
+++ b/apps/web/src/apis/putImageToS3.ts
@@ -1,9 +1,9 @@
 import axios from 'axios';
 
-import type { PresignedImageUploadT } from '@/types/image';
+import type { PresignedImageResponseT } from '@/types/image';
 import { createS3UploadError } from '@/utils/apiError';
 
-export const putImageToS3 = async (upload: PresignedImageUploadT, file: File) => {
+export const putImageToS3 = async (upload: PresignedImageResponseT, file: File) => {
   try {
     await axios.put(upload.uploadUrl, file, {
       headers: { 'Content-Type': upload.contentType },

--- a/apps/web/src/hooks/useImagePicker.ts
+++ b/apps/web/src/hooks/useImagePicker.ts
@@ -1,6 +1,12 @@
 'use client';
 
-import { type ImagePickerSuccessPayloadT, WEBBRIDGE_MESSAGE_TYPE } from '@piki/core';
+import {
+  ERROR_CODE,
+  ERROR_MESSAGE_MAP,
+  type ImagePickerSuccessPayloadT,
+  MAX_IMAGE_UPLOAD_BYTES,
+  WEBBRIDGE_MESSAGE_TYPE,
+} from '@piki/core';
 import type { ChangeEvent } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
@@ -10,9 +16,6 @@ import { nativeImageToFile } from '@/utils/handleImage';
 import { WebBridge, isWebview } from '@/utils/webBridge';
 
 const DEFAULT_MAX_COUNT = 5;
-
-const MAX_IMAGE_FILE_SIZE_MB = 5;
-const MAX_IMAGE_FILE_SIZE_BYTES = MAX_IMAGE_FILE_SIZE_MB * 1024 * 1024;
 
 type ImagePickerResultT = {
   files: File[];
@@ -54,12 +57,11 @@ export const useImagePicker = ({
 
   const handleImagesSelect = useCallback(
     async ({ files, skippedCount }: ImagePickerResultT) => {
-      // 한도 초과 파일은 처리 전에 거른다 (웹/웹뷰 공통 경로).
-      const validFiles = files.filter(file => file.size <= MAX_IMAGE_FILE_SIZE_BYTES);
+      /** 한도 초과 파일은 처리 전에 거른다 */
+      const validFiles = files.filter(file => file.size <= MAX_IMAGE_UPLOAD_BYTES);
       const oversizedCount = files.length - validFiles.length;
-      if (oversizedCount > 0) {
-        toast.error(`${MAX_IMAGE_FILE_SIZE_MB}MB 이하 이미지만 업로드할 수 있어요.`);
-      }
+      if (oversizedCount > 0) 
+        toast.error(ERROR_MESSAGE_MAP[ERROR_CODE.UPLOAD_SIZE_EXCEEDED]);
       if (validFiles.length === 0) return;
 
       setIsPending(true);

--- a/apps/web/src/hooks/usePatchMe.ts
+++ b/apps/web/src/hooks/usePatchMe.ts
@@ -17,7 +17,10 @@ export const usePatchMe = () => {
       let imageKey: string | undefined;
 
       if (image) {
-        const upload = await postProfileImagePresignedUrl({ contentType: image.type });
+        const upload = await postProfileImagePresignedUrl({
+          contentType: image.type,
+          contentLength: image.size,
+        });
         await putImageToS3(upload, image);
         imageKey = upload.imageKey;
       }

--- a/apps/web/src/hooks/usePostTournamentOCR.ts
+++ b/apps/web/src/hooks/usePostTournamentOCR.ts
@@ -27,7 +27,7 @@ export const usePostTournamentOCR = (tournamentId: number) => {
   } = useMutation({
     mutationFn: async (files: File[]) => {
       const { uploads } = await postTournamentItemPresignedUrl(tournamentId, {
-        contentTypes: files.map(file => file.type),
+        images: files.map(file => ({ contentType: file.type, contentLength: file.size })),
       });
 
       /** 일부 실패 시 전체 실패 처리 */

--- a/apps/web/src/hooks/usePostWishOCR.ts
+++ b/apps/web/src/hooks/usePostWishOCR.ts
@@ -24,7 +24,7 @@ export const usePostWishOCR = () => {
   } = useMutation({
     mutationFn: async (files: File[]) => {
       const { uploads } = await postWishPresignedUrl({
-        contentTypes: files.map(file => file.type),
+        images: files.map(file => ({ contentType: file.type, contentLength: file.size })),
       });
 
       /** 일부 실패 시 전체 실패 처리 */

--- a/apps/web/src/types/image.ts
+++ b/apps/web/src/types/image.ts
@@ -3,7 +3,7 @@ export type PresignedImageRequestT = {
   contentLength: number;
 };
 
-export type PresignedImageUploadT = {
+export type PresignedImageResponseT = {
   imageKey: string;
   uploadUrl: string;
   contentType: string;

--- a/apps/web/src/types/image.ts
+++ b/apps/web/src/types/image.ts
@@ -1,3 +1,8 @@
+export type PresignedImageRequestT = {
+  contentType: string;
+  contentLength: number;
+};
+
 export type PresignedImageUploadT = {
   imageKey: string;
   uploadUrl: string;

--- a/apps/web/src/types/tournament.ts
+++ b/apps/web/src/types/tournament.ts
@@ -1,5 +1,5 @@
 import type { TOURNAMENT_PLAY_TYPE, TOURNAMENT_STATUS } from '@/consts/tournament';
-import type { PresignedImageRequestT, PresignedImageUploadT } from '@/types/image';
+import type { PresignedImageRequestT, PresignedImageResponseT } from '@/types/image';
 import type { ItemStatusT } from '@/types/item';
 
 export type TournamentStatusT = (typeof TOURNAMENT_STATUS)[keyof typeof TOURNAMENT_STATUS];
@@ -48,7 +48,7 @@ export type PostTournamentItemPresignedUrlRequestT = {
 };
 
 export type PostTournamentItemPresignedUrlResponseT = {
-  uploads: PresignedImageUploadT[];
+  uploads: PresignedImageResponseT[];
 };
 
 export type PostTournamentItemImagesRequestT = {

--- a/apps/web/src/types/tournament.ts
+++ b/apps/web/src/types/tournament.ts
@@ -1,5 +1,5 @@
 import type { TOURNAMENT_PLAY_TYPE, TOURNAMENT_STATUS } from '@/consts/tournament';
-import type { PresignedImageUploadT } from '@/types/image';
+import type { PresignedImageRequestT, PresignedImageUploadT } from '@/types/image';
 import type { ItemStatusT } from '@/types/item';
 
 export type TournamentStatusT = (typeof TOURNAMENT_STATUS)[keyof typeof TOURNAMENT_STATUS];
@@ -44,7 +44,7 @@ export type GetTournamentListResponseT = {
 }[];
 
 export type PostTournamentItemPresignedUrlRequestT = {
-  contentTypes: string[];
+  images: PresignedImageRequestT[];
 };
 
 export type PostTournamentItemPresignedUrlResponseT = {

--- a/apps/web/src/types/user.ts
+++ b/apps/web/src/types/user.ts
@@ -1,3 +1,5 @@
+import type { PresignedImageRequestT } from '@/types/image';
+
 /** 유저 식별 타입: GUEST(비회원), MEMBER(회원) */
 export type UserIdentityTypeT = 'GUEST' | 'MEMBER';
 
@@ -36,10 +38,7 @@ export type PatchMeRequestT = {
 };
 
 /** 프로필 이미지 업로드 URL 발급 요청 */
-export type PostProfileImagePresignedUrlRequestT = {
-  /** 올릴 이미지의 MIME 타입 (png · jpeg · webp · heic · heif) */
-  contentType: string;
-};
+export type PostProfileImagePresignedUrlRequestT = PresignedImageRequestT;
 
 /** 닉네임 중복 체크 응답 */
 export type GetNicknameCheckResponseT = {

--- a/apps/web/src/types/wish.ts
+++ b/apps/web/src/types/wish.ts
@@ -1,4 +1,4 @@
-import type { PresignedImageRequestT, PresignedImageUploadT } from './image';
+import type { PresignedImageRequestT, PresignedImageResponseT } from './image';
 import type { ItemT } from './item';
 
 export type WishT = {
@@ -35,7 +35,7 @@ export type PostWishPresignedUrlRequestT = {
 };
 
 export type PostWishPresignedUrlResponseT = {
-  uploads: PresignedImageUploadT[];
+  uploads: PresignedImageResponseT[];
 };
 
 export type PostWishImagesRequestT = {

--- a/apps/web/src/types/wish.ts
+++ b/apps/web/src/types/wish.ts
@@ -1,4 +1,4 @@
-import type { PresignedImageUploadT } from './image';
+import type { PresignedImageRequestT, PresignedImageUploadT } from './image';
 import type { ItemT } from './item';
 
 export type WishT = {
@@ -31,7 +31,7 @@ export type PostWishLinkResponseT = {
 };
 
 export type PostWishPresignedUrlRequestT = {
-  contentTypes: string[];
+  images: PresignedImageRequestT[];
 };
 
 export type PostWishPresignedUrlResponseT = {

--- a/packages/core/src/consts/errorCode.ts
+++ b/packages/core/src/consts/errorCode.ts
@@ -125,6 +125,8 @@ export const ERROR_MESSAGE_MAP = {
   /** UPLOAD */
   'UPLOAD-001': '올바르지 않은 이미지 업로드 정보예요. 업로드를 다시 시도해 주세요.',
   'UPLOAD-002': '아직 업로드되지 않은 이미지예요. 업로드를 마친 뒤 다시 시도해 주세요.',
+  'UPLOAD-003': '이미지는 5MB 까지 올릴 수 있어요.',
+  'UPLOAD-004': '이미지 크기 정보가 올바르지 않아요.',
 
   /** PRODUCTIMAGE */
   'PRODUCTIMAGE-001': '빈 이미지 파일은 올릴 수 없어요.',
@@ -262,6 +264,8 @@ export const ERROR_CODE = {
   /** 이미지 업로드 */
   UPLOAD_INVALID_KEY: 'UPLOAD-001',
   UPLOAD_NOT_UPLOADED: 'UPLOAD-002',
+  UPLOAD_SIZE_EXCEEDED: 'UPLOAD-003',
+  UPLOAD_INVALID_SIZE: 'UPLOAD-004',
 
   /** 상품 이미지 */
   PRODUCT_IMAGE_EMPTY_IMAGE: 'PRODUCTIMAGE-001',

--- a/packages/core/src/consts/image.ts
+++ b/packages/core/src/consts/image.ts
@@ -1,3 +1,6 @@
+/** 이미지 업로드 용량 상한 - 5MB */
+export const MAX_IMAGE_UPLOAD_BYTES = 5 * 1024 * 1024;
+
 export const SUPPORTED_IMAGE_MIME_TYPES: readonly string[] = [
   'image/png',
   'image/jpeg',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,7 @@ export {
   S3_UPLOAD_ERROR_MESSAGE,
   SERVER_ERROR_MESSAGE,
 } from './consts/errorCode';
-export { SUPPORTED_IMAGE_MIME_TYPES } from './consts/image';
+export { MAX_IMAGE_UPLOAD_BYTES, SUPPORTED_IMAGE_MIME_TYPES } from './consts/image';
 export {
   PUSH_NOTIFICATION_TYPE,
   WEBBRIDGE_MESSAGE_TYPE,


### PR DESCRIPTION

## 작업 요약

- 이미지 presigned URL 발급 요청에 파일 바이트 수(`contentLength`)를 실어 보내, 5MB 상한을 클라 필터가 아닌 S3 서명이 직접 강제하게 합니다
- 5MB 상한 상수와 초과 안내 문구를 `@piki/core` 단일 소스로 통일합니다
- 에러 카탈로그에 `UPLOAD-003`(5MB 초과)·`UPLOAD-004`(크기 정보 오류)를 추가합니다

## 작업 세부 내용

기존에는 presigned 발급 시 Content-Type 만 서명에 묶여 있어, 서명 유효 시간(5분) 안이면 **어떤 크기든** S3 에 올라갔습니다. 용량 방어선이 `useImagePicker` 의 클라 필터 하나뿐이라 우회 가능했고, 서버가 TeamPiKi/core#1053 으로 `contentLength` 선택 필드를 열어 이를 서명에 묶을 수 있게 되어 클라 전환을 진행합니다. (서버 후속 PR 이 미지정 요청을 400 으로 막을 예정이라 이 전환이 그 선행 조건입니다)

### presign 요청에 contentLength 전달

- 위시·토너먼트: `contentTypes: string[]` → `images: { contentType, contentLength }[]` (`usePostWishOCR` · `usePostTournamentOCR`)
- 프로필: `contentLength` 필드 추가 (`usePatchMe`)
- 세 경로(웹 input · 웹뷰 브릿지 · 프로필 크롭) 모두 PUT 직전의 `File`/`Blob` 이 곧 PUT 본문이라, 값은 그 객체의 **`.size` 하나로 통일**됩니다 — 경로별 분기 없음
  - 프로필은 원본이 아니라 **크롭 산출물**의 크기여야 해서 `usePatchMe` 가 받는 `image.size` 를 사용 (주석으로 명시)
- `putImageToS3` 는 무변경 — `Content-Length` 는 fetch/XHR 에서 수동 설정이 금지된 헤더로, 브라우저가 본문에서 자동 계산합니다
- 크기 계산이 전부 웹에서 일어나 브릿지 메시지·payload 가 그대로이므로 **앱 릴리즈 불필요** (`BRIDGE_GATE` 등록 대상 아님)

### 타입 정리

- 요청 단건 타입 `PresignedImageRequestT { contentType, contentLength }` 를 `types/image.ts` 에 추가 — 위시·토너먼트가 배열로 공유, 단건 flat 인 프로필 `PostProfileImagePresignedUrlRequestT` 는 alias 로 재사용
- 기존 응답 타입 `PresignedImageUploadT` 를 `PresignedImageResponseT` 로 rename — Request/Response 짝 통일

### 5MB 상한 단일 소스화 (`@piki/core`)

- `useImagePicker` 지역 상수였던 5MB 상한을 `MAX_IMAGE_UPLOAD_BYTES` 로 올려 서버 `UploadSize.MAX_BYTES`(5,242,880) 와 한곳에서 맞춤
- 에러 카탈로그에 `UPLOAD-003` · `UPLOAD-004` 추가
- 선차단 토스트 문구를 리터럴 대신 `ERROR_MESSAGE_MAP[ERROR_CODE.UPLOAD_SIZE_EXCEEDED]` 참조로 교체 — 서버 거절 문구("이미지는 5MB 까지 올릴 수 있어요.")와 어긋날 여지를 제거

### e2e — 계약 위반을 잡는 유일한 자리

- `profileImageEdit.spec.ts` 에 presign 요청 body 의 `contentLength` == S3 PUT 본문 바이트 수 단언 추가 (빈 본문 0 == 0 통과 방지용 `> 0` 가드 포함)
- 어긋남은 실서버에서 S3 403 → `S3UploadError` → 전역 처리로 흡수되어 일반 업로드 실패로만 보이므로, 이 테스트가 계약 위반을 잡는 유일한 지점입니다

### 검증

- 임시 Playwright 스펙으로 위시 이미지 담기(웹 input) 경로도 presign body·PUT 바이트 일치, 초과 파일 선차단·정상 파일만 발급 요청에 실리는 것 확인 (검증 후 제거)
- **dev 실서버 확인** — 발급된 URL 의 `X-Amz-SignedHeaders` 에 `content-length` 가 포함되고,
  - 선언 크기 == 실제 바이트: 200 업로드 성공
  - 선언 크기 ≠ 실제 바이트: 403 `SignatureDoesNotMatch` 로 S3 가 직접 거부

## 연관 이슈

closes #626

- 서버: TeamPiKi/core#1053


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 프로필 및 OCR 이미지 업로드 시 파일 형식과 함께 파일 크기 정보가 검증됩니다.
  - 이미지 업로드 용량이 5MB를 초과하면 공통 오류 메시지가 표시됩니다.
  - 이미지 크기 정보가 올바르지 않은 경우에도 안내 메시지를 제공합니다.
  - 프로필, 대회, 위시 이미지 업로드 과정에서 파일 크기 검증이 일관되게 적용됩니다.

- **테스트**
  - 업로드 요청에 실제 파일 크기가 정확히 전달되는지 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->