### PR TITLE
fix: 초대 코드 입력 플레이스홀더 대문자 표기로 수정

### DIFF
--- a/apps/web/src/app/home/_components/InviteTournamentDialog.tsx
+++ b/apps/web/src/app/home/_components/InviteTournamentDialog.tsx
@@ -132,7 +132,7 @@ function InviteTournamentDialog() {
           <form onSubmit={handleSubmit} className="flex flex-col gap-5">
             <Input
               label="초대 코드"
-              placeholder="pik123"
+              placeholder="PIK123"
               value={code}
               onChange={event => handleChange(event.target.value)}
               aria-invalid={showFormatError}


### PR DESCRIPTION

## 작업 요약

- 홈 공유받은 토너먼트 초대 코드 입력의 플레이스홀더를 실제 코드 형식과 일치하는 대문자 예시로 수정합니다

## 작업 세부 내용

- `InviteTournamentDialog` 초대 코드 입력 placeholder `pik123` → `PIK123`
  - 실제 초대 코드 형식은 영문 대문자 3자 + 숫자 3자로, 소문자 예시가 형식 오류 안내 문구("영문 대문자 3자 + 숫자 3자로 입력해주세요.")와 어긋나 있었음

## 스크린샷

## 연관 이슈


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 토너먼트 초대 코드 입력란의 예시 문구를 `pik123`에서 `PIK123`으로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->