### PR TITLE
feat: 로그인 유도 화면 범용화 및 토너먼트 탭 게스트 차단 적용

### DIFF
--- a/apps/web/e2e/helpers/fakeJwt.ts
+++ b/apps/web/e2e/helpers/fakeJwt.ts
@@ -5,13 +5,13 @@ const toBase64Url = (value: object) => Buffer.from(JSON.stringify(value)).toStri
  * exp가 미래인 JWT 형태 문자열이면 미들웨어를 통과하고,
  * 서버사이드 게스트 로그인(postGuestLoginServer)이 발생하지 않는다 — 네트워크 0회.
  */
-export const createFakeJwt = (expiresInSeconds = 60 * 60) =>
+export const createFakeJwt = (expiresInSeconds = 60 * 60, role: 'GUEST' | 'MEMBER' = 'MEMBER') =>
   [
     toBase64Url({ alg: 'HS256', typ: 'JWT' }),
     toBase64Url({
       sub: 'e2e-user',
-      /** role 클레임 기반 gating(getRoleFromToken) 통과용 — SSR 목의 MOCK_MEMBER_ME(회원 고정)와 정합 */
-      role: 'MEMBER',
+      /** role 클레임 기반 gating(getRoleFromToken)용 — 기본 MEMBER 는 SSR 목의 MOCK_MEMBER_ME(회원 고정)와 정합 */
+      role,
       exp: Math.floor(Date.now() / 1000) + expiresInSeconds,
     }),
     'e2e-fake-signature',

--- a/apps/web/e2e/specs/archive/loginRequired.spec.ts
+++ b/apps/web/e2e/specs/archive/loginRequired.spec.ts
@@ -1,0 +1,52 @@
+import type { Page } from '@playwright/test';
+
+import { ENDPOINTS } from '@/consts/api';
+
+import { expect, test } from '@e2e/fixtures/mockApiFixture';
+import { createFakeJwt } from '@e2e/helpers/fakeJwt';
+import { MOCK_GUEST_ME } from '@e2e/mocks/me';
+
+/** 기본 storageState(MEMBER)를 게스트 role 토큰으로 덮어써 서버 게이트를 게스트로 통과 */
+const useGuestToken = async (page: Page) => {
+  const token = createFakeJwt(60 * 60, 'GUEST');
+  const cookie = { domain: 'localhost', path: '/', value: token };
+
+  await page.context().addCookies([
+    { ...cookie, name: 'access_token' },
+    { ...cookie, name: 'refresh_token' },
+  ]);
+};
+
+test('게스트가 위시 탭에 들어가면 로그인 유도 화면이 뜬다', async ({ page, api }) => {
+  api.get(ENDPOINTS.USER, MOCK_GUEST_ME);
+  await useGuestToken(page);
+
+  await page.goto('/archive/wish');
+
+  await expect(
+    page.getByRole('heading', { name: '위시를 담으려면 로그인이 필요해요' })
+  ).toBeVisible();
+
+  /** 차단 화면에서도 탭바는 남는다 — 다른 탭 이동 허용 (지점 간 일관 기준) */
+  await expect(page.getByRole('link', { name: '홈' })).toBeVisible();
+
+  /** 로그인 후 차단당한 맥락으로 복귀하도록 redirect 파라미터를 싣는다 */
+  await page.getByRole('button', { name: '로그인하기' }).click();
+  await expect(page).toHaveURL(/\/login\?redirect=%2Farchive%2Fwish/);
+});
+
+test('게스트가 토너먼트 탭에 들어가면 로그인 유도 화면이 뜬다', async ({ page, api }) => {
+  api.get(ENDPOINTS.USER, MOCK_GUEST_ME);
+  await useGuestToken(page);
+
+  await page.goto('/archive/tournament');
+
+  await expect(
+    page.getByRole('heading', { name: '토너먼트를 확인하려면 로그인이 필요해요' })
+  ).toBeVisible();
+
+  await expect(page.getByRole('link', { name: '홈' })).toBeVisible();
+
+  await page.getByRole('button', { name: '로그인하기' }).click();
+  await expect(page).toHaveURL(/\/login\?redirect=%2Farchive%2Ftournament/);
+});

--- a/apps/web/src/app/archive/tournament/layout.tsx
+++ b/apps/web/src/app/archive/tournament/layout.tsx
@@ -1,27 +1,14 @@
-import { cookies, headers } from 'next/headers';
-import { redirect } from 'next/navigation';
-
 import LoginRequired from '@/components/common/login-required';
 import { LOGIN_REQUIRED_TITLE } from '@/components/common/login-required/loginRequired.const';
-import { QUERY_ACTION } from '@/consts/queryAction';
 import { ROUTES } from '@/consts/route';
-import { getRoleFromToken } from '@/utils/auth';
-import { getLoginPath } from '@/utils/loginRedirect';
+import { getRoleOrRedirect } from '@/utils/getRoleOrRedirect';
 
 type TournamentArchiveLayoutProps = {
   children: React.ReactNode;
 };
 
 async function TournamentArchiveLayout({ children }: TournamentArchiveLayoutProps) {
-  const headerStore = await headers();
-  const redirectPath = headerStore.get('x-redirect-path');
-
-  /** MEMBER 권한 판별 */
-  const accessToken = (await cookies()).get('access_token')?.value;
-  const role = getRoleFromToken(accessToken);
-
-  /** 토큰이 유효하지 않은 경우 세션 만료 처리 */
-  if (role === null) redirect(getLoginPath(redirectPath, QUERY_ACTION.VALUE.SESSION_EXPIRED));
+  const role = await getRoleOrRedirect();
 
   if (role !== 'MEMBER')
     return (

--- a/apps/web/src/app/archive/tournament/layout.tsx
+++ b/apps/web/src/app/archive/tournament/layout.tsx
@@ -1,0 +1,37 @@
+import { cookies, headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+import LoginRequired from '@/components/common/login-required';
+import { LOGIN_REQUIRED_TITLE } from '@/components/common/login-required/loginRequired.const';
+import { QUERY_ACTION } from '@/consts/queryAction';
+import { ROUTES } from '@/consts/route';
+import { getRoleFromToken } from '@/utils/auth';
+import { getLoginPath } from '@/utils/loginRedirect';
+
+type TournamentArchiveLayoutProps = {
+  children: React.ReactNode;
+};
+
+async function TournamentArchiveLayout({ children }: TournamentArchiveLayoutProps) {
+  const headerStore = await headers();
+  const redirectPath = headerStore.get('x-redirect-path');
+
+  /** MEMBER 권한 판별 */
+  const accessToken = (await cookies()).get('access_token')?.value;
+  const role = getRoleFromToken(accessToken);
+
+  /** 토큰이 유효하지 않은 경우 세션 만료 처리 */
+  if (role === null) redirect(getLoginPath(redirectPath, QUERY_ACTION.VALUE.SESSION_EXPIRED));
+
+  if (role !== 'MEMBER')
+    return (
+      <LoginRequired
+        title={LOGIN_REQUIRED_TITLE.TOURNAMENT_HISTORY}
+        redirectPath={ROUTES.TOURNAMENT_HISTORY}
+      />
+    );
+
+  return children;
+}
+
+export default TournamentArchiveLayout;

--- a/apps/web/src/app/archive/wish/layout.tsx
+++ b/apps/web/src/app/archive/wish/layout.tsx
@@ -1,8 +1,10 @@
 import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-import WishLoginRequired from '@/components/common/wish-login-required';
+import LoginRequired from '@/components/common/login-required';
+import { LOGIN_REQUIRED_TITLE } from '@/components/common/login-required/loginRequired.const';
 import { QUERY_ACTION } from '@/consts/queryAction';
+import { ROUTES } from '@/consts/route';
 import { getRoleFromToken } from '@/utils/auth';
 import { getLoginPath } from '@/utils/loginRedirect';
 
@@ -22,7 +24,8 @@ async function WishArchiveLayout({ children }: WishArchiveLayoutProps) {
   if (role === null) redirect(getLoginPath(redirectPath, QUERY_ACTION.VALUE.SESSION_EXPIRED));
 
   /** 위시 페이지는 멤버가 아니면 로그인 유도 화면을 렌더 */
-  if (role !== 'MEMBER') return <WishLoginRequired />;
+  if (role !== 'MEMBER')
+    return <LoginRequired title={LOGIN_REQUIRED_TITLE.WISH} redirectPath={ROUTES.WISHLIST} />;
 
   return children;
 }

--- a/apps/web/src/app/archive/wish/layout.tsx
+++ b/apps/web/src/app/archive/wish/layout.tsx
@@ -1,27 +1,14 @@
-import { cookies, headers } from 'next/headers';
-import { redirect } from 'next/navigation';
-
 import LoginRequired from '@/components/common/login-required';
 import { LOGIN_REQUIRED_TITLE } from '@/components/common/login-required/loginRequired.const';
-import { QUERY_ACTION } from '@/consts/queryAction';
 import { ROUTES } from '@/consts/route';
-import { getRoleFromToken } from '@/utils/auth';
-import { getLoginPath } from '@/utils/loginRedirect';
+import { getRoleOrRedirect } from '@/utils/getRoleOrRedirect';
 
 type WishArchiveLayoutProps = {
   children: React.ReactNode;
 };
 
 async function WishArchiveLayout({ children }: WishArchiveLayoutProps) {
-  const headerStore = await headers();
-  const redirectPath = headerStore.get('x-redirect-path');
-
-  /** MEMBER 권한 판별 */
-  const accessToken = (await cookies()).get('access_token')?.value;
-  const role = getRoleFromToken(accessToken);
-
-  /** 토큰이 유효하지 않은 경우 세션 만료 처리 */
-  if (role === null) redirect(getLoginPath(redirectPath, QUERY_ACTION.VALUE.SESSION_EXPIRED));
+  const role = await getRoleOrRedirect();
 
   /** 위시 페이지는 멤버가 아니면 로그인 유도 화면을 렌더 */
   if (role !== 'MEMBER')

--- a/apps/web/src/app/home/_components/AddWishHomeDialog.tsx
+++ b/apps/web/src/app/home/_components/AddWishHomeDialog.tsx
@@ -3,10 +3,12 @@
 import Image from 'next/image';
 import { useState } from 'react';
 
-import WishLoginRequired from '@/components/common/wish-login-required';
+import LoginRequired from '@/components/common/login-required';
+import { LOGIN_REQUIRED_TITLE } from '@/components/common/login-required/loginRequired.const';
 import { Dialog, DialogTrigger } from '@/components/dialog';
 import GetItemDialogContent from '@/components/get-item-dialog';
 import { ANALYTICS_EVENT } from '@/consts/analytics';
+import { ROUTES } from '@/consts/route';
 import { useGetMe } from '@/hooks/useGetMe';
 import { logAnalyticsEvent } from '@/utils/analytics';
 
@@ -38,7 +40,11 @@ function AddWishHomeDialog() {
         </button>
         {isLoginRequiredOpen && (
           <div className="absolute inset-0 z-50">
-            <WishLoginRequired onGoHome={() => setIsLoginRequiredOpen(false)} />
+            <LoginRequired
+              title={LOGIN_REQUIRED_TITLE.WISH}
+              redirectPath={ROUTES.WISHLIST}
+              onGoHome={() => setIsLoginRequiredOpen(false)}
+            />
           </div>
         )}
       </>

--- a/apps/web/src/app/home/page.tsx
+++ b/apps/web/src/app/home/page.tsx
@@ -1,7 +1,7 @@
 import PiKiLogo from '@/assets/images/piki-logo-text.svg';
 import { Header, HeaderIcon } from '@/components/header';
 import Spacing from '@/components/spacing';
-import { getIsGuest } from '@/utils/getIsGuest';
+import { getIsGuest } from '@/utils/auth';
 
 import AddWishHomeDialog from './_components/AddWishHomeDialog';
 import CreateTournamentDialog from './_components/CreateTournamentDialog';

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -1,6 +1,6 @@
 import { Header, HeaderIcon } from '@/components/header';
 import Spacing from '@/components/spacing';
-import { getIsGuest } from '@/utils/getIsGuest';
+import { getIsGuest } from '@/utils/auth';
 
 import AccountInfoSection from './_components/AccountInfoSection';
 import AppVersionFooter from './_components/AppVersionFooter';

--- a/apps/web/src/app/tournament/[id]/result/page.tsx
+++ b/apps/web/src/app/tournament/[id]/result/page.tsx
@@ -3,8 +3,8 @@ import { redirect } from 'next/navigation';
 
 import { ROUTES } from '@/consts/route';
 import { TOURNAMENT_STATUS } from '@/consts/tournament';
+import { getIsGuest } from '@/utils/auth';
 import { getIsApp } from '@/utils/getIsApp';
-import { getIsGuest } from '@/utils/getIsGuest';
 import { getQueryClient } from '@/utils/queryClient';
 
 import { getTournament } from '../_common/_apis/getTournament';

--- a/apps/web/src/components/common/login-required/index.tsx
+++ b/apps/web/src/components/common/login-required/index.tsx
@@ -9,17 +9,21 @@ import { Header, HeaderIcon } from '@/components/header';
 import { ROUTES } from '@/consts/route';
 import { getLoginPath } from '@/utils/loginRedirect';
 
-type WishLoginRequiredProps = {
+type LoginRequiredProps = {
+  /** 지점별 안내 문구 — loginRequired.const.ts 카탈로그에서 주입 */
+  title: string;
+  /** 로그인 성공 후 복귀 경로 */
+  redirectPath: string;
   /** '홈으로 돌아가기' 동작 — 미지정 시 홈으로 이동 (홈 오버레이에서는 닫기 핸들러 주입) */
   onGoHome?: () => void;
 };
 
-/** 게스트가 위시에 접근할 때 로그인을 유도하는 전체 화면 */
-function WishLoginRequired({ onGoHome }: WishLoginRequiredProps) {
+/** 게스트가 잠긴 기능에 접근할 때 로그인을 유도하는 전체 화면 */
+function LoginRequired({ title, redirectPath, onGoHome }: LoginRequiredProps) {
   const router = useRouter();
 
   const handleLoginClick = () => {
-    router.push(getLoginPath(ROUTES.WISHLIST));
+    router.push(getLoginPath(redirectPath));
   };
 
   const handleGoHomeClick = () => {
@@ -38,9 +42,7 @@ function WishLoginRequired({ onGoHome }: WishLoginRequiredProps) {
         <LockIconFill width={60} height={60} className="text-sky-blue-400" aria-hidden />
 
         <div className="flex flex-col items-center gap-[30px]">
-          <h2 className="heading-1-semibold text-text-neutral-primary">
-            위시를 담으려면 로그인이 필요해요
-          </h2>
+          <h2 className="heading-1-semibold text-text-neutral-primary">{title}</h2>
 
           <div className="flex flex-col items-center gap-6">
             <Button variant="primary" size="md" onClick={handleLoginClick}>
@@ -60,4 +62,4 @@ function WishLoginRequired({ onGoHome }: WishLoginRequiredProps) {
   );
 }
 
-export default WishLoginRequired;
+export default LoginRequired;

--- a/apps/web/src/components/common/login-required/loginRequired.const.ts
+++ b/apps/web/src/components/common/login-required/loginRequired.const.ts
@@ -1,0 +1,5 @@
+/** 페이지별 로그인 유도 문구 카탈로그 */
+export const LOGIN_REQUIRED_TITLE = {
+  WISH: '위시를 담으려면 로그인이 필요해요',
+  TOURNAMENT_HISTORY: '토너먼트를 확인하려면 로그인이 필요해요',
+} as const;

--- a/apps/web/src/utils/auth.ts
+++ b/apps/web/src/utils/auth.ts
@@ -1,4 +1,6 @@
+/** NOTE: 서버 전용 모듈 — 클라이언트의 role 판정은 useGetMe 로 */
 import { decodeJwtPayload, isTokenUnexpired } from '@piki/core';
+import { cookies } from 'next/headers';
 
 import type { UserIdentityTypeT } from '@/types/user';
 
@@ -8,4 +10,9 @@ export const getRoleFromToken = (token?: string): UserIdentityTypeT | null => {
 
   const role = decodeJwtPayload(token)?.role;
   return role === 'GUEST' || role === 'MEMBER' ? role : null;
+};
+
+export const getIsGuest = async (): Promise<boolean> => {
+  const token = (await cookies()).get('access_token')?.value;
+  return getRoleFromToken(token) === 'GUEST';
 };

--- a/apps/web/src/utils/getIsGuest.ts
+++ b/apps/web/src/utils/getIsGuest.ts
@@ -1,9 +1,0 @@
-import { cookies } from 'next/headers';
-
-import { getRoleFromToken } from '@/utils/auth';
-
-/** RSC 전용. access_token 쿠키에서 역할을 읽어 게스트 여부를 반환한다. */
-export const getIsGuest = async (): Promise<boolean> => {
-  const token = (await cookies()).get('access_token')?.value;
-  return getRoleFromToken(token) === 'GUEST';
-};

--- a/apps/web/src/utils/getRoleOrRedirect.ts
+++ b/apps/web/src/utils/getRoleOrRedirect.ts
@@ -1,0 +1,19 @@
+import { cookies, headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+import { QUERY_ACTION } from '@/consts/queryAction';
+import type { UserIdentityTypeT } from '@/types/user';
+import { getRoleFromToken } from '@/utils/auth';
+import { getLoginPath } from '@/utils/loginRedirect';
+
+/** RSC 레이아웃 게이트용 role 판별 — 토큰이 무효하면 세션 만료로 로그인 페이지에 redirect */
+export const getRoleOrRedirect = async (): Promise<UserIdentityTypeT> => {
+  const redirectPath = (await headers()).get('x-redirect-path');
+
+  const accessToken = (await cookies()).get('access_token')?.value;
+  const role = getRoleFromToken(accessToken);
+
+  if (role === null) redirect(getLoginPath(redirectPath, QUERY_ACTION.VALUE.SESSION_EXPIRED));
+
+  return role;
+};


### PR DESCRIPTION
## 작업 요약

- 위시 전용이던 로그인 유도 전체화면을 문구·복귀 경로를 주입받는 범용 컴포넌트로 확장합니다
- 토너먼트 탭에 게스트 진입 시 로그인 유도 화면을 노출합니다

## 작업 세부 내용

- `wish-login-required` → `components/common/login-required` 이동, `title`·`redirectPath`를 props로 주입
  - 지점별 문구는 `loginRequired.const.ts` 카탈로그 한 곳으로 — 디자인 4번(라이팅 통일) 확정 시 이 파일만 교체
  - 토너먼트 탭 문구("토너먼트를 확인하려면 로그인이 필요해요")는 라이팅 전달 전 임시
- 기존 두 사용처는 기존 문구·복귀 경로(위시 탭)·닫기 동작을 그대로 주입 — 위시 탭 진입 차단, 홈 위시 담기 오버레이 모두 동작 회귀 없음
- `archive/tournament/layout.tsx` 신설 — 위시 탭과 동일한 RSC 게이트 패턴
  - 무효 토큰은 세션 만료 리다이렉트, 게스트는 차단 화면 렌더 (로그인 후 토너먼트 탭 복귀)
  - #643 라우팅 차단과 역할 분담: 이 layout은 화면 노출만 책임, `getRouteType` 분류는 건드리지 않음
  - layout 게이트 방식이라 차단 화면에서 하단 탭바가 남는 동작이 위시 탭과 일관됨
- 두 layout에 중복되던 쿠키 role 판독·세션 만료 리다이렉트를 `getRoleOrRedirect` 헬퍼로 추출
  - 상위 layout + 클라이언트 훅 방식은 기각 — 서버 렌더 차단(플래시 없음)과 지점별 문구 선언을 유지
- `getIsGuest`를 `utils/auth.ts`로 통합 — 토큰 기반 role 판정 유틸 단일화 (소비처 전부 RSC라 `next/headers` 유입 문제 없음)
- E2E: `fakeJwt`에 role 파라미터 추가(기본 MEMBER로 기존 스펙 무영향), 게스트의 위시·토너먼트 탭 차단 화면 노출·탭바 잔존·로그인 `redirect` 파라미터 검증 스펙 추가
- 배포 주의: 토너먼트 탭 차단은 게스트에게 보이는 동작 변화 — production 승격은 #643(게스트 세션·라우팅 개편)과 함께 진행

## 연관 이슈

closes #646


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 회원 전용 대회 기록 및 위시 아카이브 페이지를 추가했습니다.
  - 비회원이 접근하면 페이지별 안내 문구와 함께 로그인 화면으로 이동합니다.
  - 로그인 후 원래 접근하려던 페이지로 돌아갈 수 있도록 리다이렉트 경로를 제공합니다.

- **개선 사항**
  - 위시 담기와 아카이브 접근에 공통 로그인 안내 화면을 적용했습니다.
  - 세션이 만료된 경우에도 로그인 안내 및 복귀 경로가 일관되게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->