### PR TITLE
fix: 쿼리 소비 지점 간 router.replace 충돌 방지

### DIFF
--- a/apps/web/src/components/common/query-action-toast/index.tsx
+++ b/apps/web/src/components/common/query-action-toast/index.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 import { toast } from 'sonner';
 
 import { QUERY_ACTION, type QueryActionValueT } from '@/consts/queryAction';
 import { QUERY_ACTION_TOAST } from '@/consts/queryActionToast';
+import { clearQueryParam } from '@/utils/clearQueryParam';
 
 /**
  * `?action=` 으로 넘어온 안내 토스트를 노출하고 쿼리를 URL 에서 제거한다.
@@ -15,24 +16,17 @@ import { QUERY_ACTION_TOAST } from '@/consts/queryActionToast';
  */
 function QueryActionToast() {
   const searchParams = useSearchParams();
-  const pathname = usePathname();
-  const router = useRouter();
 
   const action = searchParams.get(QUERY_ACTION.KEY);
   const toastEntry = action ? QUERY_ACTION_TOAST[action as QueryActionValueT] : null;
-
-  /** action 만 걷어낸다 — 도착지가 함께 실어 보낸 쿼리(redirect·필터 등)까지 지우면 안 된다 */
-  const restParams = new URLSearchParams(searchParams.toString());
-  restParams.delete(QUERY_ACTION.KEY);
-  const rest = restParams.toString();
-  const nextUrl = rest ? `${pathname}?${rest}` : pathname;
 
   useEffect(() => {
     if (!toastEntry) return;
 
     toast[toastEntry.variant](toastEntry.message);
-    router.replace(nextUrl, { scroll: false });
-  }, [toastEntry, nextUrl, router]);
+    /** action 만 걷어낸다 — 도착지가 함께 실어 보낸 쿼리(redirect·필터 등)까지 지우면 안 된다 */
+    clearQueryParam(QUERY_ACTION.KEY);
+  }, [toastEntry]);
 
   return null;
 }

--- a/apps/web/src/hooks/useQueryAction.ts
+++ b/apps/web/src/hooks/useQueryAction.ts
@@ -1,17 +1,16 @@
 'use client';
 
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import { QUERY_ACTION, type QueryActionValueT } from '@/consts/queryAction';
+import { clearQueryParam } from '@/utils/clearQueryParam';
 
 type UseQueryActionOptions = {
   /** `action` 쿼리 값 (예: `get-item`) */
   action: QueryActionValueT;
   /** 쿼리 키. 기본값 `action` */
   paramKey?: string;
-  /** 실행 후 이동할 경로. 미지정 시 현재 pathname */
-  clearPath?: string;
 };
 
 type UseQueryActionReturn = {
@@ -28,19 +27,16 @@ type UseQueryActionReturn = {
 export const useQueryAction = ({
   action,
   paramKey = QUERY_ACTION.KEY,
-  clearPath,
 }: UseQueryActionOptions): UseQueryActionReturn => {
   const searchParams = useSearchParams();
-  const pathname = usePathname();
-  const router = useRouter();
 
   const [isActive, setIsActive] = useState(() => searchParams.get(paramKey) === action);
 
   useEffect(() => {
     if (searchParams.get(paramKey) !== action) return;
 
-    router.replace(clearPath ?? pathname, { scroll: false });
-  }, [searchParams, paramKey, action, clearPath, pathname, router]);
+    clearQueryParam(paramKey);
+  }, [searchParams, paramKey, action]);
 
   return { isActive, setIsActive };
 };

--- a/apps/web/src/hooks/useQueryParamOnce.ts
+++ b/apps/web/src/hooks/useQueryParamOnce.ts
@@ -1,27 +1,21 @@
 'use client';
 
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
+
+import { clearQueryParam } from '@/utils/clearQueryParam';
 
 export const useQueryParamOnce = (paramKey: string) => {
   const searchParams = useSearchParams();
-  const pathname = usePathname();
-  const router = useRouter();
 
   /** 진입 시점의 값만 필요하므로 초기화 함수에서 한 번만 읽는다 */
   const [value] = useState(() => searchParams.get(paramKey));
 
-  /** 도착지가 함께 실어 보낸 다른 쿼리까지 지우면 안 된다 */
-  const restParams = new URLSearchParams(searchParams.toString());
-  restParams.delete(paramKey);
-  const rest = restParams.toString();
-  const nextUrl = rest ? `${pathname}?${rest}` : pathname;
-
   useEffect(() => {
     if (searchParams.get(paramKey) === null) return;
 
-    router.replace(nextUrl, { scroll: false });
-  }, [searchParams, paramKey, nextUrl, router]);
+    clearQueryParam(paramKey);
+  }, [searchParams, paramKey]);
 
   return value;
 };

--- a/apps/web/src/utils/clearQueryParam.test.ts
+++ b/apps/web/src/utils/clearQueryParam.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { removeQueryParam } from './clearQueryParam';
+
+const ORIGIN = 'https://piki.app';
+
+describe('removeQueryParam', () => {
+  it('키가 없으면 null 을 반환해 URL 갱신을 건너뛰게 한다', () => {
+    expect(removeQueryParam(`${ORIGIN}/tournament/1/create`, 'action')).toBeNull();
+    expect(removeQueryParam(`${ORIGIN}/tournament/1/create?other=1`, 'action')).toBeNull();
+  });
+
+  it('대상 키만 제거하고 나머지 쿼리는 보존한다', () => {
+    expect(
+      removeQueryParam(
+        `${ORIGIN}/tournament/1/create?action=scroll-to-last&highlightItem=10`,
+        'action'
+      )
+    ).toBe('/tournament/1/create?highlightItem=10');
+  });
+
+  it('연속 호출이 합성되어 소비한 키가 되살아나지 않는다', () => {
+    const afterFirst = removeQueryParam(
+      `${ORIGIN}/tournament/1/create?action=scroll-to-last&highlightItem=10`,
+      'action'
+    );
+    expect(afterFirst).toBe('/tournament/1/create?highlightItem=10');
+
+    const afterSecond = removeQueryParam(`${ORIGIN}${afterFirst}`, 'highlightItem');
+    expect(afterSecond).toBe('/tournament/1/create');
+  });
+});

--- a/apps/web/src/utils/clearQueryParam.ts
+++ b/apps/web/src/utils/clearQueryParam.ts
@@ -1,0 +1,22 @@
+/** `href` 에서 `paramKey` 를 제거한 다음 URL(경로부터). 제거할 것이 없으면 `null`. */
+
+export const removeQueryParam = (href: string, paramKey: string): string | null => {
+  const url = new URL(href);
+  if (!url.searchParams.has(paramKey)) return null;
+
+  url.searchParams.delete(paramKey);
+
+  return `${url.pathname}${url.search}${url.hash}`;
+};
+
+/**
+ * `router.replace` 를 쓰지 않는 이유 — 여러 effect 가 함께 정리하면 각자 자기 렌더 시점의
+ * `searchParams` 스냅샷으로 계산해 남이 지운 키를 되살린다. History API 는 실행 시점의
+ * 현재 URL 을 읽어 그 문제가 없고, App Router 가 이를 감지해 관련 훅도 동기화한다.
+ */
+export const clearQueryParam = (paramKey: string) => {
+  const nextUrl = removeQueryParam(window.location.href, paramKey);
+  if (nextUrl === null) return;
+
+  window.history.replaceState(null, '', nextUrl);
+};


### PR DESCRIPTION
## 작업 요약

- 소비한 쿼리 키를 정리하는 세 지점이 서로의 결과를 덮어쓰던 문제 수정
- 정리 로직을 공통 유틸로 모으고 `router.replace` 대신 History API 사용
- `useQueryAction` 이 자기 키가 아닌 다른 쿼리까지 삭제하던 문제 수정
## 작업 세부 내용

### 문제

소비한 쿼리를 URL 에서 지우는 주체가 세 곳인데, 각자 독립적으로 `router.replace` 를 호출합니다.
셋 다 같은 렌더의 `searchParams` 스냅샷에서 다음 URL 을 계산하기 때문에, 두 곳 이상이 동시에 발화하면 나중 실행이 앞선 결과를 덮어써 **이미 소비한 쿼리가 되살아납니다.**

`/tournament/1/create?action=scroll-to-last&highlightItem=10` 진입 시

    useQueryAction     → /tournament/1/create                        (쿼리 전체 삭제)
    useQueryParamOnce  → /tournament/1/create?action=scroll-to-last  ← 나중 실행, 이게 최종

다음 렌더에서 다시 제거되어 수렴하지만, 그 사이 새로고침하면 `action` 이 재실행됩니다.

각 훅이 "자기 키만 삭제" 하도록 고쳐도 해결되지 않습니다. 살아남는 키가 바뀔 뿐, 같은 스냅샷에서 각자 계산하는 구조가 원인이기 때문입니다.

### 해결 — History API 로 전환

`router.replace` 는 렌더 시점의 스냅샷을 쓰지만, History API 는 **실행 시점의 현재 URL** 을 읽으므로 순차 실행이 그대로 합성됩니다. 공유 상태나 스케줄러 없이 각 훅이 자족적으로 유지됩니다.

Next 16.2.0 이 `replaceState` 를 패치해 `usePathname`·`useSearchParams` 를 동기화하는 을 `next/dist/client/components/app-router.js` 에서 확인했습니다. 

내부 호출 판별용 플래그(`__NA`·`_N`) 없이 호출하면 `ACTION_RESTORE` 가 디스패치되어 라우터 상태가 따라옵니다.

### 함께 수정한 것

- `useQueryAction` 이 `replace(clearPath ?? pathname)` 로 **쿼리 전체를 삭제**하고 있었습니다.
  (남이 실어 보낸 파라미터를 지우는 것이라 순서 문제와 별개로 버그. 현재는 형제 파라미터가 없어 드러나지 않음.)
- 사용처가 없던 `clearPath` 옵션을 제거했습니다. "다른 경로로 이동" 이라는 의미가 "자기 키만 삭제" 와 양립하지 않습니다.



### 테스트

`vitest` 환경이 `node` 라 `window` 를 쓸 수 없어, 순수 계산부(`removeQueryParam`)를 분리하고 3 케이스를 남겼습니다. `연속 호출이 합성되어 소비한 키가 되살아나지 않는다` 가 이번 버그의 회귀 방어입니다.

`URLSearchParams` 가 보장하는 동작(해시 보존·중복 키 제거 등)은 테스트하지 않았습니다.

## 스크린샷

UI 변경 없음

## 연관 이슈

closes #637


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 쿼리 파라미터를 처리할 때 페이지 이동 없이 현재 URL을 업데이트하도록 개선했습니다.
  * 대상 파라미터만 제거하고, 경로·해시 및 다른 쿼리 파라미터는 유지됩니다.
  * 동일한 파라미터를 여러 번 처리해도 이미 제거된 값이 복원되지 않습니다.

* **테스트**
  * 쿼리 파라미터 제거 및 기존 URL 정보 보존 동작에 대한 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->