### PR TITLE
feat: 토너먼트 주최자 HostBadge 표시

### DIFF
--- a/apps/web/e2e/mocks/tournament.ts
+++ b/apps/web/e2e/mocks/tournament.ts
@@ -87,6 +87,7 @@ export const MOCK_TOURNAMENT_PENDING: GetTournamentPendingResponseT = {
         nickname: '피키게스트',
         itemCount: 0,
         profileImage: MOCK_IMAGE_URLS.avatar,
+        isHost: true,
       },
     ],
   },

--- a/apps/web/src/app/tournament/[id]/_common/_types/tournamentResponse.ts
+++ b/apps/web/src/app/tournament/[id]/_common/_types/tournamentResponse.ts
@@ -10,6 +10,7 @@ type TournamentParticipantT = {
   nickname: string;
   itemCount: number;
   profileImage: string;
+  isHost: boolean;
 };
 
 /** 서버가 브래킷에서 파생해 내려주는 대결 한 판 */

--- a/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/TournamentCreateClient.tsx
@@ -97,6 +97,7 @@ function TournamentCreateClient({ tournamentId }: TournamentCreateClientProps) {
       id: p.userId,
       name: p.nickname,
       imageUrl: p.profileImage,
+      isHost: p.isHost,
     },
     itemCount: p.itemCount,
   }));

--- a/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantChip.tsx
+++ b/apps/web/src/app/tournament/[id]/create/_components/participant-panel/ParticipantChip.tsx
@@ -1,6 +1,7 @@
 import UserProfile from '@/components/user-profile-group/UserProfile';
 import type { UserT } from '@/components/user-profile-group/userProfile.types';
 import { useGetMe } from '@/hooks/useGetMe';
+import { cn } from '@/utils/cn';
 
 type ParticipantChipProps = {
   user: UserT;
@@ -14,7 +15,7 @@ function ParticipantChip({ user, itemCount }: ParticipantChipProps) {
   return (
     <span className="inline-flex items-center gap-1.5 rounded-full border border-border-neutral-muted bg-bg-layer-default py-1 pr-3 pl-1 body-2-medium text-text-neutral-primary">
       <UserProfile user={user} className="border-0" />
-      <span>{isMe ? '나' : user.name}</span>
+      <span className={cn(user.isHost && 'ml-1.5')}>{isMe ? '나' : user.name}</span>
       <span className="body-2-semibold text-text-neutral-secondary">{itemCount}개</span>
     </span>
   );

--- a/apps/web/src/app/tournament/[id]/result/_types/groupResult.ts
+++ b/apps/web/src/app/tournament/[id]/result/_types/groupResult.ts
@@ -2,6 +2,7 @@ type GroupResultParticipantT = {
   userId: string;
   nickname: string;
   profileImage: string;
+  isHost: boolean;
 };
 
 export type GroupResultItemT = {

--- a/apps/web/src/app/tournament/[id]/result/group/_components/GroupResultClient.tsx
+++ b/apps/web/src/app/tournament/[id]/result/group/_components/GroupResultClient.tsx
@@ -13,6 +13,7 @@ import {
 import PikiLogo from '@/assets/images/piki-logo-cart.svg';
 import ReceiptZigzag from '@/assets/images/tournament/result/receipt-zigzag.svg';
 import TrophyBadge from '@/assets/images/tournament/result/trophy-badge.svg';
+import HostBadge from '@/components/common/host-badge';
 import Spinner from '@/components/spinner';
 import { ROUTES } from '@/consts/route';
 import { useBackWithFallback } from '@/hooks/useBackWithFallback';
@@ -283,15 +284,22 @@ function GroupProductCard({ item, highlight = false }: GroupProductCardProps) {
               key={chooser.userId}
               className="flex items-center gap-1.5 rounded-full bg-gray-50 py-1 pr-3 pl-1"
             >
-              <Image
-                src={chooser.profileImage}
-                alt={chooser.nickname}
-                width={20}
-                height={20}
-                className="size-5 rounded-full bg-gray-50 object-cover"
-                unoptimized
-              />
-              <span className="caption-1-semibold text-text-neutral-primary">
+              <span className="relative shrink-0">
+                <Image
+                  src={chooser.profileImage}
+                  alt={chooser.nickname}
+                  width={20}
+                  height={20}
+                  className="size-5 rounded-full bg-gray-50 object-cover"
+                  unoptimized
+                />
+                {chooser.isHost && (
+                  <span className="pointer-events-none absolute -bottom-px -right-1.5">
+                    <HostBadge />
+                  </span>
+                )}
+              </span>
+              <span className={cn('caption-1-semibold text-text-neutral-primary', chooser.isHost && 'ml-1.5')}>
                 {chooser.nickname}
               </span>
             </li>

--- a/apps/web/src/assets/images/host-badge.svg
+++ b/apps/web/src/assets/images/host-badge.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none">
+  <circle cx="6" cy="6" r="6" fill="#1BAEFD"/>
+  <path d="M3.47417 7.71719L3.20312 5.03424L4.82939 6.6446L5.91356 4L6.99774 6.6446L8.624 5.03424L8.35296 7.71719H3.47417Z" fill="#ECF8FE" stroke="#ECF8FE" stroke-width="0.861715" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/web/src/components/common/host-badge/index.tsx
+++ b/apps/web/src/components/common/host-badge/index.tsx
@@ -1,0 +1,7 @@
+import HostBadgeSvg from '@/assets/images/host-badge.svg';
+
+function HostBadge() {
+  return <HostBadgeSvg aria-label="주최자" role="img" />;
+}
+
+export default HostBadge;

--- a/apps/web/src/components/user-profile-group/UserProfile.tsx
+++ b/apps/web/src/components/user-profile-group/UserProfile.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 
+import HostBadge from '@/components/common/host-badge';
 import { cn } from '@/utils/cn';
 
 import type { UserT } from './userProfile.types';
@@ -10,7 +11,7 @@ type UserProfileProps = {
 };
 
 function UserProfile({ user, className }: UserProfileProps) {
-  return (
+  const profileImage = (
     <span
       className={cn(
         'relative block size-6.75 shrink-0 overflow-hidden rounded-full border-[1.6px] border-white',
@@ -24,6 +25,17 @@ function UserProfile({ user, className }: UserProfileProps) {
         sizes="27px"
         className="object-cover"
       />
+    </span>
+  );
+
+  if (!user.isHost) return profileImage;
+
+  return (
+    <span className="relative inline-block shrink-0">
+      {profileImage}
+      <span className="pointer-events-none absolute -bottom-px -right-1.5">
+        <HostBadge />
+      </span>
     </span>
   );
 }

--- a/apps/web/src/components/user-profile-group/userProfile.types.ts
+++ b/apps/web/src/components/user-profile-group/userProfile.types.ts
@@ -2,4 +2,5 @@ export type UserT = {
   id: string;
   name: string;
   imageUrl: string;
+  isHost?: boolean;
 };


### PR DESCRIPTION
## 작업 요약

- 주최자 배지(HostBadge) UI를 추가하고 담기 배너 칩·영수증 확장 목록에 적용합니다

## 작업 세부 내용

- `HostBadge` 컴포넌트 추가 (`assets/images/host-badge.svg` + `components/common/host-badge`)
- `UserT`에 `isHost?: boolean` 추가, `UserProfile`에서 주최자일 때 배지 렌더링
  - 배지는 프로필 우측 하단 (`bottom: -1px, right: -6px`) 고정
  - 배지 오른쪽 overflow만큼 다음 텍스트에 `ml-1.5` 추가해 시각적 간격 유지
- `TournamentParticipantT`, `GroupResultParticipantT`에 `isHost: boolean` 타입 반영
- `TournamentCreateClient` 클라이언트 정렬 제거 (서버가 본인→주최자→입장순 정렬)
- 담기 배너 펼쳤을 때 `ParticipantChip`에 주최자 배지 표시
- 영수증 화면 확장 목록(`chosenBy` 칩)에 주최자 배지 표시
  - 담기 배너 접힌 프로필 스택, 영수증 프로필 스택은 배지 미적용

## 스크린샷
<img width="429" height="753" alt="스크린샷 2026-09-08 오후 9 40 55" src="https://github.com/user-attachments/assets/96914af3-71e7-4d7d-929a-851aca1d6669" />


## 연관 이슈

closes #639


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 토너먼트 참가자와 결과 화면에서 주최자에게 호스트 배지가 표시됩니다.
  - 참가자 목록과 프로필 이미지에 주최자 표시가 추가되어 주최자를 쉽게 식별할 수 있습니다.
  - 주최자 배지와 이름 간격이 화면 구성에 맞게 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->