### PR TITLE
feat: 토너먼트 카드 참여자 정보 UI 수정

### DIFF
--- a/apps/web/e2e/mocks/tournament.ts
+++ b/apps/web/e2e/mocks/tournament.ts
@@ -20,7 +20,7 @@ export const MOCK_TOURNAMENT_LIST: GetTournamentListResponseT = [
     status: 'PENDING',
     createdAt: '2026-01-01T00:00:00Z',
     participantCount: 1,
-    playerCount: 0,
+    playedCount: 0,
     thumbnailUrls: [],
   },
 ];

--- a/apps/web/e2e/mocks/tournament.ts
+++ b/apps/web/e2e/mocks/tournament.ts
@@ -19,8 +19,8 @@ export const MOCK_TOURNAMENT_LIST: GetTournamentListResponseT = [
     name: 'E2E 토너먼트',
     status: 'PENDING',
     createdAt: '2026-01-01T00:00:00Z',
-    /** 가짜 URL — fixture 가 가로채 로컬 이미지로 응답한다 (e2e/mocks/images.ts) */
-    participantProfileImages: [MOCK_IMAGE_URLS.avatar],
+    participantCount: 1,
+    playerCount: 0,
     thumbnailUrls: [],
   },
 ];

--- a/apps/web/src/app/archive/tournament/_components/TournamentHistoryList.tsx
+++ b/apps/web/src/app/archive/tournament/_components/TournamentHistoryList.tsx
@@ -36,8 +36,8 @@ function TournamentHistoryList({ statuses, playType, statusTab }: Props) {
           tournamentId={tournament.tournamentId}
           status={tournament.status}
           name={tournament.name}
-          profileImageUrls={tournament.participantProfileImages}
-          participantCount={tournament.participantProfileImages.length}
+          participantCount={tournament.participantCount}
+          playerCount={tournament.playerCount}
           scrollRestoration={{ namespace: SCROLL_NAMESPACE.ARCHIVE_TOURNAMENT, scope: statusTab }}
         />
       ))}

--- a/apps/web/src/app/archive/tournament/_components/TournamentHistoryList.tsx
+++ b/apps/web/src/app/archive/tournament/_components/TournamentHistoryList.tsx
@@ -37,7 +37,7 @@ function TournamentHistoryList({ statuses, playType, statusTab }: Props) {
           status={tournament.status}
           name={tournament.name}
           participantCount={tournament.participantCount}
-          playerCount={tournament.playerCount}
+          playedCount={tournament.playedCount}
           scrollRestoration={{ namespace: SCROLL_NAMESPACE.ARCHIVE_TOURNAMENT, scope: statusTab }}
         />
       ))}

--- a/apps/web/src/app/home/_components/tournament-list/client.tsx
+++ b/apps/web/src/app/home/_components/tournament-list/client.tsx
@@ -33,7 +33,7 @@ function TournamentListClient({ isGuest = false }: TournamentListClientProps) {
           status={tournament.status}
           name={tournament.name}
           participantCount={tournament.participantCount}
-          playerCount={tournament.playerCount}
+          playedCount={tournament.playedCount}
           showMorePopover={false}
         />
       ))}

--- a/apps/web/src/app/home/_components/tournament-list/client.tsx
+++ b/apps/web/src/app/home/_components/tournament-list/client.tsx
@@ -32,8 +32,8 @@ function TournamentListClient({ isGuest = false }: TournamentListClientProps) {
           tournamentId={tournament.tournamentId}
           status={tournament.status}
           name={tournament.name}
-          profileImageUrls={tournament.participantProfileImages}
-          participantCount={tournament.participantProfileImages.length}
+          participantCount={tournament.participantCount}
+          playerCount={tournament.playerCount}
           showMorePopover={false}
         />
       ))}

--- a/apps/web/src/components/tournament-card/index.tsx
+++ b/apps/web/src/components/tournament-card/index.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
 import type { MouseEvent } from 'react';
 
+import { PersonIconFill } from '@/assets/icons';
 import StatusChip from '@/components/status-chip';
-import UserProfileGroup from '@/components/user-profile-group';
 import { ROUTES } from '@/consts/route';
 import type { TournamentStatusT } from '@/types/tournament';
 import { cn } from '@/utils/cn';
@@ -16,12 +16,12 @@ type TournamentCardProps = {
   tournamentId: number;
   status: TournamentStatusT;
   name: string;
-  profileImageUrls: string[];
   /** 토너먼트 아이템 썸네일. 최대 2개. */
   imageUrls: string[];
-  maxProfiles?: number;
-  /** 본인 포함 참여자 수. 2명 이상이면 더보기에 '친구 목록 보기' 메뉴 노출. */
-  participantCount?: number;
+  /** 본인 포함 함께 담은 참여자 수. 2명 이상이면 더보기에 '친구 목록 보기' 메뉴 노출. */
+  participantCount: number;
+  /** 실제로 플레이한 인원 수 */
+  playerCount: number;
   className?: string;
   showMorePopover?: boolean;
   scrollRestoration?: ScrollRestorationTargetT;
@@ -31,10 +31,9 @@ function TournamentCard({
   tournamentId,
   status,
   name,
-  profileImageUrls,
   imageUrls = [],
-  maxProfiles = 3,
   participantCount,
+  playerCount,
   className,
   showMorePopover = true,
   scrollRestoration,
@@ -76,7 +75,7 @@ function TournamentCard({
 
       <ItemImageThumbnails imageUrls={imageUrls} />
 
-      <div className="flex flex-1 flex-col items-start gap-2 self-center">
+      <div className="flex flex-1 flex-col items-start gap-2.5 self-center">
         <div className="flex w-full items-center justify-between gap-2">
           <div className="flex items-center gap-2">
             <StatusChip status={status} />
@@ -94,7 +93,12 @@ function TournamentCard({
           )}
         </div>
 
-        <UserProfileGroup profileImageUrls={profileImageUrls} max={maxProfiles} size="sm" />
+        <div className="flex items-center gap-1 caption-1-regular">
+          <PersonIconFill className="size-3 shrink-0 text-sky-blue-500" aria-hidden />
+          <span className="text-text-neutral-secondary">함께 담은 {participantCount}</span>
+          <div className="mx-2 h-2 w-px shrink-0 bg-border-neutral-muted" aria-hidden />
+          <span className="text-text-neutral-secondary">플레이한 {playerCount}</span>
+        </div>
       </div>
     </article>
   );

--- a/apps/web/src/components/tournament-card/index.tsx
+++ b/apps/web/src/components/tournament-card/index.tsx
@@ -21,7 +21,7 @@ type TournamentCardProps = {
   /** 본인 포함 함께 담은 참여자 수. 2명 이상이면 더보기에 '친구 목록 보기' 메뉴 노출. */
   participantCount: number;
   /** 실제로 플레이한 인원 수 */
-  playerCount: number;
+  playedCount: number;
   className?: string;
   showMorePopover?: boolean;
   scrollRestoration?: ScrollRestorationTargetT;
@@ -33,7 +33,7 @@ function TournamentCard({
   name,
   imageUrls = [],
   participantCount,
-  playerCount,
+  playedCount,
   className,
   showMorePopover = true,
   scrollRestoration,
@@ -97,7 +97,7 @@ function TournamentCard({
           <PersonIconFill className="size-3 shrink-0 text-sky-blue-500" aria-hidden />
           <span className="text-text-neutral-secondary">함께 담은 {participantCount}</span>
           <div className="mx-2 h-2 w-px shrink-0 bg-border-neutral-muted" aria-hidden />
-          <span className="text-text-neutral-secondary">플레이한 {playerCount}</span>
+          <span className="text-text-neutral-secondary">플레이한 {playedCount}</span>
         </div>
       </div>
     </article>

--- a/apps/web/src/components/tournament-card/index.tsx
+++ b/apps/web/src/components/tournament-card/index.tsx
@@ -95,9 +95,13 @@ function TournamentCard({
 
         <div className="flex items-center gap-1 caption-1-regular">
           <PersonIconFill className="size-3 shrink-0 text-sky-blue-500" aria-hidden />
-          <span className="text-text-neutral-secondary">함께 담은 {participantCount}</span>
+          <span className="text-text-neutral-secondary">
+            함께 담은 <span className="text-text-neutral-primary">{participantCount}</span>
+          </span>
           <div className="mx-2 h-2 w-px shrink-0 bg-border-neutral-muted" aria-hidden />
-          <span className="text-text-neutral-secondary">플레이한 {playedCount}</span>
+          <span className="text-text-neutral-secondary">
+            플레이한 <span className="text-text-neutral-primary">{playedCount}</span>
+          </span>
         </div>
       </div>
     </article>

--- a/apps/web/src/types/tournament.ts
+++ b/apps/web/src/types/tournament.ts
@@ -39,7 +39,8 @@ export type GetTournamentListResponseT = {
   name: string;
   status: TournamentStatusT;
   createdAt: string;
-  participantProfileImages: string[];
+  participantCount: number;
+  playerCount: number;
   thumbnailUrls: string[];
 }[];
 

--- a/apps/web/src/types/tournament.ts
+++ b/apps/web/src/types/tournament.ts
@@ -40,7 +40,7 @@ export type GetTournamentListResponseT = {
   status: TournamentStatusT;
   createdAt: string;
   participantCount: number;
-  playerCount: number;
+  playedCount: number;
   thumbnailUrls: string[];
 }[];
 


### PR DESCRIPTION
## 작업 요약

- 토너먼트 카드의 참여자 프로필 이미지 스택을 인원수 텍스트로 교체합니다

## 작업 세부 내용

- `GetTournamentListResponseT`에서 `participantProfileImages` 제거, `participantCount`·`playedCount` 추가
- `TournamentCard` props 변경: `profileImageUrls`/`maxProfiles` → `participantCount`/`playedCount`
  - 아이콘(PersonIconFill, sky-blue-500) + "함께 담은 N" + 구분선 + "플레이한 N" 레이아웃
  - 텍스트는 `caption-1-regular`, 숫자는 `text-neutral-primary`, 레이블은 `text-neutral-secondary`
- 홈 카드(`tournament-list/client.tsx`), 아카이브(`TournamentHistoryList.tsx`) prop 업데이트
- e2e 목 업데이트: `participantProfileImages` → `participantCount: 1, playedCount: 0`

## 스크린샷
<img width="486" height="801" alt="스크린샷 2026-09-08 오후 9 47 08" src="https://github.com/user-attachments/assets/ac037444-d2c8-463a-8bbb-95e6e873fd15" />


## 연관 이슈

closes #638
