### PR TITLE
fix: App Promote 버전 갱신 가드 오판정 수정

### DIFF
--- a/.github/workflows/app-promote.yml
+++ b/.github/workflows/app-promote.yml
@@ -122,7 +122,11 @@ jobs:
           set -euo pipefail
           # 0,/re/ 는 첫 일치만 바꾼다 — 뒤쪽 url·extraMavenRepos 줄을 건드리지 않는다
           sed -i "0,/\"version\": \"[0-9][0-9.]*\"/s//\"version\": \"$NEXT\"/" apps/app/app.json
-          git diff --quiet apps/app/app.json && { echo "::error::버전이 갱신되지 않았습니다"; exit 1; }
+          # git diff --quiet 는 변경 없음=0 — && 연결이면 정상 경로(변경 있음=1)가 스텝을 실패시킨다
+          if git diff --quiet apps/app/app.json; then
+            echo "::error::버전이 갱신되지 않았습니다"
+            exit 1
+          fi
 
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION

## 작업 요약

- App Promote 워크플로우가 버전 범프 성공을 실패로 오판정해 죽던 가드를 수정합니다

## 작업 세부 내용

- `app.json 버전 갱신` 스텝의 `git diff --quiet ... && { ...; exit 1; }` 를 if 문으로 교체
  - `git diff --quiet` 는 변경 없음=0, 변경 있음=1 — sed 치환이 성공하면(변경 있음) `&&` 단락으로 이 줄이 exit 1 이 되고, 스크립트 마지막 줄이라 스텝 전체가 실패
  - 9/8 실행(run 34201601908)이 이 경로로 실패 — 에러 메시지 없이 exit code 1 만 남고, EAS 빌드 트리거·커밋·태그 푸시 전이라 부수효과 없음
  - 수정 후: 치환 성공 시 통과, 진짜 치환 실패(변경 없음)일 때만 에러로 중단

## 스크린샷

## 연관 이슈
