### PR TITLE
feat: SSE 양방향 하트비트로 연결 생존 관리

### DIFF
--- a/apps/web/src/apis/postNotificationHeartbeat.ts
+++ b/apps/web/src/apis/postNotificationHeartbeat.ts
@@ -1,0 +1,7 @@
+import { ENDPOINTS } from '@/consts/api';
+
+import { clientApi } from './client';
+
+export const postNotificationHeartbeat = async (connectionId: string) => {
+  await clientApi.post(ENDPOINTS.NOTIFICATIONS_HEARTBEAT, { connectionId });
+};

--- a/apps/web/src/consts/api.ts
+++ b/apps/web/src/consts/api.ts
@@ -43,6 +43,7 @@ export const ENDPOINTS = {
   NOTIFICATIONS_SUBSCRIBE: '/api/v1/notifications/subscribe',
   NOTIFICATIONS: '/api/v1/notifications',
   NOTIFICATIONS_READ: '/api/v1/notifications/read',
+  NOTIFICATIONS_HEARTBEAT: '/api/v1/notifications/heartbeat',
 
   /** FCM */
   FCM_TOKENS: '/api/v1/fcm/tokens',

--- a/apps/web/src/hooks/useNotificationSSE.ts
+++ b/apps/web/src/hooks/useNotificationSSE.ts
@@ -1,19 +1,22 @@
 import { fetchEventSource } from '@microsoft/fetch-event-source';
-import { WEBBRIDGE_MESSAGE_TYPE } from '@piki/core';
+import { ERROR_CODE, WEBBRIDGE_MESSAGE_TYPE } from '@piki/core';
 import type { QueryClient } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
 import { usePathname } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 
+import { postNotificationHeartbeat } from '@/apis/postNotificationHeartbeat';
 import { ENDPOINTS } from '@/consts/api';
 import { QUERY_KEYS } from '@/consts/queryKeys';
 import { ROUTES } from '@/consts/route';
 import { CLIENT_TYPE } from '@/consts/webBridge';
 import type { NotificationSsePayloadT, SilentSyncSsePayloadT } from '@/types/notification';
+import { getApiErrorCode, getApiErrorStatus } from '@/utils/apiError';
 import { getCookie } from '@/utils/cookie';
 import { handleSessionExpired } from '@/utils/handleSessionExpired';
 import { refreshClientToken } from '@/utils/refreshClientToken';
+import { SSE_HEARTBEAT_INTERVAL_MS, decideHeartbeatTick } from '@/utils/sseHeartbeat';
 import { WebBridge, isWebview } from '@/utils/webBridge';
 
 const MAX_RETRY_DELAY_MS = 30_000;
@@ -40,6 +43,10 @@ export const useNotificationSSE = (enabled: boolean) => {
   const abortRef = useRef<AbortController | null>(null);
   const hasConnectedRef = useRef(false);
   const authFailCountRef = useRef(0);
+  // connect에서 받은 ID. 하트비트에 포함하며 재연결 시 갱신한다
+  const connectionIdRef = useRef<string | null>(null);
+  // 60초간 이벤트가 없으면 끊긴 스트림으로 보고 재연결한다
+  const lastHeartbeatAtRef = useRef(0);
 
   // 주최자 알림 토스트를 담기 화면에서만 노출하기 위해 최신 경로를 ref로 관리
   const pathnameRef = useRef(pathname);
@@ -52,13 +59,55 @@ export const useNotificationSSE = (enabled: boolean) => {
 
     let cancelled = false;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let isHeartbeatInFlight = false;
     // ref 는 언마운트/재로그인 후에도 남으므로, 이전 세션의 실패 횟수를 물려받지 않도록 초기화
     authFailCountRef.current = 0;
+    connectionIdRef.current = null;
 
     const scheduleReconnect = (delay: number) => {
       if (reconnectTimer) clearTimeout(reconnectTimer);
       const jitteredDelay = delay * (0.5 + Math.random() * 0.5);
       reconnectTimer = setTimeout(connect, jitteredDelay);
+    };
+
+    // heartbeat 결측·409 등 연결 종료가 확정되면 백오프 없이 즉시 재연결한다
+    const reconnectNow = () => {
+      retryDelayRef.current = INITIAL_RETRY_DELAY_MS;
+      connect();
+    };
+
+    const tick = () => {
+      if (cancelled) return;
+
+      const connectionId = connectionIdRef.current;
+      const decision = decideHeartbeatTick({
+        isVisible: !document.hidden,
+        connectionId,
+        lastHeartbeatAt: lastHeartbeatAtRef.current,
+        now: Date.now(),
+      });
+
+      if (decision === 'SKIP' || !connectionId) return;
+      if (decision === 'RECONNECT') {
+        reconnectNow();
+        return;
+      }
+      if (isHeartbeatInFlight) return;
+
+      isHeartbeatInFlight = true;
+      postNotificationHeartbeat(connectionId)
+        .catch(error => {
+          if (cancelled) return;
+          // 서버에 그 번호의 연결이 없음(배포로 서버가 바뀌었거나 이미 정리됨) → 즉시 재연결
+          const isConnectionGone =
+            getApiErrorStatus(error) === 409 &&
+            getApiErrorCode(error) === ERROR_CODE.NOTIFICATION_CONNECTION_NOT_FOUND;
+          // 응답 지연 중 이미 재연결됐으면 옛 번호의 409 로 새 연결을 끊지 않는다
+          if (isConnectionGone && connectionIdRef.current === connectionId) reconnectNow();
+        })
+        .finally(() => {
+          isHeartbeatInFlight = false;
+        });
     };
 
     const connect = () => {
@@ -70,6 +119,8 @@ export const useNotificationSSE = (enabled: boolean) => {
       }
       // 기존 연결 정리 — 중복 알림 방지
       abortRef.current?.abort();
+      // 다음 connect 이벤트 전까지 이전 연결 ID로 하트비트를 보내지 않는다
+      connectionIdRef.current = null;
 
       const controller = new AbortController();
       abortRef.current = controller;
@@ -101,6 +152,8 @@ export const useNotificationSSE = (enabled: boolean) => {
           if (response.ok) {
             retryDelayRef.current = INITIAL_RETRY_DELAY_MS;
             authFailCountRef.current = 0;
+            // 연결 직후 첫 heartbeat 까지 60초 유예
+            lastHeartbeatAtRef.current = Date.now();
             if (hasConnectedRef.current) {
               // 재연결 성공 — 끊긴 동안 SSE 이벤트로 놓쳤을 수 있는 도메인만 재조회
               void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.NOTIFICATION.LIST });
@@ -134,6 +187,16 @@ export const useNotificationSSE = (enabled: boolean) => {
         },
 
         onmessage: event => {
+          // 어떤 이벤트든 도착했다는 것은 스트림이 살아 있다는 뜻 — heartbeat 만 세면 알림이 잦을 때 오판한다
+          lastHeartbeatAtRef.current = Date.now();
+
+          if (event.event === 'connect') {
+            connectionIdRef.current = event.data || null;
+            return;
+          }
+
+          if (event.event === 'heartbeat') return;
+
           if (event.event === 'silent-sync') {
             try {
               const payload = JSON.parse(event.data) as SilentSyncSsePayloadT;
@@ -244,23 +307,30 @@ export const useNotificationSSE = (enabled: boolean) => {
       });
     };
 
-    // 화면 복귀 시 예약된 재연결을 즉시 실행해 알림 공백을 줄인다
+    // 화면 복귀 시 예약된 재연결은 즉시 실행하고, 없으면 하트비트로 백그라운드 중 정리된 연결(409)을 빠르게 감지한다.
     const handleVisibilityChange = () => {
-      if (document.hidden || !reconnectTimer) return;
+      if (document.hidden) return;
 
-      retryDelayRef.current = INITIAL_RETRY_DELAY_MS;
-      connect();
+      if (reconnectTimer) {
+        reconnectNow();
+        return;
+      }
+
+      tick();
     };
 
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
     connect();
+    const heartbeatTimer = setInterval(tick, SSE_HEARTBEAT_INTERVAL_MS);
 
     return () => {
       cancelled = true;
       document.removeEventListener('visibilitychange', handleVisibilityChange);
+      clearInterval(heartbeatTimer);
       if (reconnectTimer) clearTimeout(reconnectTimer);
       abortRef.current?.abort();
+      connectionIdRef.current = null;
     };
   }, [enabled, queryClient]);
 };

--- a/apps/web/src/utils/sseHeartbeat.test.ts
+++ b/apps/web/src/utils/sseHeartbeat.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { SSE_HEARTBEAT_STALE_MS, decideHeartbeatTick } from './sseHeartbeat';
+
+const NOW = 1_000_000;
+
+describe('decideHeartbeatTick', () => {
+  it('백그라운드면 연결 중이어도 아무것도 보내지 않는다', () => {
+    expect(
+      decideHeartbeatTick({ isVisible: false, connectionId: 'c1', lastHeartbeatAt: NOW, now: NOW })
+    ).toBe('SKIP');
+  });
+
+  it('연결 번호가 없으면(연결 전·재연결 중) 보내지 않는다', () => {
+    expect(
+      decideHeartbeatTick({ isVisible: true, connectionId: null, lastHeartbeatAt: 0, now: NOW })
+    ).toBe('SKIP');
+  });
+
+  it('서버 heartbeat 가 60초 넘게 안 오면 재연결한다', () => {
+    expect(
+      decideHeartbeatTick({
+        isVisible: true,
+        connectionId: 'c1',
+        lastHeartbeatAt: NOW - SSE_HEARTBEAT_STALE_MS - 1,
+        now: NOW,
+      })
+    ).toBe('RECONNECT');
+  });
+
+  it('정확히 60초까지는 결측으로 보지 않고 하트비트를 보낸다', () => {
+    expect(
+      decideHeartbeatTick({
+        isVisible: true,
+        connectionId: 'c1',
+        lastHeartbeatAt: NOW - SSE_HEARTBEAT_STALE_MS,
+        now: NOW,
+      })
+    ).toBe('SEND');
+  });
+
+  it('포그라운드·연결 중·최근 heartbeat 수신이면 하트비트를 보낸다', () => {
+    expect(
+      decideHeartbeatTick({
+        isVisible: true,
+        connectionId: 'c1',
+        lastHeartbeatAt: NOW - 10_000,
+        now: NOW,
+      })
+    ).toBe('SEND');
+  });
+});

--- a/apps/web/src/utils/sseHeartbeat.test.ts
+++ b/apps/web/src/utils/sseHeartbeat.test.ts
@@ -17,23 +17,23 @@ describe('decideHeartbeatTick', () => {
     ).toBe('SKIP');
   });
 
-  it('서버 heartbeat 가 60초 넘게 안 오면 재연결한다', () => {
-    expect(
-      decideHeartbeatTick({
-        isVisible: true,
-        connectionId: 'c1',
-        lastHeartbeatAt: NOW - SSE_HEARTBEAT_STALE_MS - 1,
-        now: NOW,
-      })
-    ).toBe('RECONNECT');
-  });
-
-  it('정확히 60초까지는 결측으로 보지 않고 하트비트를 보낸다', () => {
+  it('서버 heartbeat 가 60초 이상 안 오면 재연결한다', () => {
     expect(
       decideHeartbeatTick({
         isVisible: true,
         connectionId: 'c1',
         lastHeartbeatAt: NOW - SSE_HEARTBEAT_STALE_MS,
+        now: NOW,
+      })
+    ).toBe('RECONNECT');
+  });
+
+  it('60초 직전까지는 결측으로 보지 않고 하트비트를 보낸다', () => {
+    expect(
+      decideHeartbeatTick({
+        isVisible: true,
+        connectionId: 'c1',
+        lastHeartbeatAt: NOW - SSE_HEARTBEAT_STALE_MS + 1,
         now: NOW,
       })
     ).toBe('SEND');

--- a/apps/web/src/utils/sseHeartbeat.ts
+++ b/apps/web/src/utils/sseHeartbeat.ts
@@ -1,0 +1,29 @@
+/** 클라이언트 → 서버 하트비트 전송 주기 */
+export const SSE_HEARTBEAT_INTERVAL_MS = 30_000;
+
+/** 서버 heartbeat 결측 임계값 — 한 번 밀린 ping 을 끊김으로 오판하지 않도록 두 주기 */
+export const SSE_HEARTBEAT_STALE_MS = 60_000;
+
+export type HeartbeatTickInputT = {
+  /** 문서가 포그라운드인지 — 백그라운드에선 아무것도 하지 않는다 */
+  isVisible: boolean;
+  /** `connect` 이벤트로 받은 연결 번호. 없으면 아직 연결 중이 아니다 */
+  connectionId: string | null;
+  /** 마지막으로 스트림 이벤트를 받은 시각 (ms) */
+  lastHeartbeatAt: number;
+  now: number;
+};
+
+export type HeartbeatTickDecisionT = 'SKIP' | 'RECONNECT' | 'SEND';
+
+export const decideHeartbeatTick = ({
+  isVisible,
+  connectionId,
+  lastHeartbeatAt,
+  now,
+}: HeartbeatTickInputT): HeartbeatTickDecisionT => {
+  if (!isVisible || !connectionId) return 'SKIP';
+  if (now - lastHeartbeatAt > SSE_HEARTBEAT_STALE_MS) return 'RECONNECT';
+
+  return 'SEND';
+};

--- a/apps/web/src/utils/sseHeartbeat.ts
+++ b/apps/web/src/utils/sseHeartbeat.ts
@@ -23,7 +23,7 @@ export const decideHeartbeatTick = ({
   now,
 }: HeartbeatTickInputT): HeartbeatTickDecisionT => {
   if (!isVisible || !connectionId) return 'SKIP';
-  if (now - lastHeartbeatAt > SSE_HEARTBEAT_STALE_MS) return 'RECONNECT';
+  if (now - lastHeartbeatAt >= SSE_HEARTBEAT_STALE_MS) return 'RECONNECT';
 
   return 'SEND';
 };

--- a/packages/core/src/consts/errorCode.ts
+++ b/packages/core/src/consts/errorCode.ts
@@ -135,6 +135,7 @@ export const ERROR_MESSAGE_MAP = {
 
   /** NOTIFICATION */
   'NOTIFICATION-001': '알림을 불러오지 못했어요. 새로고침 해주세요.',
+  'NOTIFICATION-002': '알림 연결이 끊겨 다시 연결했어요.',
 } as const;
 
 /**
@@ -274,6 +275,7 @@ export const ERROR_CODE = {
 
   /** 알림 */
   NOTIFICATION_INVALID_CURSOR: 'NOTIFICATION-001',
+  NOTIFICATION_CONNECTION_NOT_FOUND: 'NOTIFICATION-002',
 } as const satisfies Record<string, keyof typeof ERROR_MESSAGE_MAP>;
 
 /**


### PR DESCRIPTION
## 작업 요약

- SSE `connect` / `heartbeat` 이벤트로 받은 연결 번호를 보관하고, 30초마다 서버에 클라이언트 하트비트를 보냅니다.
- 서버 heartbeat 가 60초 동안 없거나 하트비트 응답이 409(NOTIFICATION-002)면 즉시 재연결합니다.

## 작업 세부 내용

### 배경

- 기존 훅은 `connect` / `heartbeat` 이벤트를 버리고 있어, 프록시나 이동통신망에서 스트림이 조용히 끊기면 30분 타임아웃까지 알 수 없었습니다.
- 서버 ping 은 프록시까지 도달한 것만 확인되므로, 클라이언트가 비정상 종료돼도 서버는 약 17분 뒤에야 정리했습니다.
- 범위는 웹(`apps/web`)만입니다. RN 앱은 WebView 의 웹 SSE 를 그대로 쓰고, 공유 시트의 일회성 파싱 구독은 하트비트를 보낸 적이 없어 서버 정리 대상이 아니므로 변경하지 않았습니다.

### 설계

두 방향의 생존 판정을 연결 번호 하나로 묶습니다.

| 방향 | 신호 | 판정 주체 | 결측 시 동작 |
|---|---|---|---|
| 서버 → 클라 | `heartbeat` 이벤트 (30초) | 클라이언트 | 60초 결측이면 백오프 없이 즉시 재연결 |
| 클라 → 서버 | `POST /heartbeat { connectionId }` (30초) | 서버 | 60초 결측이면 서버가 정상 종료, 클라는 `onclose` 로 재연결 |

- **생존 시각은 heartbeat 만이 아니라 모든 수신 이벤트로 갱신**합니다. heartbeat 만 세면 알림이 잦은 구간에서 정상 스트림을 끊김으로 오판합니다.
- **POST 는 포그라운드 + 연결 중일 때만** 보냅니다. 실패해도 재시도하지 않고 다음 주기에 맡깁니다.
- **401 은 `clientApi` 인터셉터에 위임**합니다. 이미 토큰 갱신 후 1회 재시도가 걸려 있어 훅에 토큰 로직을 따로 두지 않았습니다.
- **409 `NOTIFICATION-002`(서버에 그 번호의 연결 없음)면 즉시 재연결**합니다. 응답 지연 중 이미 새 연결로 바뀐 경우는 옛 번호의 409 로 새 연결을 끊지 않도록 번호를 대조합니다.
- **재연결을 시작하는 순간 연결 번호를 비웁니다.** 새 `connect` 이벤트가 올 때까지 옛 번호로 POST 하지 않습니다.
- **화면 복귀 시** 예약된 재연결이 있으면 즉시 실행하고, 없으면 tick 을 바로 돌립니다. 백그라운드 동안 서버가 정리한 연결을 다음 30초 주기까지 기다리지 않고 409 로 잡기 위해서입니다.

### 구현

- `packages/core` 에러 카탈로그에 `NOTIFICATION-002` 를 `ERROR_CODE.NOTIFICATION_CONNECTION_NOT_FOUND` 로 등록했습니다. 완전성 검사 때문에 문구도 함께 추가했습니다(토스트되지는 않습니다).
- `postNotificationHeartbeat` API 함수와 `NOTIFICATIONS_HEARTBEAT` 엔드포인트를 추가했습니다.
- `useNotificationSSE` 에 `connect` / `heartbeat` 이벤트 처리, 30초 인터벌 tick, 409 재연결, 화면 복귀 처리를 추가했습니다. 기존 `notification` / `silent-sync` 처리와 백오프 재연결 로직은 그대로입니다.
- tick 의 분기(SKIP / RECONNECT / SEND)는 `decideHeartbeatTick` 순수 함수로 분리했습니다. 훅은 jsdom 없이 테스트할 수 없어 분기만 뽑아 vitest 로 검증합니다.





## 연관 이슈

closes #628


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 알림 연결 상태를 주기적으로 확인해 장시간 이벤트가 없거나 연결이 유효하지 않을 때 자동으로 재연결합니다.
  * 백그라운드에서 복귀한 뒤 정리된 알림 연결도 감지해 다시 연결합니다.
  * 연결이 끊겨 재연결될 때 사용자에게 안내 메시지를 표시합니다.
  * 알림 연결이 정상적으로 유지되는 동안 불필요한 재연결을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->