### PR TITLE
fix: next/image sizes 정정 및 LCP 이미지 preload로 이미지 트래픽 절감

### DIFF
--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/ProductImage.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/ProductImage.tsx
@@ -41,7 +41,13 @@ function ProductImage({ src, alt, status }: ProductImageProps) {
       {isProcessing && loadingFallback}
       {isError && errorFallback(status)}
       {!isProcessing && !isError && src && (
-        <BaseImage src={src} alt={alt} className="object-cover" loadingFallback={loadingFallback} />
+        <BaseImage
+          src={src}
+          alt={alt}
+          sizes="68px"
+          className="object-cover"
+          loadingFallback={loadingFallback}
+        />
       )}
     </div>
   );

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentBasketItem.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentBasketItem.tsx
@@ -32,7 +32,13 @@ function TournamentBasketItem({ item, index, participantImageMap }: TournamentBa
           className="absolute -right-1 -bottom-0.5 overflow-hidden rounded-full border-2 border-white"
           style={{ width: '35%', height: '35%', zIndex: Z_INDEX.BASE_IMAGE + 10 }}
         >
-          <Image src={friendImageUrl} alt="친구 프로필" fill className="object-cover" />
+          <Image
+            src={friendImageUrl}
+            alt="친구 프로필"
+            fill
+            sizes="30px"
+            className="object-cover"
+          />
         </div>
       )}
     </div>

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
@@ -65,7 +65,7 @@ function TournamentItemBasket({
         src={basketImg}
         alt={`장바구니 ${basketIndex + 1}`}
         fill
-        preload
+        preload={basketIndex === 0}
         sizes="(max-width: 480px) 80vw, 384px"
         className="object-contain"
       />

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
@@ -65,6 +65,7 @@ function TournamentItemBasket({
         src={basketImg}
         alt={`장바구니 ${basketIndex + 1}`}
         fill
+        preload
         sizes="(max-width: 480px) 80vw, 384px"
         className="object-contain"
       />

--- a/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/tournament-item-basket/TournamentItemBasket.tsx
@@ -65,7 +65,7 @@ function TournamentItemBasket({
         src={basketImg}
         alt={`장바구니 ${basketIndex + 1}`}
         fill
-        sizes="(max-width: 480px) 100vw, 480px"
+        sizes="(max-width: 480px) 80vw, 384px"
         className="object-contain"
       />
       <div className="absolute inset-0 flex items-start justify-center">

--- a/apps/web/src/components/base-image/index.tsx
+++ b/apps/web/src/components/base-image/index.tsx
@@ -11,8 +11,10 @@ import { cn } from '@/utils/cn';
 type ImgEvent = SyntheticEvent<HTMLImageElement>;
 type ImageState = 'loading' | 'success' | 'error';
 
-type BaseImageProps = Omit<ImageProps, 'src' | 'fill'> & {
+type BaseImageProps = Omit<ImageProps, 'src' | 'fill' | 'sizes'> & {
   src: ImageProps['src'];
+  /** 항상 fill 로 렌더하므로 없으면 100vw 로 떨어져 화면 폭짜리 이미지를 받는다 */
+  sizes: string;
   loadingFallback?: ReactNode;
   errorFallback?: ReactNode;
 };

--- a/apps/web/src/components/common/item-info-screen/ItemDetailView.tsx
+++ b/apps/web/src/components/common/item-info-screen/ItemDetailView.tsx
@@ -25,12 +25,11 @@ function ItemDetailView({ item, memo, priceRefresh, onEdit }: ItemDetailViewProp
           src={item.imageUrl}
           alt="상품 이미지"
           fill
+          preload
           sizes={ITEM_IMAGE_SIZES}
           className="object-cover"
         />
-        {item.sourceUrl && (
-          <ItemLinkBanner sourceUrl={item.sourceUrl} />
-        )}
+        {item.sourceUrl && <ItemLinkBanner sourceUrl={item.sourceUrl} />}
       </div>
 
       <Spacing size={12} />

--- a/apps/web/src/components/common/item-info-screen/ItemDetailView.tsx
+++ b/apps/web/src/components/common/item-info-screen/ItemDetailView.tsx
@@ -5,6 +5,7 @@ import Spacing from '@/components/spacing';
 import ItemInfoCard from './ItemInfoCard';
 import ItemLinkBanner from './ItemLinkBanner';
 import ItemMemoCard from './ItemMemoCard';
+import { ITEM_IMAGE_SIZES } from './itemInfoScreen.const';
 import type { MemoT, PriceRefreshT, ReadyItemInfoT } from './itemInfoScreen.type';
 
 type ItemDetailViewProps = {
@@ -20,7 +21,13 @@ function ItemDetailView({ item, memo, priceRefresh, onEdit }: ItemDetailViewProp
   return (
     <>
       <div className="relative mt-5 aspect-square w-full overflow-hidden rounded-xl bg-gray-50">
-        <Image src={item.imageUrl} alt="상품 이미지" fill sizes="440px" className="object-cover" />
+        <Image
+          src={item.imageUrl}
+          alt="상품 이미지"
+          fill
+          sizes={ITEM_IMAGE_SIZES}
+          className="object-cover"
+        />
         {item.sourceUrl && (
           <ItemLinkBanner sourceUrl={item.sourceUrl} />
         )}

--- a/apps/web/src/components/common/item-info-screen/ItemImagePicker.tsx
+++ b/apps/web/src/components/common/item-info-screen/ItemImagePicker.tsx
@@ -8,6 +8,8 @@ import { ImageIconFill } from '@/assets/icons';
 import { useImagePicker } from '@/hooks/useImagePicker';
 import { cn } from '@/utils/cn';
 
+import { ITEM_IMAGE_SIZES } from './itemInfoScreen.const';
+
 type ItemImagePickerProps = {
   imageUrl: string | null;
   onImageSelect?: (file: File) => void;
@@ -59,7 +61,7 @@ function ItemImagePicker({ imageUrl, onImageSelect, className }: ItemImagePicker
             src={displayUrl}
             alt="상품 이미지"
             fill
-            sizes="440px"
+            sizes={ITEM_IMAGE_SIZES}
             className="object-cover"
             unoptimized={previewUrl !== null}
           />

--- a/apps/web/src/components/common/item-info-screen/itemInfoScreen.const.ts
+++ b/apps/web/src/components/common/item-info-screen/itemInfoScreen.const.ts
@@ -9,6 +9,8 @@ export const isReadyItemInfo = (item: ItemInfoT): item is ReadyItemInfoT =>
   item.name !== null &&
   item.price !== null;
 
+export const ITEM_IMAGE_SIZES = '(max-width: 480px) calc(100vw - 40px), 440px';
+
 type ItemInfoScreenConfigT = {
   viewTitle: string;
   deleteConfirmTitle: string;

--- a/apps/web/src/components/common/wish-card/WishReadyCard.tsx
+++ b/apps/web/src/components/common/wish-card/WishReadyCard.tsx
@@ -27,7 +27,7 @@ function WishReadyCard({
           <BaseImage
             src={imageUrl}
             alt={name ?? ''}
-            sizes="(max-width: 480px) calc(100vw - 40px - 8px), 216px"
+            sizes="(max-width: 480px) 50vw, 240px"
             preload={preload}
             loadingFallback={<Skeleton className="absolute inset-0 rounded-none" />}
             errorFallback={


### PR DESCRIPTION


## 작업 요약
- 각 이미지의 `sizes`를 추정이 아닌 실측 렌더 폭 기준으로 정정
- 화면별 LCP 요소가 늦게 발견되지 않도록 `preload` 적용
- `sizes` 누락이 다시 들어오지 않도록 타입 가드 추가

## 배경

`next/image`는 `sizes`와 기기 DPR로 srcset 후보를 골라 `/_next/image?url=...&w=<폭>`을 요청합니다.
`sizes`를 주지 않으면 `100vw`로 간주해 화면 전체 폭짜리 이미지를 받습니다.

두 종류의 문제가 섞여 있었습니다.
- **누락**: `fill`인데 `sizes`가 아예 없는 경우 — 담기 화면 장바구니 썸네일(실측 44.7px)과 친구 프로필 뱃지(약 16px)가 둘 다 `w=1200`을 받고 있었습니다
- **낡음**: `sizes`는 있으나 값이 실제 렌더 폭과 어긋난 경우 — 위시 카드는 `calc(100vw - 40px - 8px)`였는데 그 사이 그리드 패딩·gap이 제거되어 실제로는 `50vw`였고, 상품 상세는 `440px` 고정인데 부모 `px-5` 때문에 실제로는 350px였습니다

작업 중 세 번째 문제도 드러났습니다. 담기 화면과 상품 상세 화면의 **LCP 요소가 `loading="lazy"`**였습니다.
lazy는 프리로드 스캐너가 건너뛰어 레이아웃이 끝난 뒤에야 요청이 나가는데, 두 화면 모두 레이아웃이 JS 측정에 의존해 이미지가 JS 뒤에 줄 서는 구조였습니다.

## 작업 내용

### 1. sizes 정정

Playwright로 `/_next/image` 요청의 `w`를 수집하면서, 같은 실행에서 `boundingBox()`로 실제 렌더 폭을 재어 대조했습니다 (iPhone 14 프리셋, 뷰포트 390px, DPR 3).

| 위치 | 실측 렌더 폭 | 변경 전 | 변경 후 |
| --- | --- | --- | --- |
| 담기: 장바구니 썸네일 | 44.7px | w=1200 (sizes 없음) | w=256 |
| 담기: 친구 프로필 뱃지 | 약 16px | w=1200 (sizes 없음) | w=96 |
| 담기: 장바구니 배경 | 239.4px | w=1080/1200/1920 | w=1080 |
| 위시 목록: 카드 | 195.0px | w=1080 | w=640 |
| 상품 상세: 상품 이미지 | 350.0px | w=1920 | w=1080 |

- 장바구니 배경은 캐러셀 슬라이드가 컨테이너의 80%라 `100vw`가 과대 선언이었습니다. 뷰포트마다 `w`가 1080/1200/1920으로 갈려 같은 PNG가 캐시를 재사용하지 못하고 있었습니다
- 위시 카드가 매치 화면(`PRODUCT_CARD_IMAGE_SIZES`)과 같은 `w=640`이 되면서, 같은 상품 이미지를 두 화면이 캐시로 공유하게 됐습니다
- 상품 상세는 조회 화면과 수정 폼이 같은 값을 쓰므로 `ITEM_IMAGE_SIZES` 상수로 뺐습니다

### 2. LCP 요소 preload

`PerformanceObserver`로 화면별 LCP 요소를 실측한 뒤, **첫 화면에서 즉시 보이는 가장 큰 이미지에만** 적용했습니다.
전부 붙이면 서로 대역폭을 다투어 정작 LCP 요소가 밀립니다.

| 화면 | LCP 요소 | 크기 | 조치 |
| --- | --- | --- | --- |
| 담기 | 장바구니 배경 | 119,658px² (2등의 27배) | lazy였음, `preload` 추가 |
| 상품 상세 | 상품 이미지 | 122,500px² (2등의 75배) | lazy였음, `preload` 추가 |
| 위시 목록 | 첫 카드 이미지 | 31,395px² | 이미 `preload={index < 4}`, 변경 없음 |

- Next 16에서 `priority`는 deprecated이므로 `preload`를 썼습니다

### 3. 재발 방지

- `@next/next`·`jsx-a11y` 어디에도 `sizes` 누락을 잡는 린트 규칙이 없어(Next는 dev 런타임 경고만 냅니다) 타입으로 막았습니다
- `BaseImage`는 내부에서 항상 `fill`을 강제하므로 `sizes`가 언제나 유의미합니다. `BaseImageProps`에서 `sizes`를 required로 바꿨습니다
  - 기존 호출부 9곳은 이미 전부 넘기고 있어 수정 비용은 0이었습니다
- 이 가드가 곧바로 효과를 봤습니다. rebase 중 dev가 재작성한 `ProductImage`가 `sizes` 없이 `BaseImage`를 쓰고 있었는데 컴파일 에러로 잡혔습니다

## 결과

실사 사진 1500x1500을 옵티마이저에 폭별로 태워 실제 응답 바이트를 쟀습니다 (webp, q75).

| 위치 | 변경 전 | 변경 후 | 절감 |
| --- | --- | --- | --- |
| 담기: 썸네일 (개당) | 105.4KB | 7.6KB | 97.8KB (93%) |
| 담기: 친구 뱃지 (개당) | 105.4KB | 1.4KB | 104.0KB (99%) |
| 위시 목록: 카드 (개당) | 90.8KB | 40.3KB | 50.5KB (56%) |
| 상품 상세: 이미지 | 141.7KB | 90.8KB | 50.9KB (36%) |

- 담기 화면은 한 바구니에 최대 8칸이라, 꽉 찬 바구니면 썸네일만 약 780KB 절감입니다
- 디코드 메모리도 함께 줄었습니다. 1200px 한 장이 약 5.7MB, 256px은 약 0.26MB이므로 8칸 기준 46MB에서 2MB가 됩니다. 램 적은 기기의 스크롤 버벅임·웹뷰 종료에 직결되는 부분입니다
- LCP는 상품 상세 화면에서 4G 스로틀(5Mbps, 지연 100ms)·브라우저 캐시 off 조건으로 **1764ms에서 576ms로** 줄었습니다 (5회 측정, 편차 작음)

## 참고

- **장바구니 배경은 바이트 절감이 0입니다.** 원본 PNG가 600x832라 Next가 업스케일하지 않아 `w`가 640이든 1920이든 응답이 70KB로 같습니다. 해당 커밋은 캐시 키 통합(1080/1200/1920을 1080 하나로)이 목적입니다. DPR 3에서 이미 원본 해상도가 부족해 소스를 키우기 전에는 개선 여지가 없습니다
- 절감 수치는 원본이 요청 폭보다 클 때 성립합니다. 쇼핑몰 상품 이미지가 작게 올라온 건이면 절감 폭이 줄어듭니다
- LCP 측정은 dev 서버 기준입니다. 프로덕션 번들은 더 작아 절대 이득은 줄지만, 이미지가 JS 뒤에 줄 서던 구조가 병렬로 바뀌는 메커니즘은 동일합니다


## 관련 이슈
- close #528 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **개선 사항**
  - 상품 및 친구 프로필 이미지가 화면 크기에 맞는 이미지 크기 정보를 사용하도록 조정되었습니다.
  - 주요 상품 이미지가 우선 로드되어 이미지 표시 속도가 개선되었습니다.
  - 모바일 화면에서 이미지가 콘텐츠 영역에 맞게 표시되도록 크기 기준을 최적화했습니다.
  - 상품 상세 및 이미지 선택 화면에서 일관된 반응형 이미지 크기 설정이 적용되었습니다.
  - 찜 목록 카드의 이미지 표시 크기가 화면 환경에 맞게 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->